### PR TITLE
docs: correct leveraged position and flash loan behavior

### DIFF
--- a/guides/leveraged-positions.md
+++ b/guides/leveraged-positions.md
@@ -1,146 +1,158 @@
-# **Looping Made Easy on Venus Protocol**
+# Leveraged Positions: Boost and Repay with Collateral
 
-On Venus Protocol, building leveraged positions — traditionally known as “looping” — used to require users to manually repeat a tedious cycle: borrow → swap on an external DEX → supply as collateral → borrow again, often 5–20 times. Each step cost gas, time, and risk of transaction failures.
+Boost and Repay with Collateral let users open or reduce leveraged Core Pool positions in a single transaction where the feature is available. Both operations use a flash loan internally, but the resulting position is an ordinary supplied-and-borrowed Venus position. It accrues interest and can be liquidated.
 
-Auto-leverage boost changes that completely.
+{% hint style="warning" %}
+**Version and deployment boundary (BNB Chain).** The behavior in this guide is mapped to `venus-periphery` source commit `c11d10190fb20394a4529872be3aebf34de0db4c` and its committed `deployments/bscmainnet/LeverageStrategiesManager_Implementation.json` artifact. That artifact records candidate implementation `0xB8c418eFf558D7eE517b8f26B5Eb0F4f3c53F5D5`, deployed at block `105684846`, for proxy `0x03F079E809185a669Ca188676D0ADb09cbAd6dC1`.
 
-With Venus’s one-click Boost feature, the entire looping process is fully automated and executed in a single, atomic transaction using flash loans.
+An artifact and deployment receipt do not prove which implementation or configuration the proxy currently uses. Before acting on this guide, verify at one recorded BNB Chain block the proxy implementation and code hash, owner and ACM permissions, flash-loan authorization and pause state, supported markets, per-market flash-loan configuration, and SwapHelper.
+{% endhint %}
 
-Here’s what happens behind the scenes when you click “Boost”:
+The source-and-artifact-mapped implementation uses one flash loan per operation. It does not repeat an internal borrow-swap-supply loop.
 
-* Venus instantly calculates the maximum safe leverage based on your current borrowing power and the selected collateral’s loan-to-value (LTV) ratio.  
-* A flash loan borrows a large amount (far beyond your normal borrowing power).  
-* The borrowed asset is swapped (via the best available route) into your chosen collateral asset.  
-* The resulting tokens are supplied as collateral on Venus.  
-* The loop repeats internally as many times as needed — all in the same transaction — until your target leverage is reached.  
-* The flash loan is repaid at the end, leaving you with a fully leveraged position.
+> Boost and Repay with Collateral are high-risk, money-moving operations. Check the selected markets, fee, minimum swap output, resulting debt, and projected health factor before signing. Leave a safety buffer rather than targeting the displayed maximum.
 
-Result: What once took dozens of manual transactions, high gas costs, and constant monitoring is now instant, and completely safe from liquidation on execution (health factor is always kept \> 1).
+## Boost
 
-Whether you’re looping 2×, 5×, or pushing close to the maximum LTV of assets like BNB, BTCB, or stablecoins, Venus does all the heavy lifting.
+Boost increases a user's supplied collateral and borrow balance in one atomic transaction.
 
-Looping is no longer reserved for advanced users — on Venus Protocol, it’s literally as easy as clicking Boost.
+### How Boost works
 
----
+For a cross-asset Boost, the leverage manager:
 
-# **Repay Debt with Collateral**
+1. Takes one flash loan of the selected borrowed asset.
+2. Swaps that asset into the selected collateral asset through the configured swap helper.
+3. Supplies the received collateral to Venus on behalf of the user.
+4. Borrows the flash-loan fee on behalf of the user and uses it for settlement.
+5. Allows the unpaid flash-loan principal to become the user's ordinary borrow balance.
+6. Checks the user's borrowing power after the operation.
 
-Closing or reducing a leveraged position on Venus Protocol is just as simple as opening one. The Repay with Collateral feature lets you instantly repay any borrowed asset using the collateral you already have supplied — without needing to hold the borrowed token in your wallet.
+For a same-asset Boost, the swap step is omitted: the flash-loaned asset is supplied directly as collateral. The fee is still borrowed on behalf of the user, and the principal still becomes ordinary debt.
 
-## **How it works**
+The user must authorize the leverage manager as a delegate. The operation also depends on current market listing, pause state, oracle prices, collateral factors, caps, available cash, token behavior, and, for cross-asset Boost, the minimum swap output.
 
-• Select the loan you want to repay (fully or partially).  
-• Venus automatically withdraws the required amount from one or more of your supplied assets.  
-• It swaps the withdrawn collateral into the exact borrowed asset (using the best available route).  
-• The debt is repaid immediately, and any leftover tokens are returned to your wallet.
+The transaction is atomic: if a required check or external call reverts, the state changes made by that operation roll back. Transaction gas is still paid. Token approvals or delegation transactions submitted earlier remain in effect.
 
-## **Perfect for leveraged positions**
+### Supported markets
 
-When you have a looped (Boosted) position, your wallet typically holds little or none of the borrowed asset. Repay with Collateral eliminates the need to manually unwind loops by letting you deleverage or fully close the position in a single transaction — even if you want to exit at maximum leverage.
+Use only markets offered by the Boost interface. The source-and-artifact-mapped manager rejects `vBNB`, the native BNB Core Pool market; verify the live proxy and interface before relying on that support boundary. Do not treat a reference to BNB as support for `vBNB`; a wrapped-token market, if offered, is a different market.
 
-## **Key benefits**
+## Repay with Collateral
 
-• No need to source the borrowed token externally  
-• One-click full or partial deleveraging  
-• Minimal slippage thanks to optimized routing  
-• Works seamlessly with Boost positions  
-• Saves a lot of time
+Repay with Collateral reduces debt using one selected supplied asset, without requiring the borrowed asset to be held in the user's wallet before the operation.
 
-Combined with the Boost feature, Repay with Collateral makes entering and exiting leveraged positions on Venus faster, and more user-friendly than ever before.
+The source-and-artifact-mapped manager processes one collateral market and one borrowed market per transaction:
 
----
+1. It takes a flash loan of the borrowed asset.
+2. It repays up to the selected amount of the user's debt.
+3. It redeems the selected collateral on behalf of the user.
+4. If the collateral and borrowed assets differ, it swaps the redeemed collateral into the borrowed asset.
+5. It requires the resulting funds to cover the flash-loan settlement and fee.
+6. It checks the user's borrowing power after the operation and returns any positive token-balance delta produced by that operation to the initiator.
 
