### PR TITLE
docs: reflect VIP-645 Critical Timelock permission revocation

### DIFF
--- a/governance/decentralization.md
+++ b/governance/decentralization.md
@@ -18,7 +18,11 @@ Venus Governance has now categorized VIPs into three types: Normal, Fast-track, 
 
 * **Normal VIPs** encompass significant updates like contract upgrades or changes in access controls.
 * **Fast-track VIPs** deal with risk parameter adjustments such as interest rates or collateral factors.
-* **Critical VIPs** are utilized during emergencies demanding an immediate reaction.
+* **Critical VIPs** were utilized during emergencies demanding an immediate reaction.
+
+{% hint style="info" %}
+Since [VIP-645](https://app.venus.io/#/governance/proposal/645?chainId=56), the Critical Timelock holds no permission on any network, so the Critical route can no longer execute privileged actions. Emergency responses rely on the fine-grained pause mechanism (see below) and Fast-track VIPs.
+{% endhint %}
 
 Each VIP type has its unique proposal threshold, timelock, and voting periods, reflecting the potential risk and impact of the proposed changes.
 
@@ -30,7 +34,7 @@ The initial voting and delay periods for these types are as follows:
 
 **Role-based Access Control**
 
-Venus V4 employs a separate Access Control Manager contract that validates access permissions rather than merely verifying the caller as an "admin". This allows certain actions to bypass voting, enabling them to take the fast-track or critical route, or even to be executed directly through a multisig by guardians. It can be particularly useful for implementing borrowing and supply caps, pausing specific market actions, or responding to rapid market fluctuations.
+Venus V4 employs a separate Access Control Manager contract that validates access permissions rather than merely verifying the caller as an "admin". This allows certain actions to bypass voting, enabling them to take the fast-track route, or even to be executed directly through a multisig by guardians. It can be particularly useful for implementing borrowing and supply caps, pausing specific market actions, or responding to rapid market fluctuations.
 
 **Fine-grained Pause**
 

--- a/guides/governance-guide/delegating.md
+++ b/guides/governance-guide/delegating.md
@@ -12,7 +12,7 @@ Venus DAO is an autonomous and decentralized organization that functions via sma
 
 **3/ Voting:** Following a proposal's creation, token holders can vote on it. Venus DAO manages the voting process, queuing and voting on protocol updates within 48-hour timelocks. The voting method could entail a simple majority vote, a supermajority, or weighted voting based on each participant's token count, as is the case with Venus Protocol.
 
-**4/ Voting Period:** Venus DAO recognizes three Venus Improvement Proposals (VIP) roles: Normal, Fast Track, and Critical. Each VIP role has a unique proposal threshold, timelock, and voting period, which can be configured by Governance. This duration allows token holders ample time to review, discuss, and cast their votes. The votes are tallied once the voting period concludes.
+**4/ Voting Period:** Venus DAO recognizes three Venus Improvement Proposals (VIP) roles: Normal, Fast Track, and Critical. Each VIP role has a unique proposal threshold, timelock, and voting period, which can be configured by Governance. Note that since [VIP-645](https://app.venus.io/#/governance/proposal/645?chainId=56) the Critical Timelock holds no permission, so in practice proposals use the Normal or Fast Track roles. This duration allows token holders ample time to review, discuss, and cast their votes. The votes are tallied once the voting period concludes.
 
 **5/ Execution:** After a proposal garners support and votes, all Venus DAO members can execute the VIP directly in the Venus dapp through smart contracts.
 

--- a/technical-reference/reference-technical-articles/omnichain-governance.md
+++ b/technical-reference/reference-technical-articles/omnichain-governance.md
@@ -90,7 +90,7 @@ It's crucial to understand that the proposal ID for the remote execution on the 
 
 * `OmnichainProposalSender` (BNB Chain):
   * Owned by: NormalTimelock contract on the BNB Chain.
-  * Authorized callers: Timelocks (Normal, Critical, Fast-track) are authorized to call the `execute` function on this contract.
+  * Authorized callers: the Normal and Fast-track Timelocks are authorized to call the `execute` function on this contract. The Critical Timelock was also authorized originally, but every permission it held was revoked in [VIP-645](https://app.venus.io/#/governance/proposal/645?chainId=56).
 * `OmnichainGovernanceExecutor` (destination network):
   * Owned by: `OmnichainExecutorOwner` contract. This owner performs Access Control Manager (ACM) checks before allowing any function calls on this contract.
 * `TimelockV8`:


### PR DESCRIPTION
## Summary

[VIP-645](https://app.venus.io/#/governance/proposal/645?chainId=56) (executed) revoked every permission the Critical Timelock held across all eight Venus mainnets. Several governance pages still described the Critical route as an active emergency path — this PR updates them:

- **governance/decentralization.md** — Critical VIPs description moved to past tense, added an info hint explaining that since VIP-645 the Critical Timelock holds no permission and emergency responses rely on the fine-grained pause mechanism and Fast-track VIPs; dropped "critical" from the ACM routes sentence.
- **technical-reference/reference-technical-articles/omnichain-governance.md** — `OmnichainProposalSender` authorized callers corrected to Normal and Fast-track Timelocks only. Verified on-chain: ACM `hasRole(keccak(sender ++ "execute(uint16,bytes,bytes,address)"))` returns true for Normal/Fast-track, false for Critical.
- **guides/governance-guide/delegating.md** — noted that in practice proposals use the Normal or Fast Track roles.

No address changes: the Critical Timelock contracts remain deployed, so `deployed-contracts/governance.md` is untouched; audit-scope mentions in `security-and-audits.md` are historical records and left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)