### PR TITLE
docs: mark standalone Isolated Pools as retired

### DIFF
--- a/getting-started/faq.md
+++ b/getting-started/faq.md
@@ -24,9 +24,9 @@ No platform can be considered entirely risk-free. Risks associated with Venus V4
 
 Venus Protocol focuses on improving three main areas:
 
-* **Risk Management:** Prioritizing the risk management, Venus introduces new features like Isolated Pools and more sophisticated risk parameters.
+* **Risk Management:** Venus introduced more sophisticated risk parameters, layered oracle validation, and fine-grained controls.
 * **Decentralization:** The governance model has been enhanced by introducing fast-track VIPs, role-based access control, and a fine-grained pause mechanism.
-* **User Experience:** The latest version offers an enhanced user interface, a more effective reward system, isolated lending, and the Venus Prime Soulbound Token, all aimed at providing a smooth user experience.
+* **User Experience:** The latest version offers an enhanced user interface, a more effective reward system, and Venus Prime, all aimed at providing a smooth user experience.
 
 ### **What is the Resilient Price Oracle?**
 
@@ -34,11 +34,13 @@ The Resilient Price Oracle introduced in Venus V4 fetches prices from multiple s
 
 ### **What are Isolated Pools?**
 
-Isolated Pools are a new feature in Venus V4, designed to overcome the limitations of a single core pool. Each Isolated Pool is an independent collection of assets with custom risk management configurations. This setup allows users to better manage their risk and earn yield, while also preventing failures in one market from impacting others.
+Standalone Isolated Pools were separate collections of lending markets with their own risk configurations. This product has since been fully deprecated on BNB Chain, Ethereum, and Arbitrum, and its screens have been removed from the Venus interface. If you still have a position or unclaimed rewards in one of these legacy pools, follow the [exit and rewards guide](../guides/isolated-pools-deprecation.md).
+
+This retirement does not apply to the Core Pool or to [Isolation Mode](../guides/isolated-e-mode.md), which applies borrowing restrictions to selected collateral within the Core Pool.
 
 ### **What is the Risk Fund?**
 
-In Venus V4, a risk fund is maintained for each pool. A percentage of the protocol's revenue is deposited into this fund, aiming to counterbalance bad debt and prevent potential market insolvencies.
+The Risk Fund is a reserve-management component used to hold protocol reserves that can help address bad debt. The original V4 isolated-pool design used per-pool accounting, but that accounting model has since been removed; the `RiskFundV2` contract itself remains active.
 
 ### **What changes were made to the governance model in Venus V4?**
 

--- a/guides/market-interaction/interface.md
+++ b/guides/market-interaction/interface.md
@@ -4,7 +4,7 @@ Let's take a quick look at the Venus interface and the features available in eac
 
 ### Dashboard
 
-In the center of the Dashboard interface, you will find the Supply and Borrow markets. You'll also notice a new column called 'Pool' which identifies the pool to which each market belongs. The Supply market allows you to lend your cryptocurrency assets and earn interest on them. You can choose which assets to supply and specify the amount you want to lend. On the other hand, the Borrow market allows you to borrow cryptocurrency assets by using your supplied assets as collateral. You can select the assets you want to borrow and specify the amount you need.
+In the center of the Dashboard interface, you will find the Supply and Borrow markets. The Supply market allows you to lend your cryptocurrency assets and earn interest on them. You can choose which assets to supply and specify the amount you want to lend. On the other hand, the Borrow market allows you to borrow cryptocurrency assets by using your supplied assets as collateral. You can select the assets you want to borrow and specify the amount you need.
 
 <figure><img src="../../.gitbook/assets/Screenshot 2023-08-02 at 9.35.46 AM.png" alt=""><figcaption></figcaption></figure>
 
@@ -16,15 +16,13 @@ The Account interface provides an overview of your supplied and borrowed assets.
 
 ### Core Pool
 
-The Core Pool interface is your hub for exploring all primary markets available. It allows you to click on each market to examine essential metrics such as 'Supply APY', 'Borrow APY', and 'Total Liquidity', among others. This interface centralizes all your lending and borrowing activities within the main markets.
+The Core Pool is accessed from the Markets interface, which lists lending markets for the selected chain and displays metrics such as Supply APY, Borrow APY, and liquidity. On chains where [Isolation Mode](../../whats-new/isolated-e-mode.md) groups are available, they appear as an **Isolation mode** tab within the Core Pool interface.
 
-<figure><img src="../../.gitbook/assets/Screenshot 2023-08-02 at 10.01.29 AM.png" alt=""><figcaption></figcaption></figure>
+Isolation Mode is separate from the deprecated standalone Isolated Pools product described below.
 
 ### Pools
 