-# **Key Use Cases for Users**
+Repay with Collateral can revert if delegation, redemption, market liquidity, the swap quote, slippage, flash-loan settlement, or the final safety check fails. A maximally leveraged position is not guaranteed to be fully closable with any selected collateral or quote.
 
-**Yield Farmers – Maximize APY with one click**  
-Loop stablecoins or blue-chip assets (e.g., USDT, USDD, BTCB) up to the maximum safe LTV and earn higher lending \+ VAI rewards without manually repeating borrow-\>swap-\>supply dozens of times.
+## Estimating a Boost amount
 
-**Long-term Bulls – Amplify exposure instantly**  
-Want 4–8× exposure to an asset with only your existing collateral? Boost turns a modest position into a highly leveraged long in seconds.
+There is no single formula that produces a safe Boost amount for every account or market. The result depends on the whole account and current market configuration, including:
 
-**Bearish Traders – Short an asset instantly**  
-Believe an asset is overvalued? Boost lets you instantly borrow and swap into stablecoins, creating a 5–10× leveraged short position in a single click.
+* collateral and borrowed-asset prices;
+* collateral factors and liquidation thresholds;
+* existing supplies and borrows;
+* the flash-loan fee and token-unit rounding;
+* borrow and supply caps;
+* available market cash and accrued interest; and
+* quoted swap output, price impact, and slippage for cross-asset Boost.
 
-**Quick deleveraging during volatility**  
-When prices move against you, repay any borrow instantly using your supplied collateral, no scrambling for tokens or manual unwinding.
+For a simplified same-asset example, let:
 
-**Closing Boosted positions – cleanly**  
-Exit an entire looped position (long or short) in one transaction. Repay with Collateral handles all withdrawals, swaps, and debt repayment automatically.
+* `S` be the existing supplied amount;
+* `D` be the existing debt;
+* `c` be the collateral factor;
+* `B` be the flash-loan principal used for Boost; and
+* `r` be the flash-loan fee rate for that market.
 
-**Capital-efficient entry & exit**  
-Enter high-leverage long or short strategies with zero upfront capital beyond your initial supply, and exit cleanly without ever holding large amounts of the borrowed asset.
+After the operation, the simplified balances are:
 
-Boost \+ Repay with Collateral turns advanced leveraged strategies — long or short — into simple, one-click actions on Venus Protocol.
+```text
+New supply = S + B
+Flash-loan fee = r × B
+New debt = D + B + (r × B)
+```
 
----
+The collateral-factor constraint is therefore:
 
-# **Risks of Using Boost & Repay with Collateral**
+```text
+c × (S + B) >= D + B + (r × B)
+```
 
-While the one-click experience makes leveraging incredibly fast and simple, the risks remain the same as any leveraged position on Venus — just easier to enter at higher ratios.
+Solving only this simplified constraint gives an algebraic boundary:
 
-## **Key risks you must understand:**
+```text
+B <= (c × S - D) / (1 - c + r)
+```
 
-**Liquidation Risk**  
-Boosted positions run very close to the asset’s maximum LTV. A small adverse price move can drop your health factor below 1.1 and trigger liquidation.
+This boundary is not a recommended amount. It has no execution or liquidation buffer and does not include the other constraints listed above. Health factor also uses liquidation thresholds, while borrowing power uses collateral factors; they are not interchangeable.
 
-**Amplified Price Exposure**  
-5–10× leverage magnifies gains and losses. A 10 % drop in the collateral asset price can wipe out 50–100 % of your equity.
+### Example: same-asset USDT Boost
 
-**Execution & Slippage Risk**  
-In rare cases of extreme market conditions, the internal swaps during Boost may fail or experience high slippage, causing the transaction to revert (you only lose gas).
+Assume only for this example:
 
-**Oracle Risk**  
-Venus relies on price oracles. Temporary oracle mispricing can lead to unexpected liquidations or failed Boost attempts.
+* 100 USDT supplied and enabled as collateral;
+* 20 USDT already borrowed;
+* an 80% collateral factor; and
+* an illustrative 0.09% flash-loan fee.
 
-**Borrow Interest Erosion**  
-High or rising borrow rates on leveraged positions can reduce net yield over time and can turn a profitable strategy negative.
+The unused borrowing power before Boost is:
 
-**Impermanent Loss (LP tokens)**  
-Boosting with liquidity-provider tokens adds impermanent loss risk on top of borrowing costs.
+```text
+(100 × 0.8) - 20 = 60 USDT
+```
 
-## **Best practices**
+The fee-omitting calculation `60 / (1 - 0.8) = 300 USDT` is not safe. Even with a zero fee, it lands exactly on the collateral-factor boundary. With the illustrative 0.09% fee:
 
-• Only use funds you can afford to lose  
-• Leave a safety margin instead of always maxing leverage  
-• Monitor your health factor regularly  
-• Know the exact liquidation price before confirming Boost
+```text
+Fee on 300 USDT = 0.27 USDT
+Supply after Boost = 100 + 300 = 400 USDT
+Debt after Boost = 20 + 300 + 0.27 = 320.27 USDT
+Collateral-factor capacity = 400 × 0.8 = 320 USDT
+```
 
-Leverage is a double-edged sword — Boost makes it easy to wield, but the responsibility remains yours.
+The resulting debt exceeds the simplified borrowing capacity, so the operation should revert rather than create the advertised position.
 
----
+The fee-aware algebraic boundary is approximately:
 
-# **How Venus Calculates Your Maximum Boost (With Example)**
+```text
+60 / (1 - 0.8 + 0.0009) = 298.65604778 USDT
+```
 
-Venus automatically determines the highest safe leverage so your health factor is above 1 after using Boost.
+That value still lands on the simplified boundary and should not be used as a target. Choose a lower amount, keep a meaningful safety margin, and verify the final wallet simulation before signing. An interface preview is an estimate, not an execution or liquidation guarantee.
 
-Note: Upon execution, the user's health factor will be greater than 1, which avoids immediate liquidation. Thereafter, the user must continue monitoring their health factor, as the protocol is not responsible for any subsequent liquidations that may occur.
+## Risks
 
-## **Internal Formula**
+### Liquidation risk
 
