### PR TITLE
[VEN-2845]: add addresses for pufETH markets and oracle

### DIFF
--- a/deployed-contracts/isolated-pools.md
+++ b/deployed-contracts/isolated-pools.md
@@ -178,6 +178,7 @@
 * Underlying tokens:
   * ezETH [`0xbf5495Efe5DB9ce00f80364C8B423567e58d2110`](https://etherscan.io/address/0xbf5495Efe5DB9ce00f80364C8B423567e58d2110)
   * PTweETH-26DEC2024 [`0x6ee2b5E19ECBa773a352E5B21415Dc419A700d1d`](https://etherscan.io/address/0x6ee2b5E19ECBa773a352E5B21415Dc419A700d1d)
+  * pufETH: [`0xD9A442856C234a39a81a089C06451EBAa4306a72`](https://etherscan.io/address/0xD9A442856C234a39a81a089C06451EBAa4306a72)
   * rsETH [`0xA1290d69c65A6Fe4DF752f95823fae25cB99e5A7`](https://etherscan.io/address/0xA1290d69c65A6Fe4DF752f95823fae25cB99e5A7)
   * sfrxETH: [`0xac3E018457B222d93114458476f3E3416Abbe38F`](https://etherscan.io/address/0xac3E018457B222d93114458476f3E3416Abbe38F)
   * weETH: [`0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee`](https://etherscan.io/address/0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee)
@@ -187,6 +188,7 @@
 * Markets:
   * vezETH\_LiquidStakedETH: [`0xA854D35664c658280fFf27B6eDC6C4195c3229B3`](https://etherscan.io/address/0xA854D35664c658280fFf27B6eDC6C4195c3229B3)
   * vPT-weETH-26DEC2024\_LiquidStakedETH: [`0x76697f8eaeA4bE01C678376aAb97498Ee8f80D5C`](https://etherscan.io/address/0x76697f8eaeA4bE01C678376aAb97498Ee8f80D5C)
+  * vpufETH\_LiquidStakedETH: [`0xE0ee5dDeBFe0abe0a4Af50299D68b74Cec31668e`](https://etherscan.io/address/0xE0ee5dDeBFe0abe0a4Af50299D68b74Cec31668e)
   * vrsETH\_LiquidStakedETH: [`0xDB6C345f864883a8F4cae87852Ac342589E76D1B`](https://etherscan.io/address/0xDB6C345f864883a8F4cae87852Ac342589E76D1B)
   * vsfrxETH\_LiquidStakedETH: [`0xF9E9Fe17C00a8B96a8ac20c4E344C8688D7b947E`](https://etherscan.io/address/0xF9E9Fe17C00a8B96a8ac20c4E344C8688D7b947E)
   * vweETH\_LiquidStakedETH: [`0xb4933AF59868986316Ed37fa865C829Eba2df0C7`](https://etherscan.io/address/0xb4933AF59868986316Ed37fa865C829Eba2df0C7)
@@ -449,6 +451,7 @@
 * Markets:
   * vezETH\_LiquidStakedETH: [`0xF4C1B7528f8B266D8ADf1a85c91d93114FeDbA2A`](https://sepolia.etherscan.io/address/0xF4C1B7528f8B266D8ADf1a85c91d93114FeDbA2A)
   * vPT-weETH-26DEC2024\_LiquidStakedETH: [`0x3AF2bE7AbEF0f840b196D99d79F4B803a5dB14a1`](https://sepolia.etherscan.io/address/0x3AF2bE7AbEF0f840b196D99d79F4B803a5dB14a1)
+  * vpufETH\_LiquidStakedETH: [`0x1E4d64B7c6f1F71969E5137B5Ee8cBa9Ab9c9356`](https://sepolia.etherscan.io/address/0x1E4d64B7c6f1F71969E5137B5Ee8cBa9Ab9c9356)
   * vrsETH\_LiquidStakedETH: [`0x20a83DE526F2CF2fCec2131E07b11F956d8f3Cdf`](https://sepolia.etherscan.io/address/0x20a83DE526F2CF2fCec2131E07b11F956d8f3Cdf)
   * vsfrxETH\_Core: [`0x83F63118dcAAdAACBFF36D78ffB88dd474309e70`](https://sepolia.etherscan.io/address/0x83F63118dcAAdAACBFF36D78ffB88dd474309e70)
   * vweETH\_LiquidStakedETH: [`0x30c31bA6f4652B548fe7a142A949987c3f3Bf80b`](https://sepolia.etherscan.io/address/0x30c31bA6f4652B548fe7a142A949987c3f3Bf80b)

--- a/risk/resilient-price-oracle.md
+++ b/risk/resilient-price-oracle.md
@@ -156,6 +156,7 @@ The current list of correlated token oracles in Venus is:
 | Curve | CRV | [Chainlink](https://etherscan.io/address/0x94c3A2d6B7B2c051aDa041282aec5B0752F8A1F2) | - | - | |
 | Liquid Staked ETH | ezETH | [ezETHOneJumpRedstoneOracle](https://etherscan.io/address/0x8062dC1b38c0b2CF6188dF605B19cFF3c4dc9b29) | [ezETHOneJumpChainlinkOracle](https://etherscan.io/address/0xa87E10C6F6DAD7af6C17f82Ce2C00FA5C64d110c) | [ezETHOneJumpChainlinkOracle](https://etherscan.io/address/0xa87E10C6F6DAD7af6C17f82Ce2C00FA5C64d110c) | Upper bound: 1.01. Lower bound: 0.99 |
 | Liquid Staked ETH | PTweETH-26DEC2024 | [PendleOracle-PT-weETH-26DEC2024](https://etherscan.io/address/0xA1eA3cB0FeA73a6c53aB07CcC703Dc039D8EAFb4) | - | - | |
+| Liquid Staked ETH | pufETH | [pufETHOneJumpRedstoneOracle](https://etherscan.io/address/0xAaE18CEBDF55bbbbf5C70c334Ee81D918be728Bc) | - | - | |
 | Liquid Staked ETH | rsETH | [rsETHOneJumpRedstoneOracle](https://etherscan.io/address/0xf689AD140BDb9425fB83ba6f55866447244b5a23) | [rsETHOneJumpChainlinkOracle](https://etherscan.io/address/0xD63011ddAc93a6f8348bf7E6Aeb3E30Ad7B46Df8) | [rsETHOneJumpChainlinkOracle](https://etherscan.io/address/0xD63011ddAc93a6f8348bf7E6Aeb3E30Ad7B46Df8) | Upper bound: 1.01. Lower bound: 0.99 |
 | Liquid Staked ETH | sfrxETH | [SFrxETHOracle](https://etherscan.io/address/0x5E06A5f48692E4Fff376fDfCA9E4C0183AAADCD1) | - | - | |
 | Liquid Staked ETH | WETH | [Chainlink](https://etherscan.io/address/0x94c3A2d6B7B2c051aDa041282aec5B0752F8A1F2) | - | - | |


### PR DESCRIPTION
Following the exectution of [VIP-395](https://app.venus.io/#/governance/proposal/395?chainId=56), this PR adds the addresses for pufETH vTokens and oracle to the documentation