### PR TITLE
docs: remove Isolated Pools from What's New nav (deprecated)

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -13,7 +13,6 @@
 * [Leveraged Positions](whats-new/leveraged-positions.md)
 * [E-Mode](whats-new/e-mode.md)
 * [Isolated E-Mode](whats-new/isolated-e-mode.md)
-* [Isolated Pools](whats-new/isolated-pools.md)
 * [Reward Distributor](whats-new/reward-distributor.md)
 * [Peg Stability Module](whats-new/psm.md)
 * [Automatic Income Allocation](whats-new/automatic-income-allocation.md)


### PR DESCRIPTION
## What

Removes the **Isolated Pools** entry from the `What's New?` navigation in `SUMMARY.md`.

```diff
- * [Isolated Pools](whats-new/isolated-pools.md)
```

## Why

Isolated Pools are fully deprecated — all isolated pools have been wound down. Keeping the page in the live navigation presents a removed product as current. This removes it from the published site's sidebar so users no longer land on it.

## Scope

- **Nav only.** The page file `whats-new/isolated-pools.md` is intentionally **kept in the repo** (content retained, recoverable, easy to restore by re-adding the line). Nothing else is touched.
- First in a series of docs-cleanup changes from the 2026-06 stale-pages audit; the sunset-chain reorg (Sunset section) lands in separate follow-up PRs.