-**Maximum Additional Borrow \= Unused Borrowing Power ÷ (1 − Collateral Factor)**
+Leverage magnifies losses and reduces the distance to liquidation. Under the interface convention, a health factor at or below 1 is the liquidation boundary. A health factor near 1, including below 1.1, means the position has a thin buffer; 1.1 is not itself the liquidation trigger.
 
-## **Example – Looping USDT (Collateral Factor \= 80%)**
+Monitor health factor after execution. Price moves, interest accrual, and oracle updates can make a previously valid position liquidatable.
 
-**Your Current Position:**  
-• Supplied: 100 USDT (enabled as collateral)  
-• Already borrowed: 20 USDT
+### Amplified price exposure
 
-### **Step-by-Step Calculation (Performed Instantly by the Protocol)**
+If one asset drives the entire exposure, debt is fixed, and liquidation has not intervened, a 10% adverse asset move produces an approximate `10% × leverage` loss of starting equity. This simplified relationship is not a prediction: cross-asset correlations, interest, fees, swaps, and liquidation materially change outcomes.
 
-1. **Unused Borrowing Power**  
-   Unused Borrowing Power \= (Supplied × Collateral Factor) − Existing Borrow  
-   → (100 × 0.8) − 20 \= 80 − 20 \= 60 USDT  
-2. **Maximum Additional Borrow with Boost**  
-   → 60 ÷ (1 − 0.8) \= 60 ÷ 0.2 \= 300 USDT
+### Swap and execution risk
 
-### **Result After Clicking Boost**
+Cross-asset operations depend on external swap execution. High price impact, insufficient output, token behavior, or an external-call failure can revert the transaction. A revert rolls back that operation, but the user pays gas, and earlier approvals or delegations remain active until revoked.
 
-• Total supplied: ≈ 400 USDT  
-• Total borrowed: ≈ 320 USDT  
-• Net equity: still ≈ 80 USDT (your original capital)  
-• Effective leverage achieved: ≈ 5×
+### Oracle and market risk
 
-With only 60 USDT of unused borrowing power, Boost instantly creates a 5× leveraged position — something that would normally require 8–10 manual loops and multiple transactions.
+Oracle prices, market cash, caps, pause state, and interest rates can change. Oracle problems can cause a failed operation or unexpected liquidation. High or rising borrow rates can make a leveraged strategy unprofitable even when asset prices do not move.
 
-The Boost interface shows the exact boost amount, the final leverage multiplier, and the updated health factor before you confirm — no manual calculations needed.
+## Safer operating practices
 
+* Use only funds you can afford to lose.
+* Confirm the exact collateral and borrowed markets; do not assume native BNB support.
+* Leave a safety margin instead of selecting the maximum.
+* Review fee, minimum swap output, debt, collateral, and health factor before signing.
+* Monitor health factor and borrow rates after execution.
+* Revoke approvals or delegation when they are no longer needed.

--- a/technical-reference/reference-technical-articles/flashloan-core-pool.md
+++ b/technical-reference/reference-technical-articles/flashloan-core-pool.md
@@ -1,75 +1,34 @@
-# Venus Protocol's FlashLoan Implementation
+# Core Pool Flash Loans
 
-## Overview
+{% hint style="warning" %}
+**Technical version map (BNB Chain).** This article is mapped to `venus-protocol` source commit `46afc66b1dbd61a707d0a3492b3ec21bf90fc17a`. The committed deployment artifacts record:
 
-Venus Protocol has natively integrated a sophisticated **flash loan** mechanism directly into its Core Pool, enabling users to borrow assets without collateral, provided the loan is repaid within the **same transaction**. This feature unlocks powerful DeFi strategies including **arbitrage, self-liquidation,** and **portfolio rebalancing**, while maintaining the protocol's security and capital efficiency.
+* Core Comptroller Unitroller proxy `0xfD36E2c2a6789Db23113685031d7F16329158384`;
+* candidate `FlashLoanFacet` `0x7F00af2f30a55e79311392C98fBBfA629D19b3A5`, deployed at block `95559359`, whose embedded `FlashLoanFacet.sol` matches that source commit apart from a final newline; and
+* candidate `VBep20Delegate` `0xb25b57599BA969c4829699F7E4Fc4076D14745E1`, deployed at block `87124541`, whose embedded `VToken.sol` contains the transfer, fee, and debt functions described below but differs from the source commit in later flash-loan interest-accrual and accounting changes.
 
-The system is designed for seamless integration with existing Venus markets, offering a **trustless** and composable foundation for advanced financial operations.
+These artifacts are candidate-build evidence, not proof of current routing or market configuration. At a recorded block, resolve the Unitroller diamond routing and selected facet code for `executeFlashLoan(address,address,address[],uint256[],bytes)` (selector `0x5544ed9c`). For every market used, also resolve the active vToken delegate and code, flash-loan enablement and fee/share values, listing, caps, cash, and pause state. Verify the initiator whitelist, user delegation, and effective ACM permissions at the same block.
+{% endhint %}
 
-### Key Features and Technical Architecture
+The Core Pool flash-loan implementation is a hybrid settlement mechanism for authorized initiating contracts. It supports full repayment in the same transaction and, when all ordinary borrowing checks pass, partial repayment with the unpaid balance created as debt for an `onBehalf` account.
 
-- **Multi-Asset Support** – Borrow single or multiple assets in a single atomic transaction, enabling complex strategies across different markets without intermediate steps.
-- **Adaptive Repayment Logic:**
-  - **Instant Full Repayment:** Repay the full principal plus flashLoan fees to complete the transaction (standard flash loan model).
-  - **Partial Repayment Conversion:** If a user has existing supplied collateral and repays partially, the outstanding balance automatically converts to a traditional borrow position secured by their collateral, preventing liquidation and failed transactions.
-- **Streamlined Fee Mechanism:**
-  - A single configurable flashLoanFeeMantissa determines the total cost of the loan.
-  - The protocol's share (flashLoanProtocolShare) is automatically calculated and routed to the **Protocol Share Reserve**, ensuring proper incentive alignment for the ecosystem.
-- **Robust Security Model:**
-  - **Governance Controlled:** Critical parameters (fee structure, activation) are managed through Venus's governance system.
-  - **Upgradeable Design:** Built using modular architecture for future improvements and maintenance.
-  - **Non-Custodial:** Funds never leave the protocol's control during the transaction, eliminating counterparty risk.
+The operation is atomic, but atomicity does not mean the protocol keeps custody of the tokens throughout the callback. Each vToken transfers underlying tokens to the receiver, and the receiver can interact with external contracts while it holds them. Either the final state, including any newly created debt, commits as a whole or a revert rolls back the transaction's state changes.
 
