### PR TITLE
Docs: Update document for Risk Stewards & Risk Oracle V2 framework

### DIFF
--- a/.gitbook/assets/risk-stewards-architecture.svg
+++ b/.gitbook/assets/risk-stewards-architecture.svg
@@ -1,0 +1,110 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 600" font-family="Inter, 'Segoe UI', system-ui, -apple-system, Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="ah" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="userSpaceOnUse">
+      <path d="M0,0 L7,3 L0,6 Z" fill="rgba(255,255,255,0.55)"/>
+    </marker>
+    <marker id="ahr" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="userSpaceOnUse">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#fb7185"/>
+    </marker>
+    <filter id="glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="2.4" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <style>
+      .top{font-size:13px;fill:#5b6b82;font-weight:600;letter-spacing:3px}
+      .panel{font-size:11px;fill:#5b6b82;font-weight:600;letter-spacing:2px}
+      .t{font-size:13.5px;font-weight:700}
+      .s{font-size:10.5px;fill:#94a3b8}
+      .e{font-size:10.5px;fill:#cbd5e1;font-weight:500}
+      .em{font-size:9.5px;fill:#7c8aa0}
+      .edge{stroke:rgba(255,255,255,0.4);stroke-width:1.6;fill:none}
+      .dash{stroke:#fb7185;stroke-width:1.5;stroke-dasharray:5 4;fill:none}
+    </style>
+  </defs>
+
+  <rect x="0" y="0" width="960" height="600" rx="14" fill="#0f1419"/>
+  <text class="top" x="480" y="30" text-anchor="middle">RISK STEWARDS — ARCHITECTURE</text>
+
+  <!-- panels -->
+  <rect x="24" y="52" width="556" height="524" rx="14" fill="rgba(255,255,255,0.02)" stroke="rgba(148,163,184,0.35)" stroke-width="1.3" stroke-dasharray="5 4"/>
+  <text class="panel" x="44" y="76">BNB CHAIN — SOURCE</text>
+  <rect x="700" y="150" width="236" height="400" rx="14" fill="rgba(255,255,255,0.02)" stroke="rgba(148,163,184,0.35)" stroke-width="1.3" stroke-dasharray="5 4"/>
+  <text class="panel" x="716" y="172">REMOTE CHAIN</text>
+  <text class="s" x="716" y="188">destination (one per supported chain)</text>
+
+  <!-- governance -->
+  <rect x="700" y="52" width="236" height="82" rx="10" fill="#1f0f14" stroke="#fb7185" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="818" y="76" text-anchor="middle" fill="#fb7185">Governance / ACM</text>
+  <text class="s" x="818" y="94" text-anchor="middle">whitelists providers &amp; executors,</text>
+  <text class="s" x="818" y="109" text-anchor="middle">sets debounce · timelock · safe-delta,</text>
+  <text class="s" x="818" y="124" text-anchor="middle">can pause processing</text>
+
+  <!-- BNB boxes -->
+  <rect x="70" y="92" width="464" height="58" rx="10" fill="#1b1407" stroke="#f59e0b" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="302" y="117" text-anchor="middle" fill="#f59e0b">Risk Parameter Providers</text>
+  <text class="s" x="302" y="136" text-anchor="middle">Chaos Labs · Allez Labs · Venus risk team — whitelisted</text>
+
+  <rect x="176" y="192" width="252" height="54" rx="10" fill="#161031" stroke="#a78bfa" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="302" y="215" text-anchor="middle" fill="#a78bfa">Risk Oracle</text>
+  <text class="s" x="302" y="233" text-anchor="middle">single source of truth</text>
+
+  <rect x="120" y="296" width="364" height="58" rx="10" fill="#0c1626" stroke="#60a5fa" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="302" y="320" text-anchor="middle" fill="#60a5fa">RiskStewardReceiver (RSR)</text>
+  <text class="s" x="302" y="338" text-anchor="middle">validate · route · execute or timelock</text>
+
+  <rect x="58" y="412" width="150" height="58" rx="10" fill="#0a1a14" stroke="#34d399" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="133" y="437" text-anchor="middle" fill="#34d399" font-size="12.5">Market Caps</text>
+  <text class="t" x="133" y="454" text-anchor="middle" fill="#34d399" font-size="12.5">Steward</text>
+  <rect x="221" y="412" width="150" height="58" rx="10" fill="#0a1a14" stroke="#34d399" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="296" y="437" text-anchor="middle" fill="#34d399" font-size="12.5">Collateral Factors</text>
+  <text class="t" x="296" y="454" text-anchor="middle" fill="#34d399" font-size="12.5">Steward</text>
+  <rect x="384" y="412" width="150" height="58" rx="10" fill="#0a1a14" stroke="#34d399" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="459" y="437" text-anchor="middle" fill="#34d399" font-size="12.5">IRM</text>
+  <text class="t" x="459" y="454" text-anchor="middle" fill="#34d399" font-size="12.5">Steward</text>
+
+  <rect x="70" y="506" width="464" height="54" rx="10" fill="#08191f" stroke="#22d3ee" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="302" y="528" text-anchor="middle" fill="#22d3ee">Core &amp; Isolated Comptrollers / vTokens</text>
+  <text class="s" x="302" y="546" text-anchor="middle">supply &amp; borrow caps · collateral factors · interest rate models</text>
+
+  <!-- BNB edges -->
+  <line class="edge" x1="302" y1="150" x2="302" y2="190" marker-end="url(#ah)"/>
+  <text class="e" x="312" y="174">publish</text>
+  <line class="edge" x1="302" y1="246" x2="302" y2="294" marker-end="url(#ah)"/>
+  <text class="e" x="312" y="266">processUpdate</text>
+  <text class="em" x="312" y="280">anyone — permissionless</text>
+  <line class="edge" x1="302" y1="354" x2="133" y2="410" marker-end="url(#ah)"/>
+  <line class="edge" x1="302" y1="354" x2="296" y2="410" marker-end="url(#ah)"/>
+  <line class="edge" x1="302" y1="354" x2="459" y2="410" marker-end="url(#ah)"/>
+  <text class="e" x="312" y="386">applyUpdate</text>
+  <line class="edge" x1="133" y1="470" x2="133" y2="504" marker-end="url(#ah)"/>
+  <line class="edge" x1="296" y1="470" x2="296" y2="504" marker-end="url(#ah)"/>
+  <line class="edge" x1="459" y1="470" x2="459" y2="504" marker-end="url(#ah)"/>
+
+  <!-- cross-chain -->
+  <rect x="596" y="307" width="92" height="42" rx="21" fill="#1e293b" stroke="#cbd5e1" stroke-width="1.5" filter="url(#glow)"/>
+  <text class="t" x="642" y="332" text-anchor="middle" fill="#e2e8f0" font-size="12">LayerZero</text>
+  <line class="edge" x1="484" y1="328" x2="594" y2="328" marker-end="url(#ah)"/>
+  <text class="e" x="498" y="320">lzSend (remote)</text>
+  <line class="edge" x1="688" y1="328" x2="714" y2="328" marker-end="url(#ah)"/>
+
+  <rect x="716" y="300" width="204" height="58" rx="10" fill="#0c1626" stroke="#60a5fa" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="818" y="323" text-anchor="middle" fill="#60a5fa" font-size="12">Destination Steward Receiver</text>
+  <text class="s" x="818" y="341" text-anchor="middle">register · remoteDelay · execute</text>
+
+  <rect x="716" y="410" width="204" height="52" rx="10" fill="#0a1a14" stroke="#34d399" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="818" y="432" text-anchor="middle" fill="#34d399" font-size="12.5">Risk Stewards (remote)</text>
+  <text class="s" x="818" y="450" text-anchor="middle">Market Caps · Collateral Factors · IRM</text>
+
+  <rect x="716" y="496" width="204" height="48" rx="10" fill="#08191f" stroke="#22d3ee" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="818" y="517" text-anchor="middle" fill="#22d3ee" font-size="12.5">Comptrollers / vTokens</text>
+  <text class="s" x="818" y="533" text-anchor="middle">on the destination chain</text>
+
+  <line class="edge" x1="818" y1="358" x2="818" y2="408" marker-end="url(#ah)"/>
+  <text class="em" x="828" y="386">executor, after delay</text>
+  <line class="edge" x1="818" y1="462" x2="818" y2="494" marker-end="url(#ah)"/>
+
+  <!-- governance control arrows -->
+  <path class="dash" d="M742,134 C660,210 560,295 488,314" marker-end="url(#ahr)"/>
+  <text class="e" x="556" y="250" fill="#fb7185">configure · whitelist</text>
+  <path class="dash" d="M818,134 L818,298" marker-end="url(#ahr)"/>
+</svg>

--- a/.gitbook/assets/risk-stewards-local-flow.svg
+++ b/.gitbook/assets/risk-stewards-local-flow.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 606" font-family="Inter, 'Segoe UI', system-ui, -apple-system, Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="ah" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="userSpaceOnUse">
+      <path d="M0,0 L7,3 L0,6 Z" fill="rgba(255,255,255,0.55)"/>
+    </marker>
+    <filter id="glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="2.4" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <style>
+      .top{font-size:13px;fill:#5b6b82;font-weight:600;letter-spacing:3px}
+      .t{font-size:13px;font-weight:700}
+      .s{font-size:10.5px;fill:#94a3b8}
+      .e{font-size:10.5px;fill:#cbd5e1;font-weight:500}
+      .edge{stroke:rgba(255,255,255,0.42);stroke-width:1.7;fill:none}
+    </style>
+  </defs>
+
+  <rect x="0" y="0" width="900" height="606" rx="14" fill="#0f1419"/>
+  <text class="top" x="450" y="28" text-anchor="middle">RISK STEWARDS — BNB CHAIN UPDATE FLOW</text>
+
+  <!-- top row -->
+  <rect x="40" y="52" width="180" height="58" rx="10" fill="#1b1407" stroke="#f59e0b" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="130" y="77" text-anchor="middle" fill="#f59e0b">Risk provider</text>
+  <text class="s" x="130" y="95" text-anchor="middle">publishRiskParameterUpdate</text>
+
+  <rect x="260" y="52" width="180" height="58" rx="10" fill="#161031" stroke="#a78bfa" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="350" y="77" text-anchor="middle" fill="#a78bfa">Risk Oracle</text>
+  <text class="s" x="350" y="95" text-anchor="middle">stores update · assigns id</text>
+
+  <rect x="480" y="52" width="200" height="58" rx="10" fill="#0c1626" stroke="#60a5fa" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="580" y="77" text-anchor="middle" fill="#60a5fa">RSR.processUpdate</text>
+  <text class="s" x="580" y="95" text-anchor="middle">anyone calls</text>
+
+  <line class="edge" x1="220" y1="81" x2="258" y2="81" marker-end="url(#ah)"/>
+  <text class="e" x="222" y="73">publish</text>
+  <line class="edge" x1="440" y1="81" x2="478" y2="81" marker-end="url(#ah)"/>
+
+  <text class="s" x="580" y="128" text-anchor="middle">validates: active · latest · not expired · debounce</text>
+
+  <!-- decision -->
+  <line class="edge" x1="580" y1="136" x2="580" y2="156" marker-end="url(#ah)"/>
+  <polygon points="580,158 650,198 580,238 510,198" fill="#1b1407" stroke="#f59e0b" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="580" y="194" text-anchor="middle" fill="#fbbf24" font-size="11.5">within</text>
+  <text class="t" x="580" y="208" text-anchor="middle" fill="#fbbf24" font-size="11.5">safe delta?</text>
+
+  <!-- yes branch -->
+  <polyline class="edge" points="510,198 210,198 210,264" marker-end="url(#ah)"/>
+  <text class="e" x="300" y="188" fill="#34d399">Yes — within delta</text>
+  <rect x="110" y="266" width="200" height="58" rx="10" fill="#0a1a14" stroke="#34d399" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="210" y="291" text-anchor="middle" fill="#34d399">Apply immediately</text>
+  <text class="s" x="210" y="309" text-anchor="middle">no timelock</text>
+
+  <!-- no branch -->
+  <polyline class="edge" points="650,198 730,198 730,264" marker-end="url(#ah)"/>
+  <text class="e" x="658" y="182" fill="#f59e0b">No — exceeds delta</text>
+  <text class="e" x="658" y="195" fill="#f59e0b">(IRM &amp; eMode always)</text>
+  <rect x="600" y="266" width="260" height="58" rx="10" fill="#1b1407" stroke="#f59e0b" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="730" y="291" text-anchor="middle" fill="#f59e0b">Register + timelock</text>
+  <text class="s" x="730" y="309" text-anchor="middle">status: Pending</text>
+
+  <line class="edge" x1="730" y1="324" x2="730" y2="354" marker-end="url(#ah)"/>
+  <text class="e" x="740" y="343">wait timelock</text>
+  <rect x="600" y="356" width="260" height="58" rx="10" fill="#0c1626" stroke="#60a5fa" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="730" y="380" text-anchor="middle" fill="#60a5fa" font-size="11.5">RSR.executeRegisteredUpdate</text>
+  <text class="s" x="730" y="398" text-anchor="middle">executor · after timelock</text>
+
+  <!-- converge to steward -->
+  <rect x="300" y="440" width="300" height="56" rx="10" fill="#0a1a14" stroke="#34d399" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="450" y="464" text-anchor="middle" fill="#34d399">Steward.applyUpdate(update)</text>
+  <text class="s" x="450" y="482" text-anchor="middle">Market Caps · Collateral Factors · IRM</text>
+
+  <polyline class="edge" points="210,324 210,468 298,468" marker-end="url(#ah)"/>
+  <polyline class="edge" points="730,414 730,468 602,468" marker-end="url(#ah)"/>
+
+  <!-- protocol -->
+  <rect x="290" y="524" width="320" height="66" rx="10" fill="#08191f" stroke="#22d3ee" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="450" y="547" text-anchor="middle" fill="#22d3ee" font-size="12.5">Comptroller / vToken updated</text>
+  <text class="s" x="450" y="565" text-anchor="middle" font-size="9.5">setMarketSupplyCaps · setMarketBorrowCaps</text>
+  <text class="s" x="450" y="580" text-anchor="middle" font-size="9.5">setCollateralFactor · setInterestRateModel</text>
+  <line class="edge" x1="450" y1="496" x2="450" y2="522" marker-end="url(#ah)"/>
+</svg>

--- a/.gitbook/assets/risk-stewards-remote-flow.svg
+++ b/.gitbook/assets/risk-stewards-remote-flow.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 460" font-family="Inter, 'Segoe UI', system-ui, -apple-system, Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="ah" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="userSpaceOnUse">
+      <path d="M0,0 L7,3 L0,6 Z" fill="rgba(255,255,255,0.55)"/>
+    </marker>
+    <filter id="glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="2.4" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <style>
+      .top{font-size:13px;fill:#5b6b82;font-weight:600;letter-spacing:3px}
+      .panel{font-size:11px;fill:#5b6b82;font-weight:600;letter-spacing:2px}
+      .t{font-size:12.5px;font-weight:700}
+      .s{font-size:10px;fill:#94a3b8}
+      .e{font-size:10px;fill:#cbd5e1;font-weight:500}
+      .edge{stroke:rgba(255,255,255,0.42);stroke-width:1.7;fill:none}
+    </style>
+  </defs>
+
+  <rect x="0" y="0" width="960" height="460" rx="14" fill="#0f1419"/>
+  <text class="top" x="480" y="28" text-anchor="middle">RISK STEWARDS — REMOTE (CROSS-CHAIN) UPDATE FLOW</text>
+
+  <!-- swimlanes -->
+  <rect x="20" y="56" width="920" height="116" rx="14" fill="rgba(255,255,255,0.02)" stroke="rgba(148,163,184,0.35)" stroke-width="1.3" stroke-dasharray="5 4"/>
+  <text class="panel" x="38" y="76">BNB CHAIN — SOURCE</text>
+  <rect x="20" y="256" width="920" height="180" rx="14" fill="rgba(255,255,255,0.02)" stroke="rgba(148,163,184,0.35)" stroke-width="1.3" stroke-dasharray="5 4"/>
+  <text class="panel" x="38" y="276">DESTINATION CHAIN</text>
+
+  <!-- BNB row -->
+  <rect x="34" y="86" width="160" height="58" rx="10" fill="#1b1407" stroke="#f59e0b" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="114" y="110" text-anchor="middle" fill="#f59e0b">Risk provider</text>
+  <text class="s" x="114" y="128" text-anchor="middle">publish · dstEid = remote</text>
+
+  <rect x="214" y="86" width="140" height="58" rx="10" fill="#161031" stroke="#a78bfa" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="284" y="119" text-anchor="middle" fill="#a78bfa">Risk Oracle</text>
+
+  <rect x="374" y="86" width="180" height="58" rx="10" fill="#0c1626" stroke="#60a5fa" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="464" y="110" text-anchor="middle" fill="#60a5fa">RSR.processUpdate</text>
+  <text class="s" x="464" y="128" text-anchor="middle">validate · forward</text>
+
+  <line class="edge" x1="194" y1="115" x2="212" y2="115" marker-end="url(#ah)"/>
+  <line class="edge" x1="354" y1="115" x2="372" y2="115" marker-end="url(#ah)"/>
+
+  <!-- RSR -> LayerZero -->
+  <polyline class="edge" points="554,115 866,115 866,178" marker-end="url(#ah)"/>
+  <text class="e" x="690" y="107" text-anchor="middle">lzSend</text>
+
+  <!-- LayerZero bridge between lanes -->
+  <rect x="806" y="180" width="120" height="58" rx="16" fill="#1e293b" stroke="#cbd5e1" stroke-width="1.5" filter="url(#glow)"/>
+  <text class="t" x="866" y="206" text-anchor="middle" fill="#e2e8f0">LayerZero</text>
+  <text class="s" x="866" y="223" text-anchor="middle">bridge</text>
+
+  <!-- destination row 1 (right to left) -->
+  <rect x="748" y="292" width="172" height="58" rx="10" fill="#0c1626" stroke="#60a5fa" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="834" y="316" text-anchor="middle" fill="#60a5fa" font-size="10">DestinationStewardReceiver</text>
+  <text class="s" x="834" y="334" text-anchor="middle">_lzReceive · register</text>
+
+  <rect x="486" y="292" width="190" height="58" rx="10" fill="#0c1626" stroke="#60a5fa" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="581" y="316" text-anchor="middle" fill="#60a5fa" font-size="11.5">DSR.executeUpdate</text>
+  <text class="s" x="581" y="334" text-anchor="middle">executor · after remoteDelay</text>
+
+  <rect x="240" y="292" width="176" height="58" rx="10" fill="#0a1a14" stroke="#34d399" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="328" y="325" text-anchor="middle" fill="#34d399" font-size="12">Risk Steward (remote)</text>
+
+  <!-- destination row 2 -->
+  <rect x="240" y="372" width="176" height="52" rx="10" fill="#08191f" stroke="#22d3ee" stroke-width="1.6" filter="url(#glow)"/>
+  <text class="t" x="328" y="394" text-anchor="middle" fill="#22d3ee">Comptroller / vToken</text>
+  <text class="s" x="328" y="410" text-anchor="middle">destination chain</text>
+
+  <!-- destination edges -->
+  <line class="edge" x1="866" y1="238" x2="866" y2="290" marker-end="url(#ah)"/>
+  <text class="e" x="876" y="252">_lzReceive</text>
+  <line class="edge" x1="748" y1="321" x2="678" y2="321" marker-end="url(#ah)"/>
+  <text class="e" x="713" y="312" text-anchor="middle">execute</text>
+  <line class="edge" x1="486" y1="321" x2="418" y2="321" marker-end="url(#ah)"/>
+  <text class="e" x="452" y="312" text-anchor="middle">applyUpdate</text>
+  <line class="edge" x1="328" y1="350" x2="328" y2="370" marker-end="url(#ah)"/>
+  <text class="e" x="338" y="364">apply</text>
+</svg>

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -33,7 +33,7 @@
 * [Interest Rate Model](risk/interest-rate-model.md)
 * [Risk Fund and Shortfall Handling](risk/risk-fund-and-shortfall-handling.md)
 * [Risk Management](risk/risk-management.md)
-* [Risk Oracles and Risk Stewards](risk/risk-oracle-and-risk-stewards.md)
+* [Risk Oracle & Risk Stewards](risk/risk-oracle-and-risk-stewards.md)
 
 ## Tokens
 
@@ -193,8 +193,13 @@
   * [OmnichainProposalSender](technical-reference/reference-governance/omnichain-proposal-sender.md) 
   * [OmnichainGovernanceExecutor](technical-reference/reference-governance/omnichain-governance-executor.md) 
   * [OmnichainExecutorOwner](technical-reference/reference-governance/omnichain-executor-owner.md) 
-  * [RiskStewardReceiver](technical-reference/reference-governance/risk-steward-receiver.md) 
+  * [RiskOracle](technical-reference/reference-governance/risk-oracle.md)
+  * [RiskStewardReceiver](technical-reference/reference-governance/risk-steward-receiver.md)
+  * [DestinationStewardReceiver](technical-reference/reference-governance/destination-steward-receiver.md)
+  * [BaseRiskSteward](technical-reference/reference-governance/base-risk-steward.md)
   * [MarketCapsRiskSteward](technical-reference/reference-governance/market-caps-risk-steward.md)
+  * [CollateralFactorsRiskSteward](technical-reference/reference-governance/collateral-factors-risk-steward.md)
+  * [IRMRiskSteward](technical-reference/reference-governance/irm-risk-steward.md)
 * [XVS Bridge](technical-reference/reference-xvs-bridge/README.md)
   * [BaseXVSProxyOFT](technical-reference/reference-xvs-bridge/BaseXVSProxyOFT.md)
   * [XVSProxyOFTSrc](technical-reference/reference-xvs-bridge/XVSProxyOFTSrc.md)

--- a/risk/risk-oracle-and-risk-stewards.md
+++ b/risk/risk-oracle-and-risk-stewards.md
@@ -1,66 +1,86 @@
-# Risk Stewards & Risk Oracles
+# Risk Oracle & Risk Stewards
 
 ## Overview
 
-Venus Protocol incorporates Risk Oracles and Risk Stewards to ensure risk parameters remain up-to-date, resilient, and aligned with real-time market conditions—all while preserving decentralized governance. Previously, Venus relied on manually created VIPs to apply risk updates based on Chaos Labs recommendations. With the introduction of the Risk Steward and its on-chain receiver, this process is now automated through a secure and permissioned mechanism. In the initial phase, only market cap-related parameters—specifically supply caps and borrow caps—will be updated automatically, improving responsiveness and operational efficiency.
+Venus Protocol uses a **Risk Oracle** and a set of **Risk Stewards** to keep risk parameters aligned with real-time market conditions while preserving decentralized governance. Previously, every risk-parameter change went through the same full VIP process, no matter how routine. The framework now lets governance-approved risk managers apply pre-authorized adjustments through a secure, automated on-chain pipeline, but no risk provider is ever given open-ended authority: each change is first proposed openly in the Venus community, and can only move a parameter within limits the DAO has set. Routine moves within a governance-set **safe delta** apply automatically within minutes; anything larger is held for a cooldown period and released only by a whitelisted Venus executor (who can also reject it), while the most sensitive changes still require a full VIP. Governance sets every limit, approves who may publish and who may execute, and can pause the system at any time.
 
----
+The framework currently automates four parameter types: **supply caps**, **borrow caps**, **collateral factors** (with their liquidation thresholds), and **interest rate models**, across all supported Venus chains. BNB Chain acts as the source chain, and updates targeting other chains are propagated via LayerZero. Every recommendation and execution is recorded on the Risk Oracle, so anyone can inspect a proposed change on-chain, before and after it takes effect.
 
-## Chaos Labs Risk Oracle
+## How the System Fits Together
 
-The **Chaos Labs Risk Oracle** is a system designed to continuously analyze market conditions—such as price volatility, liquidity, asset utilization, and liquidation events—and generate risk parameter recommendations tailored to the Venus Protocol.
+<figure><img src="../.gitbook/assets/risk-stewards-architecture.svg" alt="Risk Stewards architecture: whitelisted providers publish to the Venus Risk Oracle on BNB Chain; the RiskStewardReceiver applies updates locally or forwards them over LayerZero to a Destination Steward Receiver on other chains; governance configures and gates everything"><figcaption><p>Whitelisted providers publish to the Risk Oracle on BNB Chain; the Risk Steward Receiver applies updates locally or bridges them to other chains. Governance configures and gates the whole pipeline.</p></figcaption></figure>
 
-### Key Benefits:
+The pipeline has four parts:
 
-- **Real-time updates** to key parameters like supply and borrow caps
-- **Automated adjustments** to ensure optimal lending and borrowing rates
-- **More responsive risk management** with lower latency
-- **Reduced operational overhead** for the Venus community
+* **Risk Oracle** (BNB Chain): where whitelisted providers publish recommendations.
+* **Risk Steward Receiver** (BNB Chain, the source chain): validates each recommendation, decides how it should be applied, executes local changes, and forwards cross-chain ones via LayerZero.
+* **Destination Steward Receiver** (every other supported chain): receives bridged updates, holds them for a short delay, and lets a Venus executor apply them.
+* **Risk Stewards** (Market Caps, Collateral Factors, IRM): deployed on each chain to perform the actual change in the relevant Comptroller or vToken.
 
-The Risk Oracle makes Venus more adaptable while ensuring parameters remain within safe and governance-approved limits.
+The contract-level detail lives in the [Risk Stewards technical article](../technical-reference/reference-technical-articles/risk-stewards.md).
 
----
+## Risk Oracle
 
-## Risk Steward
+The **Risk Oracle** is Venus Protocol's own on-chain contract and the single source of truth for risk-parameter recommendations. It is owned and controlled by Venus governance, not by any third party.
 
-A **Risk Steward** is an on-chain smart contract that executes risk parameter updates on behalf of the protocol, based on recommendations from the Risk Oracle. Venus has introduced this role to bridge off-chain risk intelligence with on-chain execution in a controlled, transparent way.
+Whitelisted **risk parameter providers** publish recommendations to it. A provider can be an external risk manager such as Chaos Labs or Allez Labs, or Venus's own risk team. Providers are added or removed only through governance (via the `AccessControlManager`), so the set of authorized senders is fully under DAO control. Each recommendation records the target market, the parameter type, the new value, the destination chain, and a reference ID (typically a link to a Venus community post explaining the change).
 
-### Role of the Risk Steward:
+## Risk Stewards
 
-- Reads values from the Risk Oracle during execution
-- Updates only pre-approved risk parameters (e.g., supply caps, borrow caps)
-- Operates within limits set by Venus governance
-- Cannot modify critical protocol settings such as interest rate models, market listings, or governance controls
+A **Risk Steward** is an on-chain contract that applies one family of risk-parameter changes on behalf of the protocol, strictly within bounds set by governance:
 
-This structure ensures **faster, automated adjustments** without compromising community control.
+| Risk Steward | Parameters it can change |
+| --- | --- |
+| **Market Caps Risk Steward** | Supply caps, borrow caps |
+| **Collateral Factors Risk Steward** | Collateral factors and liquidation thresholds |
+| **IRM Risk Steward** | Interest rate model contract for a market |
 
----
+Each steward applies only validated updates routed to it, enforces a **safe delta** (changes within a governance-set percentage of the current value can execute immediately; larger ones require a timelock and executor approval), and cannot touch any parameter outside its mandate.
 
-## How It Works
+## How Updates Are Applied
 
-1. **Data Source**: Chaos Labs publishes updated recommendations via the Risk Oracle.
-2. **Keeper Role**: A Keeper bot observes changes and initiates transactions to update Venus Protocol’s parameters.
-3. **Validation**: During execution, Venus contracts read and apply new values **only if they are within predefined safety bounds**.
-4. **Challenge Window**:  Critical updates, which will be introduced in an upcoming phase, will go through governance and can be **challenged or vetoed** during a defined challenge window before they take effect.
+Anyone can trigger processing of a published recommendation; the entry point is permissionless. Before anything happens, the recommendation is validated against governance's configuration: the update type must be active, it must be the latest for that market and type, it must not have expired, and a debounce window since the last change must have passed. From there it follows one of two paths.
 
-## Governance & Control
+### On BNB Chain (local updates)
 
-Importantly, this system does **not bypass protocol governance**. All automated updates happen within constraints defined and approved by the Venus community.
+<figure><img src="../.gitbook/assets/risk-stewards-local-flow.svg" alt="Local update flow: a provider publishes to the Risk Oracle, anyone triggers processing on the Risk Steward Receiver, and the change either applies immediately when within the safe delta or is registered behind a timelock for a whitelisted executor to apply"><figcaption><p>A BNB Chain update applies immediately when it is within the safe delta; otherwise it waits through a timelock and is applied (or rejected) by a whitelisted executor.</p></figcaption></figure>
 
-Any change made through the Risk Oracle follows an **optimistic governance model**:
+If the change is within the steward's safe delta, it is applied immediately. If it exceeds the safe delta it is registered behind a timelock; after the delay a whitelisted Venus executor applies it, or rejects it. Interest rate model updates and eMode collateral-factor updates always take the timelocked path, regardless of size.
 
-This process **preserves decentralization** while enabling faster, safer protocol maintenance.
+### On Other Chains (remote updates)
 
----
+<figure><img src="../.gitbook/assets/risk-stewards-remote-flow.svg" alt="Remote update flow: a provider publishes on BNB Chain, the Risk Steward Receiver forwards the update over LayerZero to the Destination Steward Receiver on the target chain, which holds it for a remote delay before a whitelisted executor applies it through the local steward"><figcaption><p>An update targeting another chain is forwarded over LayerZero, held for a remote delay on the destination chain, then applied by a whitelisted executor there.</p></figcaption></figure>
 
-## What’s Next
+When a recommendation targets a market on another chain, the Risk Steward Receiver forwards it over LayerZero to that chain's Destination Steward Receiver, where it is held for a remote delay and then applied by a whitelisted executor on the destination chain. Cross-chain updates therefore always pass through a delay and an executor.
 
-Initially, the integration focuses on automating supply and borrow cap updates. Over time, additional parameters may be supported as part of a gradual rollout, always subject to DAO approval and governance-defined constraints.
+## Roles and Permissions
 
----
+| Role | Can do | Set by |
+| --- | --- | --- |
+| **Risk parameter providers** | Publish recommendations to the Risk Oracle; trigger processing of their own updates | Governance (ACM whitelist) |
+| **Anyone** | Trigger processing of a published recommendation | Permissionless |
+| **Whitelisted executors (Venus team)** | Apply timelocked and cross-chain updates after their delay; reject updates | Governance (ACM whitelist) |
+| **Governance / ACM** | Configure debounce, timelock, safe-delta bounds, and supported update types; add/remove providers and executors; pause processing | DAO (VIP) |
+
+## Safeguards and Governance Control
+
+This system does **not** bypass governance; it operates entirely within constraints the DAO approves:
+
+* **Bounded changes**: stewards can only move the four supported parameters, and only within the safe-delta / timelock rules set by governance.
+* **Frequency limits**: a debounce period prevents rapid repeated changes to the same market and parameter.
+* **Timelock + veto**: larger changes, IRM changes, and eMode collateral-factor changes wait through a timelock during which a Venus executor can reject them.
+* **Expiration & replay protection**: updates expire if not executed in time and can never be processed twice.
+* **Pause**: governance can pause update processing at any time.
+* **Reserved for governance**: high-impact parameters outside the four supported types still require a full VIP.
+
+The framework was enabled on BNB Chain in [VIP-592](https://app.venus.io/#/governance/proposal/592?chainId=56), which also onboarded Allez Labs as the first external risk provider. At launch, governance set a 3-day debounce, a 6-hour timelock, a 50% safe delta for market caps, and a 10% safe delta for collateral factors. These values are set by governance and can be adjusted through it.
+
+## What's Next
+
+The framework starts with supply caps, borrow caps, collateral factors, and interest rate models across supported chains. Additional parameters and refinements may be added over time, always subject to DAO approval and governance-defined constraints.
 
 ## Learn More
 
-- [Chaos Labs: Risk Oracles — Real-Time Risk Management for DeFi](https://chaoslabs.xyz/posts/risk-oracles-real-time-risk-management-for-defi)  
-- [Venus Community Proposal: Integrate Chaos Labs Risk Oracle](https://community.venus.io/t/integrate-chaos-labs-risk-oracle-to-venus-protocol/4569)
-
+* [Risk Stewards technical article](../technical-reference/reference-technical-articles/risk-stewards.md)
+* [Proposed Risk Stewards Framework for More Efficient Risk Management](https://community.venus.io/t/proposed-risk-stewards-framework-for-more-efficient-risk-management/5606)
+* [VIP-592: Risk Stewards Framework Implementation](https://app.venus.io/#/governance/proposal/592?chainId=56)

--- a/security-and-audits.md
+++ b/security-and-audits.md
@@ -75,6 +75,31 @@ We firmly believe that the true test of a smart contract's security lies in its 
 
 </details>
 
+### Risk Stewards V2
+
+**Scope**: Expansion of the Venus Risk Steward framework. In addition to supply and borrow caps, the stewards can now update collateral factors (with their liquidation thresholds) and interest rate models, governed by safe-delta and timelock controls. Recommendations are published to a Venus-owned Risk Oracle by whitelisted risk parameter providers, and updates can be executed locally on BNB Chain or forwarded cross-chain via LayerZero to destination receivers on other supported chains. Enabled in [VIP-592](https://app.venus.io/#/governance/proposal/592?chainId=56).
+
+* [Quantstamp audit report (2025/12/15)](https://github.com/VenusProtocol/governance-contracts/blob/b4b9fc4d3d4f3a8b5ecb3308693a0180399f8dec/audits/166_risk_steward_v2_quantstamp_20251215.pdf)
+* [Certik audit report (2025/12/29)](https://github.com/VenusProtocol/governance-contracts/blob/b4b9fc4d3d4f3a8b5ecb3308693a0180399f8dec/audits/167_risk_steward_v2_certik_20251229.pdf)
+
+<details>
+<summary>Detailed scope</summary>
+
+- Pull request [#163](https://github.com/VenusProtocol/governance-contracts/pull/163) in the `governance-contracts` repository:
+  - contracts/RiskSteward/RiskOracle.sol
+  - contracts/RiskSteward/RiskStewardReceiver.sol
+  - contracts/RiskSteward/DestinationStewardReceiver.sol
+  - contracts/RiskSteward/BaseRiskSteward.sol
+  - contracts/RiskSteward/MarketCapsRiskSteward.sol
+  - contracts/RiskSteward/CollateralFactorsRiskSteward.sol
+  - contracts/RiskSteward/IRMRiskSteward.sol
+  - contracts/RiskSteward/Interfaces/IRiskOracle.sol
+  - contracts/RiskSteward/Interfaces/IRiskSteward.sol
+  - contracts/RiskSteward/Interfaces/IRiskStewardReceiver.sol
+  - contracts/RiskSteward/Interfaces/IDestinationStewardReceiver.sol
+
+</details>
+
 ### Native Token Gateway upgrade
 
 **Scope**: [NativeTokenGateway contract](https://github.com/VenusProtocol/venus-periphery/blob/95e157b5b498ab80fe2715ca5ecf64203f6727fb/contracts/Gateway/NativeTokenGateway.sol) upgrade, to make it compatible with the Core pool on BNB Chain. Enabled in [VIP-543](https://app.venus.io/#/governance/proposal/543?chainId=56)

--- a/technical-reference/reference-governance/base-risk-steward.md
+++ b/technical-reference/reference-governance/base-risk-steward.md
@@ -1,0 +1,29 @@
+# BaseRiskSteward
+Abstract base contract for Risk Steward contracts providing common functionality
+
+# Solidity API
+
+### safeDeltaBps
+
+The safe delta threshold in basis points.
+Updates within this delta are considered safe and require no timelock. Updates exceeding this delta require timelock.
+
+```solidity
+uint256 safeDeltaBps
+```
+
+- - -
+
+### renounceOwnership
+
+Disables renounceOwnership function
+
+```solidity
+function renounceOwnership() public pure
+```
+
+#### ❌ Errors
+* Throws RenounceOwnershipNotAllowed
+
+- - -
+

--- a/technical-reference/reference-governance/collateral-factors-risk-steward.md
+++ b/technical-reference/reference-governance/collateral-factors-risk-steward.md
@@ -1,51 +1,41 @@
-# MarketCapsRiskSteward
-Contract that can update supply and borrow caps updates received from RiskStewardReceiver.
+# CollateralFactorsRiskSteward
+Contract that can update collateral factors and liquidation thresholds received from `RiskStewardReceiver`.
 
 # Solidity API
 
-### SUPPLY_CAP
+### COLLATERAL_FACTORS
 
-The update type for supply caps
+The update type for collateral factor and liquidation threshold.
 
 ```solidity
-string SUPPLY_CAP
+string COLLATERAL_FACTORS
 ```
 
 - - -
 
-### SUPPLY_CAP_KEY
+### COLLATERAL_FACTORS_KEY
 
-The update type key for supply caps (keccak256 hash of SUPPLY_CAP)
+The update type key for collateral factors (keccak256 hash of COLLATERAL_FACTORS)
 
 ```solidity
-bytes32 SUPPLY_CAP_KEY
+bytes32 COLLATERAL_FACTORS_KEY
 ```
 
 - - -
 
-### BORROW_CAP
+### CORE_POOL_COMPTROLLER
 
-The update type for borrow caps
-
-```solidity
-string BORROW_CAP
-```
-
-- - -
-
-### BORROW_CAP_KEY
-
-The update type key for borrow caps (keccak256 hash of BORROW_CAP)
+Address of the BNB Core Pool Comptroller.
 
 ```solidity
-bytes32 BORROW_CAP_KEY
+contract ICorePoolComptroller CORE_POOL_COMPTROLLER
 ```
 
 - - -
 
 ### RISK_STEWARD_RECEIVER
 
-Address of the RiskStewardReceiver used to validate incoming updates
+Address of the `RiskStewardReceiver` used to validate and dispatch incoming updates.
 
 ```solidity
 contract IRiskStewardReceiver RISK_STEWARD_RECEIVER
@@ -55,19 +45,20 @@ contract IRiskStewardReceiver RISK_STEWARD_RECEIVER
 
 ### constructor
 
-Sets the immutable RiskStewardReceiver address and disables initializers
+Sets the immutable `CORE_POOL_COMPTROLLER` and `RISK_STEWARD_RECEIVER` addresses and disables initializers.
 
 ```solidity
-constructor(address riskStewardReceiver_) public
+constructor(address corePoolComptroller_, address riskStewardReceiver_) public
 ```
 
 #### Parameters
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| riskStewardReceiver_ | address | The address of the RiskStewardReceiver |
+| corePoolComptroller_ | address | The address of the Core Pool Comptroller |
+| riskStewardReceiver_ | address | The address of the `RiskStewardReceiver` |
 
 #### ❌ Errors
-* Throws ZeroAddressNotAllowed if the RiskStewardReceiver address is zero
+* Throws ZeroAddressNotAllowed if any of the addresses are zero
 
 - - -
 
@@ -88,7 +79,7 @@ function initialize(address accessControlManager_) external
 
 ### setSafeDeltaBps
 
-Sets the safe delta bps
+Sets the safe delta bps.
 
 ```solidity
 function setSafeDeltaBps(uint256 safeDeltaBps_) external
@@ -113,7 +104,7 @@ function setSafeDeltaBps(uint256 safeDeltaBps_) external
 
 ### isSafeForDirectExecution
 
-Checks if an update is safe for direct execution (no timelock required)
+Checks if an update is safe for direct execution (no timelock required).
 
 ```solidity
 function isSafeForDirectExecution(struct RiskParameterUpdate update) external view returns (bool)
@@ -122,7 +113,7 @@ function isSafeForDirectExecution(struct RiskParameterUpdate update) external vi
 #### Parameters
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| update | struct RiskParameterUpdate | The update to check |
+| update | struct RiskParameterUpdate | The update to check. |
 
 #### Return Values
 | Name | Type | Description |
@@ -131,14 +122,14 @@ function isSafeForDirectExecution(struct RiskParameterUpdate update) external vi
 
 #### ❌ Errors
 * Throws UnsupportedUpdateType if the update type is not supported
-* Throws RedundantValue if the new cap value is equal to the current cap value
+* Throws RedundantValue if the new collateral factor and liquidation threshold are unchanged
 
 - - -
 
 ### applyUpdate
 
-Applies a market cap update from the RiskStewardReceiver.
-Directly updates the market supply or borrow cap on the market's comptroller.
+Applies a collateral parameter update from the `RiskStewardReceiver`.
+        Delta validation and timelock checks are already performed by `RiskStewardReceiver` before execution.
 
 ```solidity
 function applyUpdate(struct RiskParameterUpdate update) external
@@ -150,13 +141,13 @@ function applyUpdate(struct RiskParameterUpdate update) external
 | update | struct RiskParameterUpdate | RiskParameterUpdate update to apply |
 
 #### 📅 Events
-* Emits SupplyCapUpdated or BorrowCapUpdated depending on the update with the updateId, market and new cap
+* Emits CollateralFactorsUpdated with updateId
 
 #### ⛔️ Access Requirements
-* Only callable by the RiskStewardReceiver
+* Only callable by the `RiskStewardReceiver`
 
 #### ❌ Errors
-* Throws OnlyRiskStewardReceiver if the sender is not the RiskStewardReceiver
+* Throws OnlyRiskStewardReceiver if the sender is not the `RiskStewardReceiver`
 * Throws UnsupportedUpdateType if the update type is not supported
 
 - - -

--- a/technical-reference/reference-governance/destination-steward-receiver.md
+++ b/technical-reference/reference-governance/destination-steward-receiver.md
@@ -1,0 +1,372 @@
+# DestinationStewardReceiver
+Destination‑chain contract that receives bridged updates from `RiskStewardReceiver` via LayerZero,
+        enforces a fixed remote delay, and then executes the updates on the configured `IRiskSteward` contracts.
+
+# Solidity API
+
+### REMOTE_UPDATE_EXPIRATION_TIME
+
+Time before a bridged update is considered stale on the destination chain
+
+```solidity
+uint256 REMOTE_UPDATE_EXPIRATION_TIME
+```
+
+- - -
+
+### LAYER_ZERO_EID
+
+Destination chain LayerZero endpoint ID
+
+```solidity
+uint32 LAYER_ZERO_EID
+```
+
+- - -
+
+### remoteDelay
+
+Delay before a bridged update can be executed on the destination chain
+
+```solidity
+uint256 remoteDelay
+```
+
+- - -
+
+### riskParameterConfigs
+
+Mapping of supported risk configurations per update type (hashed updateType string)
+
+```solidity
+mapping(bytes32 => struct IDestinationStewardReceiver.RiskParamConfig) riskParameterConfigs
+```
+
+- - -
+
+### updates
+
+Master storage of all bridged updates by update ID
+
+```solidity
+mapping(uint256 => struct IDestinationStewardReceiver.DestinationUpdate) updates
+```
+
+- - -
+
+### lastRegisteredUpdateId
+
+Mapping from (updateType, market) to currently registered remote update ID
+
+```solidity
+mapping(bytes32 => mapping(address => uint256)) lastRegisteredUpdateId
+```
+
+- - -
+
+### lastExecutedAt
+
+Track last executed update timestamp per (updateType, market)
+
+```solidity
+mapping(bytes32 => mapping(address => uint256)) lastExecutedAt
+```
+
+- - -
+
+### whitelistedExecutors
+
+Mapping from executor address to whitelist status
+
+```solidity
+mapping(address => bool) whitelistedExecutors
+```
+
+- - -
+
+### constructor
+
+Disables initializers and sets immutable values.
+
+```solidity
+constructor(address endpoint_, uint32 layerZeroEid_) public
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| endpoint_ | address | Local LayerZero endpoint on this chain |
+| layerZeroEid_ | uint32 | LayerZero endpoint ID for this destination chain |
+
+- - -
+
+### initialize
+
+Initializes the contract with the Access Control Manager and owner.
+
+```solidity
+function initialize(address accessControlManager_, address delegate_) external
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| accessControlManager_ | address | The address of the access control manager |
+| delegate_ | address | The owner (and LayerZero delegate) of this contract |
+
+- - -
+
+### setRiskParameterConfig
+
+Sets the risk parameter config for a given update type on the destination chain.
+
+```solidity
+function setRiskParameterConfig(string updateType, address riskSteward, uint256 debounce) external
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| updateType | string | The type of update to configure (e.g., "supplyCap", "borrowCap") |
+| riskSteward | address | The address for the risk steward contract responsible for processing the update |
+| debounce | uint256 | The debounce period for updates of this type on the destination (anti‑DoS) |
+
+#### 📅 Events
+* Emits RiskParameterConfigUpdated
+
+#### ⛔️ Access Requirements
+* Controlled by AccessControlManager
+
+#### ❌ Errors
+* InvalidUpdateType if the update type string is empty
+* InvalidDebounce if the debounce is 0
+
+- - -
+
+### setConfigActive
+
+Sets the active status of a risk parameter config
+
+```solidity
+function setConfigActive(string updateType, bool active) external
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| updateType | string | The type of update to configure |
+| active | bool | The active status to set |
+
+#### 📅 Events
+* Emits ConfigActiveUpdated with the update type hash, update type, previous active status, and the active status
+
+#### ⛔️ Access Requirements
+* Controlled by AccessControlManager
+
+#### ❌ Errors
+* Throws UnsupportedUpdateType if the update type is not supported
+* Throws ConfigStatusUnchanged if the active status is already set to the desired value
+
+- - -
+
+### setRemoteDelay
+
+Sets the remote delay before bridged updates can be executed on the destination chain.
+
+```solidity
+function setRemoteDelay(uint256 newRemoteDelay) external
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| newRemoteDelay | uint256 | The new remote delay in seconds |
+
+#### 📅 Events
+* Emits RemoteDelaySet with the new remote delay value
+
+#### ⛔️ Access Requirements
+* Controlled by AccessControlManager
+
+#### ❌ Errors
+* InvalidRemoteDelay if the delay is 0 or greater than or equal to the remote update expiration time
+* RemoteDelayUnchanged if the new delay is equal to the current delay
+
+- - -
+
+### setWhitelistedExecutor
+
+Sets the whitelist status of an executor on the destination chain.
+
+```solidity
+function setWhitelistedExecutor(address executor, bool approved) external
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| executor | address | The address of the executor |
+| approved | bool | The whitelist status to set (true to whitelist, false to remove) |
+
+#### 📅 Events
+* Emits ExecutorStatusUpdated with the executor address, previous approval status, and new approval status
+
+#### ⛔️ Access Requirements
+* Controlled by AccessControlManager
+
+#### ❌ Errors
+* Throws ZeroAddressNotAllowed if the executor address is zero
+* Throws ExecutorStatusUnchanged if the executor whitelist status is already set to the desired value
+
+- - -
+
+### executeUpdate
+
+Executes a bridged update after its remote delay has passed.
+
+```solidity
+function executeUpdate(uint256 updateId) external
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| updateId | uint256 | The bridged update ID to execute |
+
+#### 📅 Events
+* Emits RemoteUpdateExecuted with the executed update ID
+
+#### ⛔️ Access Requirements
+* Only whitelisted executors can execute updates
+
+#### ❌ Errors
+* NotAnExecutor if the caller is not a whitelisted executor
+* ConfigNotActive if the configuration for the update type is not active
+* UpdateNotFound if the update is not pending for the given (updateType, market)
+* UpdateNotUnlocked if the remote delay has not elapsed
+* UpdateIsExpired if the bridged update has expired on the destination
+* UpdateTooFrequent if the debounce period has not passed since the last execution
+
+- - -
+
+### rejectUpdate
+
+Rejects a registered remote update on the destination chain.
+
+```solidity
+function rejectUpdate(uint256 updateId) external
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| updateId | uint256 | The oracle update ID of the update to reject |
+
+#### 📅 Events
+* Emits UpdateRejected with the rejected update ID
+
+#### ⛔️ Access Requirements
+* Only whitelisted executors can reject updates
+
+#### ❌ Errors
+* NotAnExecutor if the caller is not a whitelisted executor
+* UpdateNotFound if there is no pending update with the given ID
+
+- - -
+
+### getExecutableUpdates
+
+Returns executable updates for a given update type and comptroller.
+
+```solidity
+function getExecutableUpdates(string updateType, address comptroller) external view returns (uint256[] executableUpdates)
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| updateType | string | The human‑readable identifier of the update type to filter by |
+| comptroller | address | The address of the Isolated Pools Comptroller that manages the markets |
+
+#### Return Values
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| executableUpdates | uint256[] | Array of update IDs that are ready to be executed |
+
+- - -
+
+### getRiskParameterConfig
+
+Returns the risk parameter configuration for a given update type
+
+```solidity
+function getRiskParameterConfig(string updateType) external view returns (struct IDestinationStewardReceiver.RiskParamConfig)
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| updateType | string | The human-readable identifier of the update type |
+
+#### Return Values
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | struct IDestinationStewardReceiver.RiskParamConfig | The risk parameter configuration |
+
+- - -
+
+### getRegisteredUpdate
+
+Returns the registered update for a given update type and market
+
+```solidity
+function getRegisteredUpdate(string updateType, address market) external view returns (struct IDestinationStewardReceiver.DestinationUpdate)
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| updateType | string | The human-readable identifier of the update type |
+| market | address | The address of the market |
+
+#### Return Values
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | struct IDestinationStewardReceiver.DestinationUpdate | The registered update |
+
+- - -
+
+### getLastExecutedAt
+
+Returns the last executed timestamp for a given update type and market
+
+```solidity
+function getLastExecutedAt(string updateType, address market) external view returns (uint256)
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| updateType | string | The human-readable identifier of the update type |
+| market | address | The address of the market |
+
+#### Return Values
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | uint256 | The last executed timestamp |
+
+- - -
+
+### renounceOwnership
+
+Disables renounceOwnership function
+
+```solidity
+function renounceOwnership() public pure
+```
+
+#### ❌ Errors
+* Throws RenounceOwnershipNotAllowed
+
+- - -
+

--- a/technical-reference/reference-governance/irm-risk-steward.md
+++ b/technical-reference/reference-governance/irm-risk-steward.md
@@ -1,0 +1,129 @@
+# IRMRiskSteward
+Contract that can update interest rate models updates received from RiskStewardReceiver.
+
+# Solidity API
+
+### INTEREST_RATE_MODEL
+
+The update type for interest rate model
+
+```solidity
+string INTEREST_RATE_MODEL
+```
+
+- - -
+
+### INTEREST_RATE_MODEL_KEY
+
+The update type key for interest rate model (keccak256 hash of INTEREST_RATE_MODEL)
+
+```solidity
+bytes32 INTEREST_RATE_MODEL_KEY
+```
+
+- - -
+
+### CORE_POOL_COMPTROLLER
+
+Address of the BNB Core Pool Comptroller.
+
+```solidity
+contract ICorePoolComptroller CORE_POOL_COMPTROLLER
+```
+
+- - -
+
+### RISK_STEWARD_RECEIVER
+
+Address of the RiskStewardReceiver used to validate incoming updates
+
+```solidity
+contract IRiskStewardReceiver RISK_STEWARD_RECEIVER
+```
+
+- - -
+
+### constructor
+
+Sets the immutable CORE_POOL_COMPTROLLER and RISK_STEWARD_RECEIVER addresses and disables initializers
+
+```solidity
+constructor(address corePoolComptroller_, address riskStewardReceiver_) public
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| corePoolComptroller_ | address | The address of the Core Pool Comptroller |
+| riskStewardReceiver_ | address | The address of the RiskStewardReceiver |
+
+#### ❌ Errors
+* Throws ZeroAddressNotAllowed if any of the addresses are zero
+
+- - -
+
+### initialize
+
+Initializes the contract as ownable and access controlled.
+
+```solidity
+function initialize(address accessControlManager_) external
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| accessControlManager_ | address | The address of the access control manager |
+
+- - -
+
+### applyUpdate
+
+Applies an interest rate model update from the RiskStewardReceiver.
+Directly updates the market interest rate model on the vToken.
+
+```solidity
+function applyUpdate(struct RiskParameterUpdate update) external
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| update | struct RiskParameterUpdate | RiskParameterUpdate update to apply |
+
+#### 📅 Events
+* Emits InterestRateModelUpdated with the updateId, market and new IRM address
+
+#### ⛔️ Access Requirements
+* Only callable by the RiskStewardReceiver
+
+#### ❌ Errors
+* Throws OnlyRiskStewardReceiver if the sender is not the RiskStewardReceiver
+* Throws UnsupportedUpdateType if the update type is not supported
+
+- - -
+
+### isSafeForDirectExecution
+
+Checks if an update is safe for direct execution (no timelock required)
+
+```solidity
+function isSafeForDirectExecution(struct RiskParameterUpdate update) external view returns (bool)
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| update | struct RiskParameterUpdate | The update to check |
+
+#### Return Values
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | bool | True if update is safe for direct execution, false if timelock is required |
+
+#### ❌ Errors
+* Throws UnsupportedUpdateType if the update type is not supported
+* Throws RedundantValue if the new IRM address is equal to the current IRM address
+
+- - -
+

--- a/technical-reference/reference-governance/risk-oracle.md
+++ b/technical-reference/reference-governance/risk-oracle.md
@@ -1,0 +1,387 @@
+# Risk Oracle
+Contract for managing and publishing risk parameter updates for Risk-Steward Updates
+
+# Solidity API
+
+### updateCounter
+
+Counter to keep track of the total number of updates
+
+```solidity
+uint256 updateCounter
+```
+
+- - -
+
+### allUpdateTypes
+
+Array to store all update types
+
+```solidity
+string[] allUpdateTypes
+```
+
+- - -
+
+### activeUpdateTypes
+
+Whitelist of valid update type identifiers, keyed by updateType hash
+
+```solidity
+mapping(bytes32 => bool) activeUpdateTypes
+```
+
+- - -
+
+### updatesById
+
+Mapping from unique update ID to the update details
+
+```solidity
+mapping(uint256 => struct RiskParameterUpdate) updatesById
+```
+
+- - -
+
+### authorizedSenders
+
+Authorized accounts capable of proposing updates
+
+```solidity
+mapping(address => bool) authorizedSenders
+```
+
+- - -
+
+### latestUpdateIdByMarketAndType
+
+Mapping to store the latest update ID for each combination of update type key and market
+
+```solidity
+mapping(bytes32 => mapping(address => uint256)) latestUpdateIdByMarketAndType
+```
+
+- - -
+
+### constructor
+
+Disables initializers
+
+```solidity
+constructor() public
+```
+
+- - -
+
+### initialize
+
+Initializes the contract with access control manager
+
+```solidity
+function initialize(address accessControlManager_) external
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| accessControlManager_ | address | Address of the access control manager |
+
+#### ❌ Errors
+* Reverts with "invalid acess control manager address" if accessControlManager_ is zero address
+
+- - -
+
+### addAuthorizedSender
+
+Adds a new sender to the list of addresses authorized to perform updates
+
+```solidity
+function addAuthorizedSender(address sender) external
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| sender | address | Address to be authorized |
+
+#### 📅 Events
+* Emits AuthorizedSenderAdded when sender is successfully added
+
+#### ⛔️ Access Requirements
+* Controlled by AccessControlManager
+
+#### ❌ Errors
+* Throws ZeroAddressNotAllowed if sender is zero address
+* Throws SenderAlreadyAuthorized if sender is already authorized
+* Throws Unauthorized if caller is not allowed by AccessControlManager
+
+- - -
+
+### removeAuthorizedSender
+
+Removes an address from the list of authorized senders
+
+```solidity
+function removeAuthorizedSender(address sender) external
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| sender | address | Address to be unauthorized |
+
+#### 📅 Events
+* Emits AuthorizedSenderRemoved when sender is successfully removed
+
+#### ⛔️ Access Requirements
+* Controlled by AccessControlManager
+
+#### ❌ Errors
+* Throws SenderNotAuthorized if sender is not currently authorized
+* Throws Unauthorized if caller is not allowed by AccessControlManager
+
+- - -
+
+### addUpdateType
+
+Adds a new type of update to the list of authorized update types
+
+```solidity
+function addUpdateType(string newUpdateType) external
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| newUpdateType | string | New type of update to allow |
+
+#### 📅 Events
+* Emits UpdateTypeAdded when update type is successfully added
+
+#### ⛔️ Access Requirements
+* Controlled by AccessControlManager
+
+#### ❌ Errors
+* Throws InvalidUpdateTypeString if update type string is empty or exceeds 64 characters
+* Throws UpdateTypeAlreadyExists if update type already exists
+* Throws Unauthorized if caller is not allowed by AccessControlManager
+
+- - -
+
+### setUpdateTypeActive
+
+Sets the active status of an existing update type
+
+```solidity
+function setUpdateTypeActive(string updateType, bool active) external
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| updateType | string | The update type to set active status for |
+| active | bool | True to activate, false to deactivate |
+
+#### 📅 Events
+* Emits UpdateTypeActiveStatusChanged when status is successfully changed
+
+#### ⛔️ Access Requirements
+* Controlled by AccessControlManager
+
+#### ❌ Errors
+* Throws UpdateTypeNotFound if update type doesn't exist
+* Throws UpdateTypeStatusUnchanged if status is already set to the desired value
+* Throws Unauthorized if caller is not allowed by AccessControlManager
+
+- - -
+
+### publishRiskParameterUpdate
+
+Publishes a new risk parameter update
+
+```solidity
+function publishRiskParameterUpdate(string referenceId, bytes newValue, string updateType, address market, uint96 poolId, uint32 dstEid, bytes additionalData) external
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| referenceId | string | An external reference ID associated with the update |
+| newValue | bytes | The new value of the risk parameter being updated |
+| updateType | string | Type of update performed, must be previously authorized |
+| market | address | Address for market of the parameter update |
+| poolId | uint96 | Pool identifier for eMode-style collateral configuration (0 for regular markets) |
+| dstEid | uint32 | Destination endpoint ID for cross-chain routing |
+| additionalData | bytes | Additional data for the update |
+
+#### 📅 Events
+* Emits UpdatePublished when update is successfully published
+
+#### ❌ Errors
+* Throws SenderNotAuthorized if caller is not an authorized sender
+* Throws UpdateTypeNotActive if update type is not active
+* Throws ZeroAddressNotAllowed if market is zero address
+
+- - -
+
+### publishBulkRiskParameterUpdates
+
+Publishes multiple risk parameter updates in a single transaction
+
+```solidity
+function publishBulkRiskParameterUpdates(string[] referenceIds, bytes[] newValues, string[] updateTypes, address[] markets, uint96[] poolIds, uint32[] dstEid, bytes[] additionalData) external
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| referenceIds | string[] | Array of external reference IDs |
+| newValues | bytes[] | Array of new values for each update |
+| updateTypes | string[] | Array of types for each update, all must be authorized |
+| markets | address[] | Array of addresses for markets of the parameter updates |
+| poolIds | uint96[] | Array of pool identifiers for eMode-style collateral configuration (0 for regular markets) |
+| dstEid | uint32[] | Array of destination endpoint IDs for cross-chain routing |
+| additionalData | bytes[] | Array of additional data for the updates |
+
+#### 📅 Events
+* Emits UpdatePublished for each successfully published update
+
+#### ❌ Errors
+* Throws SenderNotAuthorized if caller is not an authorized sender
+* Throws ArrayLengthMismatch if the array lengths do not match or if no updates are provided
+* Throws UpdateTypeNotActive if any update type is not active
+* Throws ZeroAddressNotAllowed if any market is zero address
+
+- - -
+
+### getLatestUpdateByTypeAndMarket
+
+Fetches the most recent update for a specific parameter in a specific market
+
+```solidity
+function getLatestUpdateByTypeAndMarket(string updateType, address market) external view returns (struct RiskParameterUpdate)
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| updateType | string | The identifier for the parameter |
+| market | address | The market identifier |
+
+#### Return Values
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | struct RiskParameterUpdate | The most recent RiskParameterUpdate for the specified parameter and market |
+
+#### ❌ Errors
+* Throws NoUpdateFound if no update exists for the specified parameter and market
+
+- - -
+
+### getUpdateById
+
+Fetches the update for a provided updateId
+
+```solidity
+function getUpdateById(uint256 updateId) external view returns (struct RiskParameterUpdate)
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| updateId | uint256 | Update ID |
+
+#### Return Values
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | struct RiskParameterUpdate | The RiskParameterUpdate for the specified id |
+
+#### ❌ Errors
+* Throws InvalidUpdateId if updateId is 0 or greater than updateCounter
+
+- - -
+
+### allUpdateTypesLength
+
+Returns the total number of update types in the allUpdateTypes array
+
+```solidity
+function allUpdateTypesLength() external view returns (uint256)
+```
+
+#### Return Values
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | uint256 | The length of the allUpdateTypes array |
+
+- - -
+
+### getLatestUpdateIdByTypeAndMarket
+
+Gets the latest update ID for a specific market and update type (string) combination
+
+```solidity
+function getLatestUpdateIdByTypeAndMarket(string updateType, address market) external view returns (uint256)
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| updateType | string | The update type string |
+| market | address | The market address |
+
+#### Return Values
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | uint256 | The latest update ID for the given market and update type, or 0 if none exists |
+
+- - -
+
+### getActiveUpdateTypes
+
+Checks if a given update type is currently active.
+
+```solidity
+function getActiveUpdateTypes(string updateType) external view returns (bool)
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| updateType | string | The update type string to check |
+
+#### Return Values
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | bool | True if the update type is active, false otherwise |
+
+- - -
+
+### getAllUpdateTypes
+
+Returns all update types in the allUpdateTypes array
+
+```solidity
+function getAllUpdateTypes() external view returns (string[])
+```
+
+#### Return Values
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | string[] | An array of all update type strings |
+
+- - -
+
+### renounceOwnership
+
+Disables renounceOwnership function
+
+```solidity
+function renounceOwnership() public pure
+```
+
+#### ❌ Errors
+* Throws RenounceOwnershipNotAllowed
+
+- - -
+

--- a/technical-reference/reference-governance/risk-steward-receiver.md
+++ b/technical-reference/reference-governance/risk-steward-receiver.md
@@ -1,52 +1,12 @@
 # RiskStewardReceiver
-
-Contract that can read updates from the Chaos Labs Risk Oracle, validate them, and push them to the correct RiskSteward.
+Contract that reads updates from a Risk Oracle, validates them with timelock and debounce,
+        and either executes them locally via the configured RiskSteward or forwards them cross‑chain.
 
 # Solidity API
 
-### riskParameterConfigs
-
-Mapping of supported risk configurations and their validation parameters
-
-```solidity
-mapping(string => struct RiskParamConfig) riskParameterConfigs
-```
-
-- - -
-
-### RISK_ORACLE
-
-Whitelisted oracle address to receive updates from
-
-```solidity
-contract IRiskOracle RISK_ORACLE
-```
-
-- - -
-
-### lastProcessedTime
-
-Mapping of market and update type to last update timestamp. Used for debouncing updates.
-
-```solidity
-mapping(bytes => uint256) lastProcessedTime
-```
-
-- - -
-
-### processedUpdates
-
-Mapping of processed updates. Used to prevent re-execution
-
-```solidity
-mapping(uint256 => bool) processedUpdates
-```
-
-- - -
-
 ### UPDATE_EXPIRATION_TIME
 
-Time before a submitted update is considered stale
+Period after which a proposed update becomes expired and can no longer be applied
 
 ```solidity
 uint256 UPDATE_EXPIRATION_TIME
@@ -54,41 +14,157 @@ uint256 UPDATE_EXPIRATION_TIME
 
 - - -
 
-### initialize
+### LAYER_ZERO_EID
 
-Initializes the contract as ownable, pausable, and access controlled
+Source chain LayerZero endpoint ID
 
 ```solidity
-function initialize(address accessControlManager_) external
+uint32 LAYER_ZERO_EID
+```
+
+- - -
+
+### RISK_ORACLE
+
+The Risk Oracle contract address
+
+```solidity
+contract IRiskOracle RISK_ORACLE
+```
+
+- - -
+
+### paused
+
+Pause flag
+
+```solidity
+bool paused
+```
+
+- - -
+
+### riskParameterConfigs
+
+Mapping of supported risk configurations and their validation parameters (keyed by hashed updateType)
+
+```solidity
+mapping(bytes32 => struct IRiskStewardReceiver.RiskParamConfig) riskParameterConfigs
+```
+
+- - -
+
+### updates
+
+Master storage of all registered updates by update ID
+
+```solidity
+mapping(uint256 => struct IRiskStewardReceiver.RegisteredUpdate) updates
+```
+
+- - -
+
+### lastProcessedUpdate
+
+Track last processed update ID per (updateTypeKey, market)
+
+```solidity
+mapping(bytes32 => mapping(address => uint256)) lastProcessedUpdate
+```
+
+- - -
+
+### lastRegisteredUpdate
+
+Track the current registered update per (updateType, market) to avoid registering multiple updates
+
+```solidity
+mapping(bytes32 => mapping(address => uint256)) lastRegisteredUpdate
+```
+
+- - -
+
+### whitelistedExecutors
+
+Mapping from executor address to whitelist status
+
+```solidity
+mapping(address => bool) whitelistedExecutors
+```
+
+- - -
+
+### constructor
+
+Disables initializers and sets the Risk Oracle and LayerZero configuration.
+
+```solidity
+constructor(address riskOracle_, address endpoint_, uint32 layerZeroLzEid_) public
 ```
 
 #### Parameters
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| accessControlManager_ | address | The address of the access control manager |
+| riskOracle_ | address | The address of the Risk Oracle contract. |
+| endpoint_ | address | The LayerZero endpoint contract used by the underlying `OAppUpgradeable`. |
+| layerZeroLzEid_ | uint32 | The LayerZero endpoint ID (EID) for this chain. |
 
 - - -
 
-### pause
+### initialize
 
-Pauses processing of updates
+Initializes the contract with the Access Control Manager and OApp owner.
 
 ```solidity
-function pause() external
+function initialize(address acm_, address delegate_) external
 ```
 
-#### ⛔️ Access Requirements
-* Controlled by AccessControlManager
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| acm_ | address | The address of the Access Control Manager |
+| delegate_ | address | The address of the OApp owner passed to `__OApp_init`. |
 
 - - -
 
-### unpause
+### receive
 
-Unpauses processing of updates
+Accepts native tokens (e.g., BNB) sent to this contract.
 
 ```solidity
-function unpause() external
+receive() external payable
 ```
+
+- - -
+
+### sweepNative
+
+Allows the owner to sweep leftover native tokens (e.g., BNB) from the contract.
+
+```solidity
+function sweepNative() external
+```
+
+#### 📅 Events
+* Emits SweepNative event.
+
+- - -
+
+### setPaused
+
+Sets the pause status for `processUpdate`.
+
+```solidity
+function setPaused(bool paused_) external
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| paused_ | bool | True to pause, false to unpause |
+
+#### 📅 Events
+* Emits PauseStatusUpdated
 
 #### ⛔️ Access Requirements
 * Controlled by AccessControlManager
@@ -100,7 +176,7 @@ function unpause() external
 Sets the risk parameter config for a given update type
 
 ```solidity
-function setRiskParameterConfig(string updateType, address riskSteward, uint256 debounce) external
+function setRiskParameterConfig(string updateType, address riskSteward, uint256 debounce, uint256 timelock) external
 ```
 
 #### Parameters
@@ -109,94 +185,338 @@ function setRiskParameterConfig(string updateType, address riskSteward, uint256 
 | updateType | string | The type of update to configure |
 | riskSteward | address | The address for the risk steward contract responsible for processing the update |
 | debounce | uint256 | The debounce period for the update |
+| timelock | uint256 | The timelock period before the update can be executed |
 
 #### 📅 Events
-* Emits RiskParameterConfigSet with the update type, previous risk steward, new risk steward, previous debounce,
-* new debounce, previous active status, and new active status
+* Emits RiskParameterConfigUpdated
 
 #### ⛔️ Access Requirements
 * Controlled by AccessControlManager
 
 #### ❌ Errors
-* Throws UnsupportedUpdateType if the update type is an empty string
+* InvalidUpdateType if the update type string is empty
 * Throws InvalidDebounce if the debounce is 0
+* Throws InvalidTimelock if the timelock is greater than or equal to the expiration time
 * Throws ZeroAddressNotAllowed if the risk steward address is zero
 
 - - -
 
-### toggleConfigActive
+### setConfigActive
 
-Toggles the active status of a risk parameter config
+Sets the active status of a risk parameter config
 
 ```solidity
-function toggleConfigActive(string updateType) external
+function setConfigActive(string updateType, bool active) external
 ```
 
 #### Parameters
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| updateType | string | The type of update to toggle on or off |
+| updateType | string | The type of update to configure |
+| active | bool | The active status to set |
 
 #### 📅 Events
-* Emits ToggleConfigActive with the update type and the new active status
+* Emits ConfigActiveUpdated with the update type hash, update type, previous active status, and the active status
 
 #### ⛔️ Access Requirements
 * Controlled by AccessControlManager
 
 #### ❌ Errors
 * Throws UnsupportedUpdateType if the update type is not supported
+* Throws ConfigStatusUnchanged if the active status is already set to the desired value
 
 - - -
 
-### processUpdateById
+### setWhitelistedExecutor
 
-Processes an update by its ID. Will validate that the update configuration is active, is not expired, unprocessed, and that the debounce period has passed.
-Validated updates will be processed by the associated risk steward contract which will perform update specific validations and apply validated updates.
+Manages the whitelist of executors that are allowed to execute timelocked registered updates.
 
 ```solidity
-function processUpdateById(uint256 updateId) external
+function setWhitelistedExecutor(address executor, bool approved) external
 ```
 
 #### Parameters
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| updateId | uint256 | The ID of the update to process |
+| executor | address | The address of the executor |
+| approved | bool | The whitelist status to set (true to whitelist, false to remove) |
 
 #### 📅 Events
-* Emits RiskParameterUpdated with the update ID
+* Emits ExecutorStatusUpdated with the executor address, previous approval status, and approval status
+
+#### ⛔️ Access Requirements
+* Controlled by AccessControlManager
 
 #### ❌ Errors
-* Throws ConfigNotActive if the config is not active
-* Throws UpdateIsExpired if the update is expired
-* Throws ConfigAlreadyProcessed if the update has already been processed
-* Throws UpdateTooFrequent if the update is too frequent
+* Throws ZeroAddressNotAllowed if the executor address is zero
+* Throws ExecutorStatusUnchanged if the executor whitelist status is already set to the desired value
 
 - - -
 
-### processUpdateByParameterAndMarket
+### processUpdate
 
-Processes the latest update for a given parameter and market. Will validate that the update configuration is active, is not expired,
-unprocessed, and that the debounce period has passed.
-Validated updates will be processed by the associated risk steward contract which will perform update specific validations and apply validated updates.
+Processes an update from the Risk Oracle. Validates, registers the update,
+and either executes immediately, registers with timelock, or forwards cross-chain.
 
 ```solidity
-function processUpdateByParameterAndMarket(string updateType, address market) external
+function processUpdate(uint256 updateId) external
 ```
 
 #### Parameters
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| updateType | string | The type of update to process |
-| market | address | The market to process the update for |
+| updateId | uint256 | The update ID from the oracle's perspective |
 
 #### 📅 Events
-* Emits RiskParameterUpdated with the update ID
+* Emits UpdateRegistered, UpdateExecuted, or UpdateSentToDestination depending on the update type
 
 #### ❌ Errors
+* Throws UpdateAlreadyResolved if the update was already processed
+* Throws UpdateIsExpired if the update has expired
 * Throws ConfigNotActive if the config is not active
-* Throws UpdateIsExpired if the update is expired
-* Throws ConfigAlreadyProcessed if the update has already been processed
-* Throws UpdateTooFrequent if the update is too frequent
+* Throws UpdateTooFrequent if the debounce period has not passed
+* Throws RegisteredUpdateTypeExist if there is a non-expired pending update of the same type
+
+- - -
+
+### executeRegisteredUpdate
+
+Executes a registered update. Only whitelisted executors can call this function.
+        This function can be used for updates that have completed their timelock and are ready to execute.
+
+```solidity
+function executeRegisteredUpdate(uint256 updateId) external
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| updateId | uint256 | The oracle update ID of the update to execute |
+
+#### 📅 Events
+* Emits UpdateExecuted with the oracle update ID
+
+#### ⛔️ Access Requirements
+* Only whitelisted executors can call this function
+
+#### ❌ Errors
+* Throws NotAnExecutor if the caller is not a whitelisted executor
+* Throws InvalidRegisteredUpdate if the update was never registered
+* Throws UpdateAlreadyResolved if the update was already executed or rejected
+* Throws UpdateIsExpired if the update has expired
+* Throws ConfigNotActive if the config is not active
+* Throws UpdateNotUnlocked if the unlock time has not passed
+
+- - -
+
+### rejectUpdate
+
+Rejects a registered update
+
+```solidity
+function rejectUpdate(uint256 updateId) external
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| updateId | uint256 | The oracle update ID of the update to reject |
+
+#### 📅 Events
+* Emits UpdateRejected with the oracle update ID
+
+#### ⛔️ Access Requirements
+* Only whitelisted executors can call this function
+
+#### ❌ Errors
+* Throws UpdateAlreadyResolved if the update was already executed or rejected
+
+- - -
+
+### resendRemoteUpdate
+
+Resends a remote update to the destination chain. This function is useful in case of bridge failures.
+
+```solidity
+function resendRemoteUpdate(uint256 updateId, bytes options) external payable
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| updateId | uint256 | The oracle update ID to resend |
+| options | bytes | LayerZero message options; if empty, default executor option is used |
+
+#### 📅 Events
+* Emits UpdateResentToDestination with the update ID, destination chain ID, update type, and market
+
+#### ⛔️ Access Requirements
+* Only whitelisted executors can call this function
+
+#### ❌ Errors
+* Throws NotAnExecutor if the caller is not a whitelisted executor
+* Throws InvalidUpdateToResend if the update status is not SENT_TO_DESTINATION
+* Throws UpdateIsExpired if the update has expired
+
+- - -
+
+### getExecutableUpdates
+
+Returns an array of update IDs for executable registered updates for a given update type and comptroller.
+
+```solidity
+function getExecutableUpdates(string updateType, address comptroller) external view returns (uint256[] executableUpdates)
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| updateType | string | The human‑readable identifier of the update type to filter by |
+| comptroller | address | The address of the Comptroller (either Core Pool or Isolated Pools) that manages the markets |
+
+#### Return Values
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| executableUpdates | uint256[] | Array of update IDs that are ready to be executed |
+
+- - -
+
+### isUpdateExecutable
+
+Returns whether a registered update is ready to be executed.
+
+```solidity
+function isUpdateExecutable(uint256 updateId) external view returns (bool)
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| updateId | uint256 | The oracle update ID to query |
+
+#### Return Values
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | bool | True if the update is pending, not expired, active, and past its timelock |
+
+- - -
+
+### getRiskParameterConfig
+
+Returns the risk parameter configuration for a given update type
+
+```solidity
+function getRiskParameterConfig(string updateType) external view returns (struct IRiskStewardReceiver.RiskParamConfig)
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| updateType | string | The human-readable identifier of the update type |
+
+#### Return Values
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | struct IRiskStewardReceiver.RiskParamConfig | The risk parameter configuration |
+
+- - -
+
+### getLastProcessedUpdate
+
+Returns the last processed update ID for a given update type and market
+
+```solidity
+function getLastProcessedUpdate(string updateType, address market) external view returns (uint256)
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| updateType | string | The human-readable identifier of the update type |
+| market | address | The address of the market |
+
+#### Return Values
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | uint256 | The last processed update ID |
+
+- - -
+
+### getLastRegisteredUpdate
+
+Returns the last registered update ID for a given update type and market
+
+```solidity
+function getLastRegisteredUpdate(string updateType, address market) external view returns (uint256)
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| updateType | string | The human-readable identifier of the update type |
+| market | address | The address of the market |
+
+#### Return Values
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | uint256 | The last registered update ID |
+
+- - -
+
+### quote
+
+Quotes the gas fee needed to pay for the full omnichain transaction in native gas or ZRO token.
+
+```solidity
+function quote(struct RiskParameterUpdate update, bytes options, bool payInLzToken) public view returns (struct MessagingFee fee)
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| update | struct RiskParameterUpdate | The risk parameter update payload to be sent |
+| options | bytes | Message execution options (e.g., for sending gas to the destination) |
+| payInLzToken | bool | Whether to return the fee in ZRO token instead of native gas |
+
+#### Return Values
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| fee | struct MessagingFee | A `MessagingFee` struct containing the calculated gas fee |
+
+- - -
+
+### lzSend
+
+Sends a `RiskParameterUpdate` to a destination chain via LayerZero.
+
+```solidity
+function lzSend(uint32 dstEid, struct RiskParameterUpdate update, bytes options, struct MessagingFee fee, address refundAddress) public payable
+```
+
+#### Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| dstEid | uint32 | Destination chain endpoint ID |
+| update | struct RiskParameterUpdate | The risk parameter update payload to send |
+| options | bytes | LayerZero message options; if empty, a default executor option is used |
+| fee | struct MessagingFee | Messaging fee structure returned by `quote` |
+| refundAddress | address | Address to receive any surplus fee refunds |
+
+#### ❌ Errors
+* InvalidLzSendCaller if called by any address other than this contract
+
+- - -
+
+### renounceOwnership
+
+Disables renounceOwnership function
+
+```solidity
+function renounceOwnership() public pure
+```
+
+#### ❌ Errors
+* Throws RenounceOwnershipNotAllowed
 
 - - -
 

--- a/technical-reference/reference-technical-articles/risk-stewards.md
+++ b/technical-reference/reference-technical-articles/risk-stewards.md
@@ -1,240 +1,97 @@
 # Risk Stewards
 
-## Overview
+The Risk Stewards system is a permissioned, automated pipeline for applying a bounded set of risk-parameter changes to Venus markets without a manual governance proposal for each one. Whitelisted risk providers publish recommendations to a Venus-owned on-chain oracle; the protocol validates each one, applies small changes immediately, holds larger ones behind a timelock, and bridges changes destined for other chains over LayerZero. Governance keeps control of everything that matters: who may publish, who may execute held updates, the bounds, and an emergency pause.
 
-The Risk Stewards system introduces a secure and modular mechanism for automatically updating borrow and supply caps in the Venus Protocol. In the earlier model, these risk parameters were modified manually via governance proposals (VIPs). This new architecture eliminates manual intervention by enabling fully on-chain, automated updates.
+It currently supports four update types: `supplyCap`, `borrowCap`, `collateralFactors` (collateral factor and liquidation threshold, set together), and `interestRateModel`. Anything outside this set still requires a full VIP.
 
-In this updated model, **Chaos Labs provides risk parameter updates through their on-chain Risk Oracle**. These updates are delivered directly to dedicated steward contracts, such as `MarketCapsRiskSteward`, which are responsible for applying the changes to the protocol.
+This article describes the contracts and the update lifecycle. For function-level signatures, structs, events, and errors, see the reference page linked under each contract.
 
-All updates are executed through a central router contract, `RiskStewardReceiver`, which ensures:
+## Architecture
 
-- Only pre-approved steward contracts are allowed to execute logic
-- Updates adhere to protocol-defined rules such as:
-  - Debounce periods between consecutive updates
-  - Maximum allowable percentage change in parameters
-  - Access control enforced through Venus’s `AccessControlManager`
+<figure><img src="../../.gitbook/assets/risk-stewards-architecture.svg" alt="Risk Stewards architecture: providers publish to the Risk Oracle on BNB Chain; the RiskStewardReceiver routes updates to local stewards or forwards them over LayerZero to a Destination Steward Receiver on remote chains; governance configures the whole system"><figcaption><p>Providers publish to the Risk Oracle on BNB Chain; the RiskStewardReceiver applies updates locally or bridges them to a Destination Steward Receiver on remote chains. Governance configures and gates the whole pipeline.</p></figcaption></figure>
 
-This architecture enables faster response to market dynamics while maintaining the safety and integrity of the protocol’s core risk parameters.
+BNB Chain is the **source chain**: it hosts the oracle and the source-chain receiver. Every update is published there, even ones destined for another chain. Each supported chain (including BNB Chain itself) hosts the steward contracts that perform the actual change, plus a destination receiver on non-source chains.
 
----
+**[Risk Oracle](../reference-governance/risk-oracle.md)** is the single source of truth for recommendations. A whitelisted provider calls `publishRiskParameterUpdate(referenceId, newValue, updateType, market, poolId, dstEid, additionalData)`; the oracle assigns a monotonic `updateId`, records the previous value for history, and emits `UpdatePublished`. Senders are added and removed only by governance (`addAuthorizedSender` / `removeAuthorizedSender`), as are the supported update-type strings (`addUpdateType`, `setUpdateTypeActive`). The oracle only stores recommendations; it never touches the protocol itself.
 
-## Contracts and Responsibilities
+**[RiskStewardReceiver](../reference-governance/risk-steward-receiver.md) (RSR)** on BNB Chain is where updates are processed. `processUpdate(updateId)` is permissionless: anyone can push a published update through the pipeline. The RSR holds a per-type config (`riskParameterConfigs`) mapping each update type to its steward, a `debounce` period, and a `timelock`, all set by governance. It validates the update, decides the execution path, and either applies it locally, registers it behind a timelock, or forwards it cross-chain.
 
-### 1. `RiskStewardReceiver.sol`
+**[DestinationStewardReceiver](../reference-governance/destination-steward-receiver.md) (DSR)** lives on each non-source chain. It receives bridged updates over LayerZero, registers them with status `Pending`, and holds them for a fixed `remoteDelay` (6 hours by default) before a whitelisted executor applies them.
 
-### Purpose
+**Risk Stewards** do the actual writing. All three inherit **[BaseRiskSteward](../reference-governance/base-risk-steward.md)**, which holds the `safeDeltaBps` bound and enforces that `applyUpdate` may only be called by the steward's receiver (`OnlyRiskStewardReceiver`). Each steward owns one parameter family:
 
-The `RiskStewardReceiver` contract acts as the **central entry point for processing on-chain risk parameter updates** in the Venus Protocol. It integrates directly with the **Chaos Labs Risk Oracle**, pulling risk recommendations (like borrow/supply caps) and forwarding them to the appropriate **RiskSteward** contract (e.g., `MarketCapsRiskSteward`) for enforcement.
+| Steward | Update type(s) | Encoded `newValue` | Writes via |
+| --- | --- | --- | --- |
+| [MarketCapsRiskSteward](../reference-governance/market-caps-risk-steward.md) | `supplyCap`, `borrowCap` | one `uint256` | `setMarketSupplyCaps` / `setMarketBorrowCaps` |
+| [CollateralFactorsRiskSteward](../reference-governance/collateral-factors-risk-steward.md) | `collateralFactors` | two `uint256` (CF, LT) | `setCollateralFactor` |
+| [IRMRiskSteward](../reference-governance/irm-risk-steward.md) | `interestRateModel` | one `address` | `_setInterestRateModel` (core) / `setInterestRateModel` (isolated) |
 
-Its key role is to:
-- **Validate**, **deduplicate**, and **throttle** risk updates,
-- And **delegate the actual update execution** to the appropriate steward contract responsible for enforcing specific risk parameter types.
+## Update types and encoding
 
-This contract enables a **modular and secure pipeline** for processing real-time risk recommendations on-chain.
+Each update carries its new value as opaque ABI-encoded `bytes`. Passing it this way is deliberate: one `newValue` field (and so a single `publishRiskParameterUpdate` entry point and one update struct) can express payloads of completely different shapes. A market cap is a single number, collateral factors are a pair (the factor and its liquidation threshold), and an interest rate model is an address; each steward decodes the bytes into the shape it expects and rejects anything of the wrong length. New parameter types can therefore be added later without changing the oracle or receiver interfaces.
 
----
+The encoding per type (type strings are case-sensitive):
 
-### Key Responsibilities
-
-- **Oracle Integration**:  
-  Directly reads data from the `IRiskOracle`, which provides structured `RiskParameterUpdate` records.
-
-- **Per-Type Configuration**:  
-  Maintains a `riskParameterConfigs` mapping to register:
-  - Which `updateType` is supported,
-  - Which steward contract should handle it,
-  - What debounce period (minimum time between updates) is enforced.
-
-- **Validation Checks Before Processing**:  
-  Before an update is executed, the contract validates that:
-  - The update type is **active** (`ConfigNotActive`)
-  - The update is **not expired** (`UpdateIsExpired`)
-  - The update has **not already been processed** (`ConfigAlreadyProcessed`)
-  - The **debounce period** since the last update has passed (`UpdateTooFrequent`)
-
-- **Processing Updates**:
-  Provides two ways to trigger an update:
-  1. `processUpdateById(updateId)`
-  2. `processUpdateByParameterAndMarket(updateType, market)`
-  
-  Both functions:
-  - Fetch the update from the risk oracle
-  - Validate its status
-  - Delegate the update execution to the configured `IRiskSteward` contract
-
-- **State Tracking**:
-  - `lastProcessedTime`: Tracks last update per `(market + updateType)` to enforce debounce period
-  - `processedUpdates`: Marks updates that have already been processed, preventing replay
-
-- **Governance and Controls**:
-  - Uses `AccessControlledV8` to restrict who can:
-    - Set or modify risk configs
-    - Pause or unpause the contract
-  - Can be paused to halt all update processing using OpenZeppelin’s `PausableUpgradeable`
-
----
-
-### 2. `MarketCapsRiskSteward.sol`
-
-The `MarketCapsRiskSteward` contract is responsible for **processing supply cap and borrow cap updates** for Venus markets. These updates originate from the `RiskStewardReceiver`, which itself receives on-chain recommendations from the Chaos Labs Risk Oracle.
-
-This contract **does not fetch or validate updates directly**. Instead, it:
-- **Receives validated updates** delegated by the `RiskStewardReceiver`
-- **Performs delta checks** to ensure caps are within allowed bounds
-- **Writes new cap values** into the correct pool comptroller (either Core or Isolated)
-- Emits events for transparency and downstream indexing
-
----
-
-### Key Responsibilities
-
-- **Parameter Enforcement**  
-  Applies updates only for:
-  - `supplyCap`
-  - `borrowCap`
-
-- **Source Validation**  
-  Ensures updates can only be executed by the trusted `RiskStewardReceiver`.  
-  → Any direct call from an external or malicious contract is rejected (`OnlyRiskStewardReceiver`).
-
-- **Delta Bounding**  
-  Before updating any cap, the new value is validated against the previous cap. The change is only allowed if it’s within the `maxDeltaBps` (basis points) threshold.  
-  → Ensures the system remains stable and avoids drastic risk shifts (`UpdateNotInRange`).
-
-- **Governance Access**  
-  `AccessControlledV8` is used to restrict who can:
-  - Set the `maxDeltaBps`
-  - Initialize the contract
-
----
-
-## End-to-End Flow: Market Cap Update via Risk Stewards 
-
-This example walks through a complete end-to-end flow where **Chaos Labs** updates a **borrow cap** for a market using the on-chain risk oracle, and the change is processed securely through the steward contracts.
-
-### Roles
-
-| Role | Description |
-|------|-------------|
-| Chaos Labs | Publishes risk parameter updates on-chain via a Risk Oracle |
-| Keeper Bot | External off-chain agent responsible for calling the RiskStewardReceiver to apply updates |
-| RiskStewardReceiver | Central processor that validates updates and routes them to the correct steward |
-| MarketCapsRiskSteward | Applies validated supply/borrow cap updates to the appropriate pool comptroller |
-
----
-
-### Example Scenario
-
-Chaos Labs recommends updating the **borrow cap** for the USDC market (`vUSDC`) from **5,000,000** to **6,000,000** tokens.
-
----
-
-### Step-by-Step Execution
-
-#### 1. **Chaos Labs Publishes an Update On-Chain**
-
-Chaos Labs publishes the following to the on-chain **Risk Oracle** contract:
-
-```json
-{
-  "updateId": 101,
-  "market": "0x...vUSDC",
-  "updateType": "borrowCap",
-  "newValue": 6000000,
-  "timestamp": 1721036000,
-  "additionalData": "<encoded underlyingAddress/chainId>"
-}
+```text
+supplyCap / borrowCap   abi.encode(uint256)            // 18-decimal amount
+collateralFactors       abi.encode(uint256, uint256)   // collateral factor, liquidation threshold (both required)
+interestRateModel       abi.encode(address)            // new IRM contract
 ```
 
-This update is stored in the oracle contract and made available via `getUpdateById(updateId)`.
+`poolId` selects the pool: `0` for core-pool and isolated-pool markets, and a non-zero group id for an eMode pool inside the core pool. `dstEid` is `0` (or the source chain's own endpoint id) for a local BNB Chain update, or a LayerZero endpoint id for a remote chain.
 
----
+## Validation and routing
 
-#### 2. **Keeper Bot Detects the Update and Calls `processUpdateById`**
+`processUpdate` is permissionless, and that is safe by design: every safety property lives in the validation below and in the steward bounds, not in gating who may call it; the caller only supplies the gas. Before acting, the RSR validates the update:
 
-A **Keeper Bot** regularly polls the Risk Oracle and calls:
+* the update type's config is **active**;
+* it is the **latest** published update for that market and type: a newer recommendation supersedes an older one, which then reverts as `UpdateIsExpired`, so a provider corrects a mistake simply by publishing again;
+* it has **not expired** (updates are valid for `UPDATE_EXPIRATION_TIME`, 2 days, from publication) and has **not already been resolved** (executed, rejected, or expired);
+* registering it behind a timelock would not push the unlock time past that 2-day expiry (`UpdateWillExpireBeforeUnlock`), so the system never parks an update that could never be executed in time; and
+* for local updates, the **debounce** window since the last applied change for that `(market, updateType)` has passed, and no other non-expired pending update of the same type is already registered.
 
-```solidity
-riskStewardReceiver.processUpdateById(101);
-```
+Debounce and timelock are different levers: **debounce** rate-limits how often a given market/type can change at all; **timelock** delays an individual large change so it can be reviewed. A change can clear debounce yet still be timelocked. Once validated, the RSR asks the steward whether the change is safe for immediate execution and routes it down one of three paths: local-immediate, local-timelocked, or cross-chain.
 
----
+## Local execution: immediate vs. timelocked
 
-#### 3. **RiskStewardReceiver Validates the Update**
+<figure><img src="../../.gitbook/assets/risk-stewards-local-flow.svg" alt="Local update flow on BNB Chain: provider publishes to the Risk Oracle, anyone calls processUpdate on the RiskStewardReceiver, which either applies the change immediately when it is within the safe delta or registers it behind a timelock for an executor to apply"><figcaption><p>A local (BNB Chain) update. Within the safe delta it applies immediately; otherwise it is registered behind a timelock and applied later by a whitelisted executor.</p></figcaption></figure>
 
-Upon receiving the call, `RiskStewardReceiver` performs **strict validations**:
+The split is decided by the steward's `isSafeForDirectExecution`, which compares the new value against the live on-chain value using `safeDeltaBps`:
 
-- ✅ Checks that the update is the **latest** from the oracle for the given market and type  
-- ✅ Validates the update is **active** in config (`ConfigNotActive`)  
-- ✅ Verifies it is **not expired** (timestamp + 1 day > now) (`UpdateIsExpired`)  
-- ✅ Ensures it is **not already processed** (`ConfigAlreadyProcessed`)  
-- ✅ Ensures **debounce interval** has passed for the `(market + updateType)` pair (`UpdateTooFrequent`)
+* **Market caps** execute immediately when the change is within `±safeDeltaBps` of the current cap, but only if the current cap is non-zero. Setting a cap from zero always takes the timelock, because there is no baseline to bound the change against.
+* **Collateral factors** execute immediately only when *both* the collateral factor and the liquidation threshold move within `safeDeltaBps`, and neither current value is zero. **eMode** updates (`poolId != 0`) always take the timelock; eMode runs at higher leverage, so its collateral changes are never auto-applied.
+* **Interest rate model** changes *always* take the timelock: an IRM is a contract address, so there is no meaningful "small change" to bound.
 
-If any check fails, the transaction reverts with the corresponding error.
+A redundant update (new value equal to the current one) reverts with `RedundantValue`.
 
----
+The bound is symmetric and per-steward. `safeDeltaBps` is applied to the absolute difference (`|new − current| ≤ safeDeltaBps × current`), so a 50% bound permits a move of up to ±50% in either direction. Each steward holds its own bound, set independently by governance: at launch the Market Caps steward uses 50% and the Collateral Factors steward 10%; collateral factors and liquidation thresholds bear directly on account solvency, so they are allowed a far smaller automatic move than caps.
 
-#### 4. **Update is Routed to MarketCapsRiskSteward**
+When the change is safe, the RSR applies it in the same `processUpdate` transaction. Otherwise it registers the update with `unlockTime = now + timelock` and status `Pending`; after the timelock a **whitelisted executor** calls `executeRegisteredUpdate(updateId)` to apply it, or `rejectUpdate(updateId)` to discard it. A registered update that is neither executed nor rejected within the 2-day window expires.
 
-Once the update passes all validations, the RiskStewardReceiver uses the updateType to determine which RiskSteward contract should handle it, and delegates the update to MarketCapsRiskSteward:
+## Cross-chain execution
 
-```solidity
-        IRiskSteward(riskParameterConfigs[update.updateType].riskSteward).processUpdate(update);
-```
+<figure><img src="../../.gitbook/assets/risk-stewards-remote-flow.svg" alt="Remote update flow: provider publishes on BNB Chain, the RiskStewardReceiver forwards the update over LayerZero to the Destination Steward Receiver on the target chain, which holds it for the remote delay before a whitelisted executor applies it through the local steward"><figcaption><p>A remote update is forwarded over LayerZero, registered on the destination chain, held for the remote delay, then applied by a whitelisted executor through the destination-chain steward.</p></figcaption></figure>
 
-Here, the steward performs:
+When `dstEid` points at another chain, the RSR never executes locally. It registers the update and forwards it over LayerZero with `lzSend`; the local status becomes `SENT_TO_DESTINATION`. If a bridge message fails to deliver, a whitelisted executor can re-send it with `resendRemoteUpdate`.
 
-- ✅ Validates that the `msg.sender` is `RiskStewardReceiver` (`OnlyRiskStewardReceiver`)
-- ✅ Confirms that `updateType` is either `supplyCap` or `borrowCap` (`UnsupportedUpdateType`)
-- ✅ Retrieves the current cap from the comptroller and validates that the new cap change is within the allowed delta range defined by `maxDeltaBps`:
-- ✅ Writes the new cap into the pool comptroller:
-- ✅ Emits `BorrowCapUpdated(market, newCap)` for downstream indexing
-- ✅ Applies the update to the pool’s comptroller, by directly making a call to the appropriate setter function: 
-`comptroller.setMarketSupplyCaps(newSupplyCapMarkets, newSupplyCaps)`
+On the destination chain the DSR receives the message (`_lzReceive`), registers it as `Pending`, and stamps its arrival time. A whitelisted executor on that chain calls `executeUpdate(updateId)` once `remoteDelay` has elapsed and before the 2-day expiry, or `rejectUpdate(updateId)` to discard it. The write is performed by the same kind of steward as on the source chain. Remote updates therefore always pass through a delay and an executor; there is no immediate cross-chain path.
 
----
+Two design choices make this robust. First, the delay clock lives on the destination, not the source: the RSR is a LayerZero OApp sender and the DSR a receiver, and because bridge latency is unpredictable the DSR measures `remoteDelay` from the message's *arrival* time. Its config carries no timelock field at all (only a steward, a debounce, and the chain-wide `remoteDelay`), so locally the forwarded update is recorded with an immediate unlock and status `SENT_TO_DESTINATION` purely as bookkeeping, while the real wait plays out on the destination. Second, the RSR pays the LayerZero messaging fee from its own native balance (funded through its `receive()` and recoverable by governance with `sweepNative`), so the `processUpdate` caller never pre-pays the bridge, and a message that fails to deliver can be re-sent with `resendRemoteUpdate` rather than re-published.
 
-#### 5. **Update State is Committed**
+## Roles and governance
 
-Once the steward call completes:
+| Role | Capability | Granted by |
+| --- | --- | --- |
+| Risk parameter providers | Publish recommendations; may also call `processUpdate` for their own | Governance (ACM) |
+| Anyone | Call `processUpdate` | Permissionless |
+| Whitelisted executors | Execute / reject timelocked and remote updates; resend failed bridges | Governance (ACM) |
+| Governance / ACM | Whitelist providers & executors; set debounce, timelock, `safeDeltaBps`, `remoteDelay`; register update types; pause the RSR | DAO (VIP) |
 
-- The update ID is marked as **processed**
-- The `(market + updateType)` debounce timer is updated with the current block time
-- `RiskParameterUpdated(updateId)` is emitted
+The framework never bypasses governance. Stewards can only touch the four supported parameters, and only within governance-set bounds; larger, IRM, and eMode changes are delayed and vetoable; updates expire and cannot be replayed; and governance can pause processing or remove a provider at any time. The framework was enabled on BNB Chain in [VIP-592](https://app.venus.io/#/governance/proposal/592?chainId=56), which onboarded Allez Labs as the first external risk provider; at launch governance set a 3-day debounce, a 6-hour timelock, a 50% safe delta for market caps, and a 10% safe delta for collateral factors.
 
----
+## Further reading
 
-### Failure Scenarios
-
-| Scenario | Failure Trigger | Result |
-|----------|-----------------|--------|
-| Keeper calls too late (e.g. after 24h) | `UpdateIsExpired` | Revert |
-| Keeper tries again for same ID | `ConfigAlreadyProcessed` | Revert |
-| Another update was already applied for the same market+type | `UpdateIsExpired` | Revert |
-| Debounce timer has not passed | `UpdateTooFrequent` | Revert |
-| Chaos Labs sets too large a delta | `UpdateNotInRange` | Revert |
-| Cap type is misspelled | `UnsupportedUpdateType` | Revert |
-| Non-receiver tries to call steward | `OnlyRiskStewardReceiver` | Revert |
-
----
-
-<figure><img src="../../.gitbook/assets/riskStewards.svg" alt="Risk Stewards"><figcaption>Risk Stewards</figcaption></figure>
-
-## Limitations
-
-While the Risk Steward system enables secure and automated updates to certain risk parameters, there are important limitations to keep in mind:
-
-### 1. Bypasses On-Chain Governance
-
-This architecture allows updates (e.g., supply and borrow caps) to be applied automatically, without going through the formal governance process.
-
-- Critical parameters such as collateral factors, liquidation thresholds, and reserve factors are intentionally excluded.
-- These parameters are considered sensitive and must be proposed and approved through governance (via Venus Improvement Proposals or VIPs) to ensure proper transparency and community review.
-
-### 2. No Cross-Chain Initiation Support
-
-The current design supports only same-chain update processing.
-
-- Updates on a specific chain can only be processed if a Risk Oracle is deployed and supported on that chain..
-- For operational efficiency and monitoring, it would be beneficial to register or reflect these updates on BNB Chain, where monitoring systems and automation (such as keeper bots) are primarily active.
-
+* [Risk Oracle & Risk Stewards (overview)](../../risk/risk-oracle-and-risk-stewards.md)
+* Contract references: [Risk Oracle](../reference-governance/risk-oracle.md) · [RiskStewardReceiver](../reference-governance/risk-steward-receiver.md) · [DestinationStewardReceiver](../reference-governance/destination-steward-receiver.md) · [BaseRiskSteward](../reference-governance/base-risk-steward.md) · [MarketCapsRiskSteward](../reference-governance/market-caps-risk-steward.md) · [CollateralFactorsRiskSteward](../reference-governance/collateral-factors-risk-steward.md) · [IRMRiskSteward](../reference-governance/irm-risk-steward.md)
+* [VIP-592: Risk Stewards Framework Implementation](https://app.venus.io/#/governance/proposal/592?chainId=56)
+* [Repository](https://github.com/VenusProtocol/governance-contracts)


### PR DESCRIPTION
## Overview

Updates the documentation for the **Risk Stewards** framework to reflect the V2 implementation now live on BNB Chain (VIP-592). The previous docs described the V1 design and attributed the Risk Oracle to Chaos Labs; V2 introduces Venus's own Risk Oracle, three steward types, and cross-chain execution.

## What changed

**Narrative docs (rewritten for V2)**
- `risk/risk-oracle-and-risk-stewards.md` — overview: Venus-owned Risk Oracle; whitelisted risk providers (Chaos Labs, Allez Labs, or the Venus risk team); four automated parameter types (supply cap, borrow cap, collateral factors, interest rate model); the safe-delta vs. timelock/cooldown model; whitelisted executors; and what stays under full governance.
- `technical-reference/reference-technical-articles/risk-stewards.md` — technical article: contract-by-contract architecture, update encoding, validation/routing, immediate vs. timelocked execution, and cross-chain flow via LayerZero (RiskStewardReceiver → DestinationStewardReceiver), with design rationale.

**Reference pages (generated via `hardhat docgen`)**
- New: RiskOracle, DestinationStewardReceiver, BaseRiskSteward, CollateralFactorsRiskSteward, IRMRiskSteward.
- Regenerated for V2: RiskStewardReceiver, MarketCapsRiskSteward.
- Wired into `SUMMARY.md`.

**Diagrams** (new, Venus dark theme; reused in both narrative docs)
- System architecture, BNB-chain (local) update flow, and remote (cross-chain) update flow.

**Security & audits**
- Added a "Risk Stewards V2" audit section (Quantstamp 2025/12/15, Certik 2025/12/29); the V1 entry is unchanged.


