### PR TITLE
[VEN-731] refactor: remove feature summary page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -5,7 +5,6 @@
 * [V4 Overview](README.md)
 * [Contracts Overview](getting-started/contracts-overview.md)
 * [V4 Whitepaper]()
-* [Protocol Features Summary](getting-started/protocol-feature-summary.md)
 
 ## What's New?
 


### PR DESCRIPTION
This page was to describe the different features available on different networks. Since the protocol is deployed in its entirety on BSC this page is not necessary.