-This architecture positions Venus as a capital-efficient platform for both simple flash loans and sophisticated multi-step strategies, all while maintaining the protocol's security guarantees and economic sustainability.
+## Important properties
 
----
+* *Authorized initiators:* `msg.sender` must be in the Core Comptroller's flash-loan authorization mapping.
+* *Delegation:* if `msg.sender` differs from `onBehalf`, the initiating contract must be an approved delegate for that account.
+* *Multi-asset support:* one request can include up to 200 listed, flash-loan-enabled Core Pool markets.
+* *Per-market fees:* each vToken stores its own flash-loan fee rate and protocol-share rate.
+* *Hybrid settlement:* actual repayment must cover at least the fee. Any remaining principal-and-fee balance is attempted as ordinary debt for `onBehalf`.
+* *Conditional debt creation:* debt conversion can fail because of market, pause, oracle, cap, policy, or collateral-factor borrowing-power checks. If it fails, the entire transaction reverts.
+* *System and market controls:* flash loans can be paused system-wide and enabled or disabled per market.
 
-## Understanding Flash Loans
+Successful debt conversion creates a normal interest-bearing borrow. It does not protect the account from later liquidation.
 
-A flash loan is an uncollateralized loan that must be initiated and repaid within the boundaries of a **single atomic transaction**. This atomicity is enforced by the blockchain itself; if the borrowed amount plus fees is not returned to the protocol by the end of the transaction, the entire operation **reverts** as if it never happened. This mechanism eliminates credit risk for the protocol while granting users unprecedented capital efficiency.
+## Core execution
 
