### PR TITLE
[VEN-2758]: add LST ETH pool contracts on BNB chain

### DIFF
--- a/deployed-contracts/isolated-pools.md
+++ b/deployed-contracts/isolated-pools.md
@@ -110,6 +110,19 @@
   * vBabyDoge\_Meme: [`0x52eD99Cd0a56d60451dD4314058854bc0845bbB5`](https://bscscan.com/address/0x52eD99Cd0a56d60451dD4314058854bc0845bbB5)
   * vUSDT\_Meme: [`0x4a9613D06a241B76b81d3777FCe3DDd1F61D4Bd0`](https://bscscan.com/address/0x4a9613D06a241B76b81d3777FCe3DDd1F61D4Bd0)
 
+### Liquid Staked ETH Pool
+
+* Comptroller: [`0xBE609449Eb4D76AD8545f957bBE04b596E8fC529`](https://bscscan.com/address/0xBE609449Eb4D76AD8545f957bBE04b596E8fC529)
+* Swap router: [`0xfb4A3c6D25B4f66C103B4CD0C0D58D24D6b51dC1`](https://bscscan.com/address/0xfb4A3c6D25B4f66C103B4CD0C0D58D24D6b51dC1)
+* Underlying tokens:
+  * wstETH: [`0x26c5e01524d2E6280A48F2c50fF6De7e52E9611C`](https://bscscan.com/address/0x26c5e01524d2E6280A48F2c50fF6De7e52E9611C)
+  * weETH: [`0x04C0599Ae5A44757c0af6F9eC3b93da8976c150A`](https://bscscan.com/address/0x04C0599Ae5A44757c0af6F9eC3b93da8976c150A)
+  * ETH: [`0x2170Ed0880ac9A755fd29B2688956BD959F933F8`](https://bscscan.com/address/0x2170Ed0880ac9A755fd29B2688956BD959F933F8)
+* Markets:
+  * vwstETH\_LiquidStakedETH: [`0x94180a3948296530024Ef7d60f60B85cfe0422c8`](https://bscscan.com/address/0x94180a3948296530024Ef7d60f60B85cfe0422c8)
+  * vweETH\_LiquidStakedETH: [`0xc5b24f347254bD8cF8988913d1fd0F795274900F`](https://bscscan.com/address/0xc5b24f347254bD8cF8988913d1fd0F795274900F)
+  * vETH\_LiquidStakedETH: [`0xeCCACF760FEA7943C5b0285BD09F601505A29c05`](https://bscscan.com/address/0xeCCACF760FEA7943C5b0285BD09F601505A29c05)
+
 ## Ethereum
 
 * PoolRegistry: [`0x61CAff113CCaf05FFc6540302c37adcf077C5179`](https://etherscan.io/address/0x61CAff113CCaf05FFc6540302c37adcf077C5179)
@@ -343,6 +356,19 @@
 * Markets:
   * vBabyDoge\_Meme: [`0x73d2F6e0708599a4eA70F6A0c55A4C59196a101c`](https://testnet.bscscan.com/address/0x73d2F6e0708599a4eA70F6A0c55A4C59196a101c)
   * vUSDT\_Meme: [`0x3AF2bE7AbEF0f840b196D99d79F4B803a5dB14a1`](https://testnet.bscscan.com/address/0x3AF2bE7AbEF0f840b196D99d79F4B803a5dB14a1)
+
+### Liquid Staked ETH Pool
+
+* Comptroller: [`0xC7859B809Ed5A2e98659ab5427D5B69e706aE26b`](https://testnet.bscscan.com/address/0xC7859B809Ed5A2e98659ab5427D5B69e706aE26b)
+* Swap router: [`0x4A73EbD3dcA511CF3574768BD6184747342C23f2`](https://testnet.bscscan.com/address/0x4A73EbD3dcA511CF3574768BD6184747342C23f2)
+* Underlying tokens:
+  * wstETH: [`0x4349016259FCd8eE452f696b2a7beeE31667D129`](https://testnet.bscscan.com/address/0x4349016259FCd8eE452f696b2a7beeE31667D129)
+  * weETH: [`0x7df9372096c8ca2401f30B3dF931bEFF493f1FdC`](https://testnet.bscscan.com/address/0x7df9372096c8ca2401f30B3dF931bEFF493f1FdC)
+  * ETH: [`0x98f7A83361F7Ac8765CcEBAB1425da6b341958a7`](https://testnet.bscscan.com/address/0x98f7A83361F7Ac8765CcEBAB1425da6b341958a7)
+* Markets:
+  * vwstETH\_LiquidStakedETH: [`0x16eb5Ce6d186B49709dD588518CD545985096Ff5`](https://testnet.bscscan.com/address/0x16eb5Ce6d186B49709dD588518CD545985096Ff5)
+  * vweETH\_LiquidStakedETH: [`0x4BD7EfB423f06fa033404FBd0935A2097918084d`](https://testnet.bscscan.com/address/0x4BD7EfB423f06fa033404FBd0935A2097918084d)
+  * vETH\_LiquidStakedETH: [`0x46D49adF48172d2e79d813A3f4F27aB61724B01e`](https://testnet.bscscan.com/address/0x46D49adF48172d2e79d813A3f4F27aB61724B01e)
 
 ## Sepolia (Ethereum testnet)
 

--- a/deployed-contracts/oracles.md
+++ b/deployed-contracts/oracles.md
@@ -14,6 +14,10 @@
 * stkBNB Oracle: [`0xdBAFD16c5eA8C29D1e94a5c26b31bFAC94331Ac6`](https://bscscan.com/address/0xdBAFD16c5eA8C29D1e94a5c26b31bFAC94331Ac6)
 * WBETH Oracle: [`0x739db790c656E54590957Ed4d6B94665bCcb3456`](https://bscscan.com/address/0x739db790c656E54590957Ed4d6B94665bCcb3456)
 * DefaultProxyAdmin: [`0x1BB765b741A5f3C2A338369DAb539385534E3343`](https://bscscan.com/address/0x1BB765b741A5f3C2A338369DAb539385534E3343)
+* OneJump Oracle wstETH/ETH/USD (having intermediate oracle Chainlink): [`0x3C9850633e8Cb5ac5c3Da833C947E7c91EED15C4`](https://bscscan.com/address/0x3C9850633e8Cb5ac5c3Da833C947E7c91EED15C4)
+* OneJump Oracle wstETH/ETH/USD (having intermediate oracle Redstone): [`0x90dd7ae1137cC072F7740Ee0b264f2351515B98A`](https://bscscan.com/address/0x90dd7ae1137cC072F7740Ee0b264f2351515B98A)
+* OneJump Oracle weETH/ETH/USD (having intermediate oracle Chainlink): [`0x3b3241698692906310A65ACA199701843404E175`](https://bscscan.com/address/0x3b3241698692906310A65ACA199701843404E175)
+* OneJump Oracle weETH/ETH/USD (having intermediate oracle Redstone): [`0xb661102c399630420A4B9fa0a5cF57161e5452F5`](https://bscscan.com/address/0xb661102c399630420A4B9fa0a5cF57161e5452F5)
 
 ## BNB Chain Testnet
 
@@ -29,6 +33,10 @@
 * stkBNB Oracle: [`0x78c1248c07c3724fe7D6FbD0e8D9859eF206B6d0`](https://testnet.bscscan.com/address/0x78c1248c07c3724fe7D6FbD0e8D9859eF206B6d0)
 * WBETH Oracle: [`0x80f80ad1d963673819752c234339901fa19fA7cb`](https://testnet.bscscan.com/address/0x80f80ad1d963673819752c234339901fa19fA7cb)
 * DefaultProxyAdmin:[`0xef480a5654b231ff7d80A0681F938f3Db71a6Ca6`](https://testnet.bscscan.com/address/0xef480a5654b231ff7d80A0681F938f3Db71a6Ca6)
+* OneJump Oracle wstETH/ETH/USD (having intermediate oracle Chainlink): [`0xB1bf3f668e0E047ab214c7373cf6B06De37c8152`](https://testnet.bscscan.com/address/0xB1bf3f668e0E047ab214c7373cf6B06De37c8152)
+* OneJump Oracle wstETH/ETH/USD (having intermediate oracle Redstone): [`0x35af302A0B4653f214240FCb2dFf059Fe42eC2CE`](https://testnet.bscscan.com/address/0x35af302A0B4653f214240FCb2dFf059Fe42eC2CE)
+* OneJump Oracle weETH/ETH/USD (having intermediate oracle Chainlink): [`0x8C8a70695DC952CA2e8CD4038907201FaBB8134E`](https://testnet.bscscan.com/address/0x8C8a70695DC952CA2e8CD4038907201FaBB8134E)
+* OneJump Oracle weETH/ETH/USD (having intermediate oracle Redstone): [`0xF1B65d1331DceEd40Da71CFc4f06d9754A3f3756`](https://testnet.bscscan.com/address/0xF1B65d1331DceEd40Da71CFc4f06d9754A3f3756)
 
 ## Ethereum mainnet
 

--- a/risk/resilient-price-oracle.md
+++ b/risk/resilient-price-oracle.md
@@ -129,6 +129,9 @@ The current list of correlated token oracles in Venus is:
 | Tron | WIN | [Chainlink](https://bscscan.com/address/0x1B2103441A0A108daD8848D8F5d790e4D402921F) | - | - | |
 | Tron | USDD | [Binance](https://bscscan.com/address/0x594810b741d136f1960141C0d8Fb4a91bE78A820) | - | - | |
 | Tron | USDT | [Chainlink](https://bscscan.com/address/0x1B2103441A0A108daD8848D8F5d790e4D402921F) | - | - | |
+| Liquid Staked ETH | ETH | [Chainlink](https://bscscan.com/address/0x1B2103441A0A108daD8848D8F5d790e4D402921F) | - | - | |
+| Liquid Staked ETH | weETH | [weETHOneJumpRedstoneOracle](https://bscscan.com/address/0xb661102c399630420A4B9fa0a5cF57161e5452F5) | [weETHOneJumpChainlinkOracle](https://bscscan.com/address/0x3b3241698692906310A65ACA199701843404E175) | [weETHOneJumpChainlinkOracle](https://bscscan.com/address/0x3b3241698692906310A65ACA199701843404E175) | Upper bound: 1.01. Lower bound: 0.99 |
+| Liquid Staked ETH | wstETH | [wstETHOneJumpChainlinkOracle](https://bscscan.com/address/0x3C9850633e8Cb5ac5c3Da833C947E7c91EED15C4) | [wstETHOneJumpRedstoneOracle](https://bscscan.com/address/0x90dd7ae1137cC072F7740Ee0b264f2351515B98A) | [wstETHOneJumpRedstoneOracle](https://bscscan.com/address/0x90dd7ae1137cC072F7740Ee0b264f2351515B98A) | Upper bound: 1.01. Lower bound: 0.99 |
 
 #### Ethereum
 


### PR DESCRIPTION
This PR adds contract addresses for LST ETH pool deployment on BNB chain, as defined in [this VIP](https://github.com/VenusProtocol/vips/pull/373/files).