### PR TITLE
feat: link to keeper bot repo in token converter docs

### DIFF
--- a/technical-reference/reference-technical-articles/token-converters.md
+++ b/technical-reference/reference-technical-articles/token-converters.md
@@ -4,6 +4,12 @@
 Only available on BNB chain
 {% endhint %}
 
+{% hint style="info" %}
+The [Venus CLI](https://github.com/VenusProtocol/keeper-bots/blob/develop/packages/cli/README.md) supports making conversions using flash swaps on Pancake Swap to fund the conversion.
+
+The [Token Converter Bot](https://github.com/VenusProtocol/keeper-bots/blob/develop/packages/token-converter-bot/README.md) shows how to interact with the converters and can be used as a base to build advanced conversion strategies.
+{% endhint %}
+
 ## Overview
 
 The **Venus Protocol** generates income in various underlying tokens from interest and liquidation fees, that are then sent to the [ProtocolShareReserve](https://bscscan.com/address/0xCa01D5A9A248a830E9D93231e791B1afFed7c446) contract. The `ProtocolShareReserve` contract disburses these earnings to number of destinations:


### PR DESCRIPTION
Adds a info hint box calling out the token converter bot and cli that can be used for conversions