-### The Venus Innovation: Flexible Repayment & Debt Conversion
-
-Venus Protocol significantly enhances the basic flash loan model by introducing a **partial repayment system**, adding a crucial layer of flexibility and user safety.
-
-**1\. Instant Full Repayment (Classic Model):**
-The borrower repays the entire principal plus the accrued fee within the transaction. This is the standard flash loan model used for strategies like arbitrage and liquidation, where the profit is guaranteed to cover the cost.
-
-**2\. Partial Repayment & Automatic Debt Conversion (Venus Model):**
-This is a unique fail-safe mechanism. The user must repay at least the flash loan fee; otherwise, the transaction will revert. However, if a borrower repays the fee but cannot fully repay the principal and has existing supplied collateral on Venus, the protocol does not force a full revert. Instead, the unpaid principal shortfall is automatically converted into a standard borrow position against the user's existing collateral. This prevents immediate liquidation from a failed flash loan and allows for more complex, multi-block strategy planning.
-**Crucially, for users with no collateral, full repayment of both principal and fee remains mandatory.** Any shortfall will cause the transaction to revert, protecting the protocol from unsecured debt.
-
-### Example: A Practical Use Case
-
-Let's imagine a user, Alice, who has supplied 10 ETH as collateral on Venus.
-
-1.  **Objective:** Alice uses a flash loan to perform a complex arbitrage trade that she expects will take several transactions to complete.
-2.  **Action:** She takes a flash loan of 100,000 USDC.
-3.  **Outcome A (Success):** Her arbitrage is successful within the single transaction. She repays the 100,000 USDC plus a 0.09% fee (90 USDC). The transaction completes, and she keeps her profit.
-4.  **Outcome B (Partial Success - Venus's Advantage):**
-    - Her strategy only partially works. By the end of the transaction, she has only generated 80,000 USDC, leaving a shortfall of 20,000 USDC plus the fee.
-    - **On another protocol,** her transaction would revert, she'd lose her gas fees, and potentially miss her profit opportunity.
-    - **On Venus,** because she has 10 ETH as collateral and she has repaid the flashLoan fee amount, the protocol **does not revert**. Instead, it automatically converts the 20,000 USDC shortfall into a standard borrow position against her 10 ETH. Her flash loan is settled, and she now has a regular debt to manage over time, potentially still allowing her to profit from the 80,000 USDC she successfully generated.
-5. **Outcome C (Failure):**
-    - **Her strategy fails completely.** She is only able to repay 50 USDC of the 90 USDC fee, leaving both a fee shortfall and the full principal unpaid.
-    - In this scenario, the transaction will revert. The protocol's safety mechanism triggers because the user must repay at least the full flash loan fee, regardless of their collateral position. This protects the protocol from accumulating bad debt.
-
-This innovative approach makes Venus flash loans both more powerful and more accessible, enabling a wider range of financial strategies while maintaining robust protocol security.
-
----
-
-## Core Smart Contracts
-
-### **1. FlashLoanFacet.sol – FlashLoan Execution & Validation**
-
-Handles core flash loan operations including:
-
-- Asset transfers
-- Fee calculations
-- Repayment logic
-- Event emissions
-
-#### Key Function
+### `FlashLoanFacet.executeFlashLoan`
 
 ```solidity
 function executeFlashLoan(
@@ -78,123 +37,88 @@ function executeFlashLoan(
     VToken[] memory vTokens,
     uint256[] memory underlyingAmounts,
     bytes memory param
-) external nonReentrant {
-    // Validation, asset transfer, fee calculation, repayment logic...
-}
+) external nonReentrant;
 ```
 
-**Explanation:**
-This function serves as the main entry point for initiating both single or multi-asset flash loans. It orchestrates the complete flash loan lifecycle through a phased approach: validating request parameters, transferring multiple assets, executing the user's custom logic via a callback, and enforcing repayment with fee distribution. The entire operation is atomic; if any condition fails (e.g., insufficient repayment or unauthorized access), the transaction reverts, ensuring protocol safety.
+The function validates and settles the complete operation.
 
-### Step-by-Step Workflow:
+### Validation
 
-#### 1. **Validation & Initial Checks**
+Before transferring funds, the Comptroller checks that:
 
-- **Array Integrity**: Ensures the vTokens and underlyingAmounts arrays are non-empty and of identical length to prevent parameter mismatches.
-- **Asset Checks**: For each vToken, verifies that:
-  - The vToken is listed.
-  - Flash loans are enabled for the asset **(isFlashLoanEnabled())**.
-  - The requested loan amount is non-zero.
-- **Authorization**: 
-    - **Initiator Authorization:** Validates that the initiating contract (msg.sender) is pre-authorized (authorizedFlashLoan[msg.sender]) by the protocol to execute flash loans. This ensures only whitelisted, secure contracts can perform these operations.
-    - **Delegate Authorization:** If the flash loan is executed on behalf of another user (onBehalf), it additionally validates that the initiator is an approved delegate (approvedDelegates[onBehalf][msg.sender]) for that specific user. This enables delegated trading strategies while maintaining security.
-- **Address Validation**: Ensures the receiver contract is a non-zero address.
+* flash loans are not paused system-wide;
+* `onBehalf` and `receiver` are nonzero addresses;
+* the asset array is nonempty and contains no more than 200 entries;
+* `vTokens` and `underlyingAmounts` have equal lengths;
+* every market is listed and has flash loans enabled;
+* every requested amount is nonzero;
+* `msg.sender` is authorized to initiate flash loans; and
+* `msg.sender` is an approved delegate when it differs from `onBehalf`.
 
-#### 2. **Phased Execution**
+Authorization applies to the initiating caller. The receiver is a separate address and must independently authenticate the callback.
 
-The core logic is delegated to an internal function that structures the process into three distinct phases:
+### Phase 1: fees and asset transfer
 
-#### **Phase 1: Pre-Transfer Setup & Asset Disbursement**
+For every requested market, the Comptroller:
 
-- **Fee Calculation**: Computes the total fee and protocol fee for each asset using the vToken's fee parameters.
-- **Asset Transfer**: Calls transferOutUnderlying on each vToken contract to disburse the underlying assets to the receiver contract.
-- **Balance Snapshot**: Records the cash balance of each vToken market after transfer for subsequent repayment verification.
+1. calls that vToken's `calculateFlashLoanFee` function; and
+2. calls `transferOutUnderlyingFlashLoan(receiver, amount)`.
 
-#### **Phase 2: User Logic Execution**
+`transferOutUnderlyingFlashLoan` transfers the underlying asset from the vToken to the receiver. The funds therefore leave the vToken during the callback. Transaction rollback and settlement checks protect atomic execution; they are not continuous protocol custody and do not eliminate receiver or external-protocol risk.
 
-- **Callback Invocation**: Calls executeOperation on the receiver contract, passing the loan details (assets, amounts, fees, initiator, onBehalf) and the param data. This is where the user's custom strategy (e.g., arbitrage, liquidation) is executed.
-- **Approval Tracking**: Returns an array (tokensApproved) indicating whether the receiver approved each asset for repayment transfer.
+### Phase 2: receiver callback
 
-#### **Phase 3: Repayment Handling & Settlement**
-
-- **Repayment Processing**: For each asset, handles repayment based on the receiver's approval and the amount transferred back:
-  - **Full Repayment**: If the receiver approved and transferred the full amount (principal + fees), the loan is settled.
-  - **Debt Conversion**: If the receiver did not approve or only partially repaid(atleast the fees), the shortfall is converted into a standard borrow position for the onBehalf (requires existing collateral).
-- **Fee Distribution**: Routes the protocol's share of fees to the Protocol Share Reserve (PSR) and credits supplier fees to the respective vToken markets.
-- **Balance Verification**: Ensures the final vToken balances reflect the correct repayment amounts, reverting if discrepancies are detected.
-
-#### 3. **Event Emission**
-
-- Upon successful completion, a **FlashLoanExecuted** event is emitted, logging the receiver address, the vTokens involved, and the amounts loaned.
-
-### Critical Security Features:
-
-- **Non-Reentrancy**: The function and its internal phases are protected against reentrancy attacks (implied by nonReentrant modifier or equivalent checks).
-- **Atomicity**: The entire operation succeeds or reverts entirely, preventing partial state changes.
-- **Authorization Enforcement**: Strict access control ensures only whitelisted initiators can trigger flash loans.
-- **Collateral Checks**: For debt conversion, the initiator must have sufficient collateral to cover the converted borrow position; otherwise, the transaction reverts.
-
----
-
-### **2. SetterFacet.sol - Setter Functions For Flashloan** 
-
-This file contains administrative functions to manage flash loan permissions.
-
-#### **Functions**
-
-#### `setWhiteListFlashLoanAccount`
+The Comptroller calls:
 
 ```solidity
-function setWhiteListFlashLoanAccount(address account, bool _isWhiteListed) external;
+function executeOperation(
+    VToken[] calldata vTokens,
+    uint256[] calldata amounts,
+    uint256[] calldata premiums,
+    address initiator,
+    address onBehalf,
+    bytes calldata param
+) external returns (bool success, uint256[] memory repayAmounts);
 ```
 
-**Explanation:**  
-This function is a central access control mechanism. In its initial phase, flash loans might be permissioned to prevent unknown or potentially malicious contracts from using the system until it's battle-tested. This function allows the admin or governance approved address to explicitly grant or revoke permission for a specific address (`account`) to call the `executeFlashLoan` function.
+`initiator` is the authorized caller of `executeFlashLoan`. `repayAmounts` contains numeric repayment amounts, not approval booleans. The receiver must return one amount for each requested asset and approve each corresponding vToken to pull that amount.
 
-- **Whitelisting (\_isWhiteListed = true)** : Adds the account to a mapping of allowed addresses. This account can now initiate flash loans for itself.
-- **Blacklisting/Removing (\_isWhiteListed = false)** : Removes the account from the whitelist, revoking its permission to initiate flash loans.
+If the receiver returns `false` or reverts, the entire transaction reverts.
 
-This is a temporary measure often used during a phased rollout before opening the system to permissionless access.
+### Phase 3: settlement and optional debt
 
----
+For each asset, settlement uses the following sequence:
 
-### **3. VToken.sol – Asset Transfer & Fee Calculation**
+1. Calculate `maximum repayment = principal + fee`.
+2. Cap the receiver's requested repayment at that maximum.
+3. Revert before the token pull if the requested repayment is less than the fee.
+4. Pull the requested amount from the receiver through the vToken.
+5. Revert if the actual amount received by the vToken is less than the fee.
+6. Calculate `unpaid balance = principal + fee - actual amount received`.
+7. If the unpaid balance is nonzero, call `flashLoanDebtPosition(onBehalf, unpaid balance)`.
 
-Manages the underlying asset transfers, flash loan fee calculations, and creation of debt positions.
+The receiver needs sufficient balance and allowance for the amount it reports. Missing allowance does not skip repayment and trigger debt conversion; it causes the token transfer, and therefore the transaction, to fail.
 
-#### Key Functions
+`flashLoanDebtPosition` uses the ordinary borrow path. Debt creation must pass the relevant protocol and market pause checks, listing and pool policy, valid oracle prices, borrow cap, and the `onBehalf` account's collateral-factor borrowing power. Merely having supplied collateral does not guarantee conversion.
 
-**1.`transferOutUnderlyingFlashLoan`**
+For multi-asset requests, a failure while settling any asset reverts all state changes in the transaction.
 
-```solidity
-function transferOutUnderlyingFlashLoan(address payable to, uint256 amount) external nonReentrant;
-```
+## Fee handling
 
-**Explanation:**
-This function is the work horse for moving assets during flash loan operations. When `FlashLoanFacet.sol` calls this during a flash loan, it performs several critical actions:
-
-1.  **Authorization Check**: Ensures only the Comptroller contract can call this function.
-2.  **Flash Loan State Management**: Sets the flashLoanAmount to track the active flashloan and prevents concurrent flash loans.
-3.  **Asset Transfer**: Performs the low-level transfer of the underlying asset to the receiver address.
-4.  **Event Emission**: Emits TransferOutUnderlyingFlashLoan event for tracking.
-
----
-
-**2. `calculateFlashLoanFee`**
+### `VToken.calculateFlashLoanFee`
 
 ```solidity
 function calculateFlashLoanFee(uint256 amount) public view returns (uint256, uint256);
 ```
 
-**Explanation:**
-This function computes the cost of a flash loan by calculating the **total fee** and the **protocol's share**. It uses fixed-point arithmetic to ensure precision in fee calculations, which is critical for maintaining protocol economics and ensuring accurate revenue distribution between suppliers and the protocol.
+The function returns:
 
-1.  **Total Fee Calculation** : Multiplies the loan amount by the global **flashLoanFeeMantissa** (a scaled value, e.g., 0.09% represented as 9e14).
-2.  **Protocol Fee Allocation** : Calculates the protocol's portion by multiplying the totalFee by **flashLoanProtocolShare** (a scaled value representing the protocol's percentage share).
+* the total fee, calculated from the vToken's `flashLoanFeeMantissa`; and
+* the protocol portion, calculated from the vToken's `flashLoanProtocolShareMantissa`.
 
