### PR TITLE
ci: add GitBook preview comment on PRs

### DIFF
--- a/.github/workflows/gitbook-preview-comment.yml
+++ b/.github/workflows/gitbook-preview-comment.yml
@@ -1,0 +1,68 @@
+name: GitBook Preview Comment
+
+on:
+  status
+
+jobs:
+  comment:
+    # Only run for GitBook status checks on PRs
+    if: >-
+      github.event.context == 'GitBook - docs-v4.venus.io' &&
+      github.event.state == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      statuses: read
+    steps:
+      - name: Find associated PR
+        id: find-pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.payload.sha;
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+            });
+            const pr = prs.find(p => p.head.sha === sha);
+            if (!pr) {
+              core.info('No open PR found for this commit');
+              return;
+            }
+            core.setOutput('pr_number', pr.number);
+            core.setOutput('found', 'true');
+
+      - name: Post or update preview comment
+        if: steps.find-pr.outputs.found == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = ${{ steps.find-pr.outputs.pr_number }};
+            const previewUrl = '${{ github.event.target_url }}';
+            const marker = '<!-- gitbook-preview -->';
+            const body = `${marker}\n**GitBook Preview:** ${previewUrl}`;
+
+            // Check for existing comment to update
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that posts a PR comment with the GitBook preview URL
- Triggers on GitBook's `status` event (specifically the `GitBook - docs-v4.venus.io` context)
- Updates the existing comment on force-push instead of creating duplicates

This makes preview links more visible — currently they're only accessible by clicking "Details" on the status check.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>