-The Pools interface allows you to explore all isolated pools available. You can click on each pool to view all the markets within it. In the markets, you can see various metrics such as 'Supply APY', 'Borrow APY', 'Total Liquidity', and more.
-
-<figure><img src="../../.gitbook/assets/Screenshot 2023-08-02 at 9.33.46 AM.png" alt=""><figcaption></figcaption></figure>
+The standalone Isolated Pools navigation and market screens described in earlier versions of this guide have been removed. New supply and borrow activity in these pools is not available through the Venus interface. If you still have a position or unclaimed rewards in a legacy isolated pool, follow the [exit and rewards guide](../isolated-pools-deprecation.md).
 
 ### Vaults
 

--- a/whats-new/isolated-pools.md
+++ b/whats-new/isolated-pools.md
@@ -1,24 +1,17 @@
-# Isolated Pools
+# Legacy Isolated Pools
 
-### Overview
+## Status
 
-Isolated Pools are made up of separate collections of assets with tailored risk management configurations. This design offers users broader opportunities to manage risk and allocate assets to earn yield. Moreover, it prevents hypothetical failures from affecting the liquidity of the entire protocol as they are confined to isolated markets.
+The standalone Isolated Pools product has been fully deprecated on BNB Chain, Ethereum, and Arbitrum. Its navigation and market screens have been removed, and new supply and borrow activity in these pools is no longer available through the Venus interface.
 
-Isolated Pools also offer custom rewards for each market in the pool, incentivizing users accordingly.
+These pools were separate collections of lending markets with their own assets and risk configurations. Their contracts and existing positions remain on-chain. If you still have supplied assets, an outstanding borrow, or unclaimed rewards in one of these pools, follow the [exit and rewards guide](../guides/isolated-pools-deprecation.md).
 
-### Isolated Pools Architecture
+## Do not confuse Isolated Pools with Isolation Mode
 
-The Isolated Pools system is based on the *PoolRegistry* contract. It maintains a directory of isolated lending pools, allows the creation and registration of new pools, and offers getter methods to fetch pool details.
+The retirement of standalone Isolated Pools does not affect the Core Pool or [Isolation Mode](isolated-e-mode.md). Isolation Mode applies borrowing restrictions to selected collateral within the Core Pool; it does not move funds into a standalone isolated pool.
 
-To add a new market to an existing lending pool, the PoolRegistry deploys a JumpRateModelV2 or a WhitePaperInterestRateModel contract, deploying the upgradable VToken for the market before gaining the approval of the market's Comptroller.
+## Technical references
 
-<figure><img src="../.gitbook/assets/fd111ec8-a057-490c-bb3d-d1a8c026bb12.png" alt=""><figcaption><p><em>Isolated Lending Pools Architecture</em></p></figcaption></figure>
+The retirement applies to the standalone product and its interface, not to the entire underlying codebase or every shared component. Some components from the Isolated Pools architecture also support active deployments, including Core Pools.
 
-### User Actions
-
-Users can perform the following actions on any market in a pool:
-
-1. **Deposit**: Users can deposit an asset, receiving vTokens that correspond to the liquidity deposited. These vTokens accrue interest until they are burned on redeem or liquidated.
-2. **Borrow**: Users can borrow assets, in exchange for locked collateral.
-3. **Redeem**: Users can redeem vTokens for the underlying asset based on the exchange rate.
-4. **Repay Borrow**: Users can repay the borrowed asset and accrued interest.
+The [Isolated Pools technical reference](../technical-reference/reference-isolated-pools/README.md) documents this architecture, while [deployed market addresses](../deployed-contracts/markets.md) remain available for developers and legacy position holders who need to inspect deployed contracts. Neither reference should be interpreted as making the standalone product available for new activity through the Venus interface.


### PR DESCRIPTION
## Summary

- replace stale standalone Isolated Pools onboarding copy with retirement guidance
- update the FAQ and interface guide while preserving existing public anchors
- distinguish the retired standalone product from active Core Pool Isolation Mode and shared technical components
- keep the legacy page path as a safe landing page for old links

## Scope

This PR intentionally does not modify the money-moving isolated pool exit instructions. Those require a separate focused review.

## Verification

- documentation main checked at 2c712ed97115a3d28a4af544b644395864d903c4
- interface main checked at c51133cb99c6881b96f9636b9cbec3bcf9c5e572
- targeted Remark checks pass for all three changed files
- git diff --check passes
- all added relative links resolve
- independent content and lifecycle review completed