----
+Both calculations use fixed-point arithmetic and truncate to token units. Fee configuration is per vToken, not one global Comptroller value.
 
-**3. `transferInUnderlyingFlashLoan`**
+### `VToken.transferInUnderlyingFlashLoan`
 
 ```solidity
 function transferInUnderlyingFlashLoan(
@@ -202,204 +126,140 @@ function transferInUnderlyingFlashLoan(
     uint256 repaymentAmount,
     uint256 totalFee,
     uint256 protocolFee
-) external nonReentrant returns (uint256);
+) external nonReentrant returns (uint256 actualAmountTransferred);
 ```
 
-**Explanation:**
-This function handles the repayment phase of flash loans with enhanced parameter validation. When called by the Comptroller, it performs several critical operations:
+Only the Comptroller can call this function. It pulls underlying from the receiver, checks the actual amount received against the fee, sends the protocol portion of the fee to the Protocol Share Reserve, records the PSR income type, and clears the active flash-loan amount. The non-protocol portion remains in market cash; there is no separate per-supplier credit call during settlement.
 
-1.  **Authorization Check**: Ensures only the Comptroller contract can call this function.
-2.  **Asset Collection**: Transfers the repayment amount from the receiver contract to the vToken.
-3.  **Repayment Validation**: Validates that the actual transferred amount meets the minimum fee requirement.
-4.  **Protocol Fee Distribution**: Automatically transfers the protocol fee portion to the Protocol Share Reserve.
-5.  **State Management**: Resets the flashLoanAmount to 0, completing the flash loan cycle.
-6.  **Event Emission**: Emits `TransferInUnderlyingFlashLoan` event with detailed repayment information.
+Tokens with transfer taxes or other non-standard transfer behavior can make `actualAmountTransferred` differ from the requested amount. Receiver code must reason about the actual amount the vToken will receive.
 
----
-
-**3. `setFlashLoanEnabled`**
+### Fee and market configuration
 
 ```solidity
 function setFlashLoanEnabled(bool enabled) external returns (uint256);
-```
 
-**Explanation:**  
-An administrative function that allows governance to explicitly enable or disable flash loan functionality for a specific vToken market. Unlike a toggle function, this takes a boolean parameter to set the exact desired state, preventing accidental state changes. This would be used to disable flash loans if a vulnerability is suspected in a particular asset's market or to enable them after security verification.
-
----
-
-**4. `setFlashLoanFeeMantissa`**
-
-```solidity
 function setFlashLoanFeeMantissa(
     uint256 flashLoanFeeMantissa_,
     uint256 flashLoanProtocolShare_
 ) external returns (uint256);
 ```
 
-**Explanation:**
-This governance-controlled function updates the core economic parameters for flash loans. It allows the protocol to adjust both the total fee charged for flash loans and how that fee is distributed between the protocol treasury and liquidity suppliers. These parameters directly impact the protocol's revenue generation and the attractiveness of providing liquidity.
+These vToken functions are controlled through the Access Control Manager using their exact function signatures. Both fee parameters are scaled by `1e18` and cannot exceed `1e18`.
 
-1.  **flashLoanFeeMantissa\_** : This is the total fee rate charged for flash loans (scaled by 1e18).
-2.  **flashLoanProtocolShare\_** : This is the percentage of the total fee allocated to the Protocol Share Reserve (scaled by 1e18).
-
----
-
-**5. `getCash`**
+The Core Comptroller also exposes ACM-controlled functions to authorize initiating accounts and pause flash loans system-wide:
 
 ```solidity
-function getCash() external view override returns (uint);
+function setWhiteListFlashLoanAccount(address account, bool isWhiteListed) external;
+
+function setFlashLoanPaused(bool paused) external;
 ```
 
-**Explanation:**
-This function provides cash balance reporting with modified behavior during active flash loan operations. During normal operations, it returns the actual underlying token balance held by the vToken contract. However, during active flash loans (`flashLoanAmount > 0`), it returns the reduced cash balance reflecting funds temporarily transferred out. 
+Do not assume the initiator whitelist is temporary or that the feature is permissionless. Integrators must verify current on-chain authorization, pause state, market enablement, and fee configuration.
 
-The protocol now internally uses `_getCashPriorWithFlashLoan()` which returns `getCashPrior() + flashLoanAmount` to calculate total available liquidity including active flash loans. This design ensures accurate accounting while maintaining protocol stability through consistent interest rate and exchange rate calculations.
-
----
-
-### **4. Flash Loan Receiver Standards**
-
-There is a standardized interface for contracts wishing to receive and handle flash loans from Venus Protocol:
-
-#### **1\. IFlashLoanReceiver - Multi-Asset Standard**
-
-**Purpose:** For complex strategies requiring multiple assets in a single flash loan operation.
-
-**Interface: IFlashLoanReceiver**
+## VToken cash accounting
 
 ```solidity
-    function executeOperation(
-        VToken[] calldata vTokens,
-        uint256[] calldata amounts,
-        uint256[] calldata premiums,
-        address initiator,
-        address onBehalf,
-        bytes calldata param
-    ) external returns (bool success, uint256[] memory repayAmounts);
+function getCash() external view returns (uint256);
 ```
 
-**Key Parameters:**
+`getCash` reports the vToken's actual underlying-token cash. During an active flash loan, it therefore reflects the lower balance after funds have been transferred to the receiver. Flash-loan-aware internal accounting can include the tracked active amount where required for rate and exchange-rate calculations. Integrators that depend on the precise accounting sequence must bind their analysis to the active vToken implementation, not only to repository `main`.
 
-- **vTokens**: Array of VToken addresses borrowed
-- **amounts**: Corresponding amounts for each asset
-- **premiums**: Fee amounts for each asset
-- **initiator**: Address that initiated the flash loan
-- **onBehalf**: Address whose debt position will be used for any unpaid balance
-- **param**: Custom encoded data for strategy execution
+## Receiver requirements
 
-**Return Value:**
+A receiver should implement `IFlashLoanReceiver` directly or use a separately published, versioned, and audited integration library.
 
-- **success**: Success status (must return true for transaction to complete)
-- **repayAmounts**: Array of actual repayment amounts for each asset
+The `FlashLoanReceiverBase` found under `contracts/test` in the protocol repository is a test helper, not a production integration standard. Its Comptroller field is ordinary public storage, not a Solidity `immutable`, and the helper does not authenticate callbacks or implement settlement.
 
-**Base Contract: FlashLoanReceiverBase**
+Production receiver code must:
 
-- Provides immutable Comptroller reference
-- Inherited by multi-asset receiver contracts
-- Ensures protocol governance integration
+1. Authenticate that `msg.sender` is the expected Core Comptroller.
+2. Validate `initiator`, `onBehalf`, `vTokens`, amounts, premiums, and strategy parameters.
+3. Execute only calls and routes the receiver is designed to trust.
+4. Return one numeric repayment amount for every asset.
+5. Approve each corresponding vToken to pull the returned amount.
+6. Ensure the vToken will actually receive at least the fee for each asset.
+7. Obtain explicit user authorization before intentionally leaving debt for `onBehalf`.
+8. Verify that the account has sufficient current borrowing power for any intended unpaid balance.
+9. Return `false` or revert when strategy validation fails.
 
-**Use Cases:** Cross-protocol arbitrage, multi-asset liquidations, complex portfolio rebalancing.
+Receiver code must not treat atomic rollback as protection from every integration risk. External protocols, swap routes, token behavior, callback authentication, approvals, and any successfully created user debt remain part of the receiver's security model.
 
-### **Core Requirements for the Standard**
+## Numerical examples
 
-Receiver Contracts Must:
+The following examples use a 100,000 USDC principal and an illustrative 0.09% fee:
 
-1.  **Receive Assets**: Acknowledge and handle the received flash-loaned assets.
-2.  **Execute Strategy**: Perform intended operations (arbitrage, liquidation, etc.)
-3.  **Ensure Repayment**: Ensure sufficient funds are available and approved for repayment:
-    - Must approve at least the fee amount to each vToken contract
-    - Return actual repayment amounts in the repayAmounts array
-    - For partial repayment: unpaid balance becomes debt against onBehalf address
-4.  **Return Success**: Return true to signal successful operation.
-5.  **Handle Reversion**: If operation fails, return false or revert to unwind the entire transaction.
+```text
+Fee = 100,000 × 0.0009 = 90 USDC
+Maximum repayment = 100,000 + 90 = 100,090 USDC
+```
 
-**Critical Security Note:** The entire flash loan transaction is atomic. If executeOperation returns false or reverts, the entire transaction reverts, ensuring protocol safety while allowing complex strategies to fail gracefully.
+The example fee is not a statement of the current fee for every market. Read the selected vToken's on-chain configuration.
 
----
+### Full repayment
 
-## Key Events
+If a strategy finishes with 100,200 USDC, approves the vToken, and reports full repayment:
 
-- **`TransferOutUnderlyingFlashLoan`** - Emitted on successful transfer of amount to receiver during flash loan initiation.
-- **`TransferInUnderlyingFlashLoan`** - Emitted on successful transfer of repayment amount from receiver to vToken.
-- **`FlashLoanExecuted`** – Emitted after a flash loan is executed successfully.
-- **`FlashLoanStatusChanged`** – Emitted when flash loan status is changed for a market.
-- **`IsAccountFlashLoanWhitelisted`** – Emitted when trying to set whitelist flashloan account.
+```text
+Amount pulled = 100,090 USDC
+Amount remaining for the receiver = 100,200 - 100,090 = 110 USDC
+Debt created = 0
+```
 
----
+The arithmetic does not guarantee strategy profit. It only describes settlement if the receiver actually has the stated balance and every check succeeds.
 
-## Key Errors
+### Partial repayment: 99,500 USDC returned
 
-- **`FlashLoanNotEnabled`** - Thrown if flash loan is not enabled for the asset.
-- **`InvalidAmount`** - Thrown when the requested flash loan amount is zero.
-- **`SenderNotAuthorizedForFlashLoan`** - Thrown when the sender is not authorized to use flash loan.
-- **`NoAssetsRequested`** - Thrown if no assets are requested for the flash loan.
-- **`InvalidFlashLoanParams`** - Thrown if the flash loan params are invalid.
-- **`ExecuteFlashLoanFailed`** - Thrown when executeOperation on the receiver contract fails.
-- **`NotEnoughRepayment`** - Thrown if the repayment amount is less than the required total fee.
-- **`FailedToCreateDebtPosition`** - Thrown when failing to create a debt position.
-- **`InvalidComptroller`** - Thrown if the caller is not the Comptroller contract.
-- **`FlashLoanAlreadyActive`** - Thrown if a flash loan is already in progress.
-- **`NotAnApprovedDelegate`** - Thrown when the sender is not an approved delegate for the onBehalf address.
-- **`MarketNotListed`** - Thrown when trying to flash loan from a market that is not listed in the core pool.
-- **`InsufficientRepayment`** - Thrown when the actual transferred amount is less than the required total fee.
+```text
+Unpaid balance = 100,090 - 99,500 = 590 USDC
+```
 
----
+The protocol attempts to create 590 USDC of ordinary debt for `onBehalf`. The transaction completes only if the vToken receives the 99,500 USDC and the additional 590 USDC borrow passes every ordinary borrow check. Otherwise, the transaction reverts.
 
-## Example FlashLoan Flow: Alice's Arbitrage
+### Partial repayment: 80,000 USDC returned
 
-**User:** Alice (has 10 ETH collateral on Venus)
+```text
+Unpaid balance = 100,090 - 80,000 = 20,090 USDC
+```
 
-**Goal:** Arbitrage 100,000 USDC between DEXs
+The debt attempt is 20,090 USDC, not 20,000 USDC. A statement such as “the user has 10 ETH collateral” is not enough to determine success. The ETH oracle price, applicable collateral factor, existing supplies and borrows, caps, pause state, and other account and market data are required.
 
-### **1\. Full Repayment (Successful Trade)**
+### Repayment below the fee
 
-1.  **Request:** Alice's ArbitrageContract calls executeFlashLoan() requesting 100000 USDC.
-2.  **Transfer:** Venus sends 100,000 USDC to Alice's contract + calculates fee (e.g., 90 USDC)
-3.  **Execution:**
-    - Venus calls executeOperation() on Alice's contract
-    - Contract performs arbitrage (buy low, sell high)
-    - Profits 100,200 USDC
-    - **Approves full repayment** of 100,090 USDC
-4.  **Repayment:** Venus pulls the approved 100,090 USDC
-5.  **Result:** Alice keeps 110 USDC profit. Transaction completes.
+If the receiver reports 50 USDC when the fee is 90 USDC, the Comptroller detects `50 < 90` and reverts before asking the vToken to pull repayment. No debt conversion occurs, all transaction state changes roll back, and the transaction sender still pays gas.
 
-### **2\. Partial Repayment (Failed Trade → Debt Conversion)**
+## Events
 
-1.  **Request:** Alice's ArbitrageContract calls executeFlashLoan() requesting 100000 USDC.
-2.  **Transfer:** Venus sends 100,000 USDC + calculates fee (90 USDC)
-3.  **Execution:**
-    - Arbitrage fails due to slippage → only gets 99,500 USDC
-    - **Approves partial repayment** of 99,500 USDC
-4.  **Debt Conversion:**
-    - Venus pulls 99,500 USDC
-    - **Shortfall detected:** 590 USDC (100,090 required - 99,500 paid)
-    - **Converts shortfall** into a borrow position against Alice's 10 ETH collateral
-5.  **Result:** Transaction does not revert. Alice now owes 590 USDC to Venus.
+The relevant events include:
 
-### **3\. Fee Not Paid (Critical Failure → Transaction Reverts)**
+* `FlashLoanExecuted`;
+* `FlashLoanRepaid`;
+* `TransferOutUnderlyingFlashLoan`;
+* `TransferInUnderlyingFlashLoan`;
+* `FlashLoanStatusChanged`;
+* `FlashLoanFeeUpdated`;
+* `IsAccountFlashLoanWhitelisted`; and
+* `FlashLoanPauseChanged`.
 
-1. **Request:** Alice's ArbitrageContract calls executeFlashLoan() requesting 100,000 USDC.
-2. **Transfer:** Venus sends 100,000 USDC + calculates fee (90 USDC)
-3. **Execution:**
-    - Arbitrage fails completely → only gets 50 USDC
-    - **Approves insufficient amount** of 50 USDC (less than the 90 USDC fee)
-4. **Validation Failure:**
-    - Venus attempts to pull funds but detects fee shortfall
-    - Protocol requires at minimum the full flash loan fee to be repaid
-5 **Result:** Transaction reverts completely. No debt conversion occurs. Alice loses gas fees but protocol remains secure.
+Use the ABI of the active implementations as the authoritative event schema.
 
-### **Key Mechanism**
+## Errors
 
-- **Full Repayment:** Strategy must profit enough to cover principal + fees.
-- **Partial Repayment:** Unique Venus feature. Requires existing collateral and atleast fees repayment.
-- **Fee Not Paid:** Transaction always reverts - critical safety mechanism.
-- **No Collateral?** Full repayment mandatory; otherwise transaction reverts.
-- **Auto-Conversion:** Shortfall automatically becomes secured debt, preventing liquidation.
+Important errors include:
 
----
+* `FlashLoanPausedSystemWide`;
+* `FlashLoanNotEnabled`;
+* `NoAssetsRequested`;
+* `TooManyAssetsRequested`;
+* `InvalidFlashLoanParams`;
+* `InvalidAmount`;
+* `MarketNotListed`;
+* `SenderNotAuthorizedForFlashLoan`;
+* `NotAnApprovedDelegate`;
+* `ExecuteFlashLoanFailed`;
+* `NotEnoughRepayment`;
+* `InsufficientRepayment`;
+* `FailedToCreateDebtPosition`;
+* `InvalidComptroller`; and
+* `FlashLoanAlreadyActive`.
 
-## Conclusion
-
-Venus Protocol’s flash loan implementation provides a **secure, composable, and flexible foundation** for advanced DeFi strategies.  
-It enables **atomic transactions**, **multi-asset borrowing**, and **deep composability** with Venus and other DeFi protocols.
+The exact error set depends on the active Comptroller facet and vToken implementation. Integrations should generate selectors from the matching deployed ABI.


### PR DESCRIPTION
## Summary

- rewrite Boost and Repay with Collateral around the actual single-flash-loan flow
- include flash-loan fees in leverage math and replace the unsafe maximum-boost example
- document market, delegation, vBNB, and one-collateral-market constraints
- correct Core Pool flash-loan custody, partial repayment, allowance, debt-conversion, and example behavior
- add explicit source, artifact, and live-deployment verification boundaries

## Why

The previous pages made absolute safety claims and omitted fee and settlement behavior. The published boost example could exceed borrowing capacity and revert.

## Validation

- independent source and deployment review
- cross-review by a separate reviewer
- targeted Remark check: no issues
- `git diff --check`: passed