### PR TITLE
docs: correct protocol rate math

### DIFF
--- a/guides/protocol-math.md
+++ b/guides/protocol-math.md
@@ -1,86 +1,178 @@
-# Protocol Math
+# Protocol math
 
-### Overview
+{% hint style="warning" %}
+**Use deployment-specific inputs.** The conversion identities on this page are current, but token decimals, vToken implementation, interest-rate model, and rate time unit are deployment state. Resolve them for the target chain, pool, market, and block before using the examples. Do not reuse vBNB or per-block assumptions on another deployment.
+{% endhint %}
 
-The contracts under the Venus Protocol employ a system called Exponential.sol. This system uses exponential mathematics to represent fractional quantities with high precision.
+Venus contracts commonly represent fractional rates and exchange rates as integer mantissas scaled by `1e18`. Token amounts use the token's own decimal scale instead. Keep those two scales separate and use integer or arbitrary-precision arithmetic for on-chain values.
 
-Most numbers in this system are represented by a mantissa, an unsigned integer scaled by a factor of 1 \* 10^18. This scaling ensures basic mathematical operations can be performed with a high degree of accuracy.
+## vToken and underlying decimals
 
-### vToken and Underlying Decimals
+vTokens are ERC-20-compatible tokens, but the contract initializer accepts the vToken decimal count as a deployment parameter. Read it instead of assuming every vToken has eight decimals:
 
-Prices and exchange rates are adjusted according to the unique decimal scaling of each asset. vTokens, which are BEP-20 tokens, are scaled with 8 decimal places. However, their underlying tokens may have different decimal scaling, which is indicated by a public member called 'decimals'.
-
-For further details, please refer to the respective token contract addresses.
-
-{% content-ref url="../deployed-contracts/markets.md" %}
-[core-pool.md](../deployed-contracts/markets.md)
-{% endcontent-ref %}
-
-### Interpreting Exchange Rates
-
-The exchange rate of vTokens is adjusted based on the decimal difference between the vToken and its underlying asset.
-
-$$
-oneVTokenInUnderlying = \frac{exchangeRateCurrent}{1 \times 10^{(18 + underlyingDecimals - vTokenDecimals)}}
-$$
-
-Here is an example illustrating how to determine the value of one vBUSD in BUSD using the Web3.js JavaScript library.
-
-```javascript
-const vTokenDecimals = 8; // all vTokens have 8 decimal places
-const underlying = new web3.eth.Contract(bep20Abi, busdAddress);
-const vToken = new web3.eth.Contract(vTokenAbi, vBusdAddress);
-const underlyingDecimals = await underlying.methods.decimals().call();
-const exchangeRateCurrent = await vToken.methods.exchangeRateCurrent().call();
-const mantissa = 18 + parseInt(underlyingDecimals) - vTokenDecimals;
-const oneVTokenInUnderlying = exchangeRateCurrent / Math.pow(10, mantissa);
-console.log('1 vBUSD can be redeemed for', oneVTokenInUnderlying, 'BUSD');
+```solidity
+function decimals() external view returns (uint8);
 ```
 
-As BNB lacks an underlying contract, you must set the 'underlyingDecimals' to 18 when dealing with vBNB.
+For an ERC-20 market, read the underlying address from the vToken and then read the underlying token's `decimals()`. Native-asset markets are an exception: for example, BNB Chain mainnet vBNB has no ERC-20 underlying contract, and native BNB uses 18 decimals.
 
-To calculate the number of underlying tokens that can be redeemed using vTokens, you should multiply the total amount of vTokens by the previously computed 'oneVTokenInUnderlying' value.
+The [deployed markets](../deployed-contracts/markets.md) page is an address-discovery starting point. Verify the address, implementation, listing state, and decimals on the target chain before calculating balances.
+
+## Exchange rates
+
+Let:
+
+* `V_raw` be a vToken amount in raw vToken units;
+* `E` be the `1e18`-scaled exchange-rate mantissa; and
+* `U_raw` be the corresponding underlying amount in raw underlying units.
+
+The exact integer conversion is:
 
 $$
-underlyingTokens = vTokenAmount \times oneVTokenInUnderlying
+U_{raw} = \left\lfloor\frac{V_{raw} \times E}{10^{18}}\right\rfloor
 $$
 
-### Calculating Accrued Interest
-
-Interest rates for each market are updated in any block where there is a change in the ratio of borrowed assets to supplied assets. The magnitude of this change in interest rates depends on the interest rate model smart contract in place for the market, and the degree of change in the aforementioned ratio.
-
-For a visualization of the current interest rate model applied to each market, refer to the market pages at the [Venus app](https://app.venus.io).
-
-The accrual of interest to suppliers and borrowers in a market occurs when any wallet interacts with the market's vToken contract. This interaction could be any of the following functions: mint, redeem, borrow, or repay. A successful execution of any of these functions triggers the `accrueInterest` method, leading to the addition of interest to the underlying balance of every supplier and borrower in the market. Interest accrues for the current block, as well as any previous blocks where the `accrueInterest` method was not triggered due to lack of interaction with the vToken contract. Interest only accumulates during blocks where one of the aforementioned methods is invoked on the vToken contract.
-
-Let's consider an example of supply interest accrual: Alice supplies 1 BNB to the Venus Protocol. At the time of her supply, the `supplyRatePerBlock` is 37893605 Wei, which equates to 0.000000000037893605 BNB per block. For 3 blocks, no interactions occur with the vBNB contract. On the subsequent 4th block, Bob borrows some BNB. As a result, Alice’s underlying balance is updated to 1.000000000151574420 BNB (calculated by multiplying 37893605 Wei by 4 blocks and adding the original 1 BNB). From this point onwards, the accrued interest on Alice’s underlying BNB balance will be based on the updated value of 1.000000000151574420 BNB, rather than the initial 1 BNB. It is important to note that the `supplyRatePerBlock` value may alter at any given time.
-
-### Calculating the APY Using Rate Per Block
-
-The Annual Percentage Yield (APY) for either supplying or borrowing in each market can be computed using the `supplyRatePerBlock` (for Supply APY) or `borrowRatePerBlock` (for Borrow APY) values. These rates can be used in the following formula (assuming a daily compound):
+Solidity integer division and the following `BigInt` code both round down:
 
 ```javascript
-Rate = vToken.supplyRatePerBlock(); // Integer
-Rate = 37893566
-BNB Mantissa = 1 * 10 ^ 18 (BNB has 18 decimal places)
-Blocks Per Day = 80 * 60 * 24 (based on 80 blocks occurring every minute on BNB Chain)
-Days Per Year = 365
+const WAD = 10n ** 18n;
 
-APY = (((Rate / BNB Mantissa) * Blocks Per Day) + 1) ^ (Days Per Year - 1) * 100
+function vTokensToUnderlyingRaw(vTokenRaw, exchangeRateMantissa) {
+  return (vTokenRaw * exchangeRateMantissa) / WAD;
+}
 ```
 
-Here is an example of calculating the supply and borrow APY with Web3.js JavaScript:
+For human-readable values, if `dV` and `dU` are the vToken and underlying decimal counts:
+
+$$
+oneVTokenInUnderlying = \frac{E}{10^{18 + dU - dV}}
+$$
+
+and:
+
+$$
+U_{human} = V_{human} \times oneVTokenInUnderlying
+$$
+
+Do not apply the human-unit formula to raw integers. For example, with `dV = 8`, `dU = 18`, and `E = 2 × 10^26`, one vToken represents `0.02` underlying tokens. A raw vToken balance of `10^8` therefore converts to `2 × 10^16` raw underlying units.
+
+### Stored versus current exchange rate
+
+```solidity
+function exchangeRateStored() external view returns (uint256);
+
+function exchangeRateCurrent() external returns (uint256);
+```
+
+`exchangeRateStored()` uses the last persisted interest checkpoint and does not accrue interest. `exchangeRateCurrent()` calls the accrual path first. It is not a Solidity `view` function:
+
+* an off-chain `eth_call` simulates catch-up accrual and returns the resulting rate without persisting state; and
+* a successful transaction persists the new checkpoint before returning the rate.
+
+When `totalSupply` is zero, the implementation returns the configured initial exchange-rate mantissa. When comparing a simulated current rate with stored state, pin every read to the same block.
+
+## Interest accrual and checkpoints
+
+Interest is economically accounted for over elapsed slots, but the contract does not update storage autonomously in every block or second. Stored totals and indexes remain at the last checkpoint until a successful call executes `accrueInterest()` directly or reaches it through another function.
+
+For the borrow side, the core checkpoint calculation is:
+
+$$
+\Delta = currentSlot - priorAccrualSlot
+$$
+
+$$
+simpleInterestFactor = borrowRatePerSlot \times \Delta
+$$
+
+$$
+interestAccumulated = \left\lfloor\frac{simpleInterestFactor \times borrowsPrior}{10^{18}}\right\rfloor
+$$
+
+The implementation then increases `totalBorrows` by `interestAccumulated`, adds the reserve-factor share to `totalReserves`, and increases `borrowIndex` by its proportional simple-interest factor. A later successful accrual therefore catches up all elapsed slots; inactivity does not make the elapsed interest disappear.
+
+A supplier does not receive an account-level `supplyRate × principal × slots` storage update. The supplier keeps a vToken balance, and its underlying value changes through the market's updated exchange rate. Calls such as mint, redeem, borrow, repay, liquidation, current-balance getters, reserve operations, and direct `accrueInterest()` can reach the checkpoint path; the exact set depends on the implementation.
+
+One catch-up over multiple slots applies a simple-interest factor for that interval. Do not describe the contract as automatically compounding in every block. Checkpoint frequency, utilization changes, and governance parameter changes affect the realized path.
+
+## Annualizing a per-slot snapshot rate
+
+The ABI names `supplyRatePerBlock()` and `borrowRatePerBlock()` are retained across Venus implementations, but modern vTokens document the return value as a rate per **slot**. A slot can be a block or a second.
+
+Before annualizing a rate:
+
+1. identify whether the target implementation is block-based or time-based;
+2. obtain the matching `slotsPerYear` value from the deployed implementation or interest-rate model;
+3. obtain the `slotsPerDay` convention used by the display client; and
+4. read the rate mantissa at the same target block.
+
+Modern TimeManager-based deployments expose `isTimeBased()` and `blocksOrSecondsPerYear()`. BNB Chain mainnet Core models are block-based and may expose their own `blocksPerYear` assumption. Do not assume `slotsPerDay = slotsPerYear / 365`: a block-based model's annualization parameter and a client's current block-cadence configuration can diverge. Do not hardcode a chain-wide blocks-per-day value in a long-lived integration.
+
+For a `1e18`-scaled rate snapshot:
+
+$$
+r_{slot} = \frac{rateMantissa}{10^{18}}
+$$
+
+The deployed model's normalization produces:
+
+$$
+modelNormalizedAPR = r_{slot} \times configuredSlotsPerYear
+$$
+
+APY is an off-chain display convention. Define the daily snapshot using the consuming client's `slotsPerDay` value:
+
+$$
+dailyRate = r_{slot} \times slotsPerDay
+$$
+
+and the corresponding non-compounded display extrapolation is:
+
+$$
+displayAPR = dailyRate \times 365
+$$
+
+The official frontend rate utility assumes 365 daily compounding periods:
+
+$$
+frontendAPY = \left(1 + dailyRate\right)^{365} - 1
+$$
+
+At the pinned source snapshots used for this page, the official API base-market supply/borrow calculator instead raises the same daily factor to 364 (`DAYS_PER_YEAR - 1`):
+
+$$
+apiAPY = \left(1 + dailyRate\right)^{364} - 1
+$$
+
+A client that consumes those API-provided base-market values can therefore differ from a direct use of the frontend utility. Other API calculations can use different conventions. Neither convention changes on-chain accrual. Choose and label the `slotsPerDay` input and daily exponent required by the consuming system; do not claim one derived value is universal across Venus components.
+
+`modelNormalizedAPR` and `displayAPR` are equal only when `configuredSlotsPerYear = slotsPerDay × 365`. Check that equality explicitly for a block-based deployment rather than treating it as an invariant.
+
+Multiply APR or APY by 100 only when formatting it as a percentage. This implementation uses arbitrary-precision decimal arithmetic, makes the number of compounding periods explicit, and returns zero for a zero rate:
 
 ```javascript
-const ethMantissa = 1e18;
-const blocksPerDay = 80 * 60 * 24;
-const daysPerYear = 365;
+import BigNumber from 'bignumber.js';
 
-const vToken = new web3.eth.Contract(vBnbAbi, vBnbAddress);
-const supplyRatePerBlock = await vToken.methods.supplyRatePerBlock().call();
-const borrowRatePerBlock = await vToken.methods.borrowRatePerBlock().call();
-const supplyApy = Math.pow(((supplyRatePerBlock / bnbMantissa) * blocksPerDay) + 1, daysPerYear - 1) * 100;
-const borrowApy = Math.pow(((borrowRatePerBlock / bnbMantissa) * blocksPerDay) + 1, daysPerYear - 1) * 100;
-console.log(`Supply APY for BNB ${supplyApy} %`);
-console.log(`Borrow APY for BNB ${borrowApy} %`);
+const WAD = new BigNumber(10).pow(18);
+const DAYS_PER_YEAR = 365;
+
+function annualizeRate(rateMantissa, configuredSlotsPerYear, slotsPerDay, dailyExponent = DAYS_PER_YEAR) {
+  const ratePerSlot = new BigNumber(rateMantissa.toString()).div(WAD);
+  const modelNormalizedApr = ratePerSlot.times(configuredSlotsPerYear.toString());
+  const dailyRate = ratePerSlot.times(slotsPerDay.toString());
+  const displayApr = dailyRate.times(DAYS_PER_YEAR);
+  const apy = dailyRate.plus(1).pow(dailyExponent).minus(1);
+
+  return {
+    modelNormalizedAprPercentage: modelNormalizedApr.times(100),
+    displayAprPercentage: displayApr.times(100),
+    apyPercentage: apy.times(100),
+  };
+}
+
+console.assert(annualizeRate(0n, 31_536_000n, 86_400n).apyPercentage.isZero());
 ```
+
+Daily compounding is a display convention, not a promise that the contract compounds once per day or that the current rate will persist for a year. Base supply and borrow APY also exclude token incentives, Prime rewards, and other distribution programs unless those components are calculated separately.
+
+For model selection and utilization formulas, see [Interest-rate models](../risk/interest-rate-model.md). Source boundaries used for this page are [`venus-protocol@v10.3.0`](https://github.com/VenusProtocol/venus-protocol/tree/46afc66b1dbd61a707d0a3492b3ec21bf90fc17a), [`isolated-pools@943e7db`](https://github.com/VenusProtocol/isolated-pools/tree/943e7db1855c8ab4a09104f1d09e2b2db0506b95), the official frontend rate utilities at [`venus-protocol-interface@532895b`](https://github.com/VenusProtocol/venus-protocol-interface/tree/532895b508b3c7cc3ee94fcd6397978b9264d5ba/apps/evm/src/utilities), and the market API calculation at [`venus-protocol-api@d61125f`](https://github.com/VenusProtocol/venus-protocol-api/blob/d61125f1cccf3b36299a69cab1b09cced90ce1a5/src/modules/calculateInterestRates.ts).

--- a/risk/interest-rate-model.md
+++ b/risk/interest-rate-model.md
@@ -1,84 +1,104 @@
-# Interest Rate Model
+# Interest-rate models
 
-### Overview
+{% hint style="info" %}
+**This is a model-selection overview, not a per-market configuration registry.** Each market points to a deployment-specific interest-rate-model contract that governance can replace. Resolve the model address, implementation family, parameters, and clock at the target chain and block before using a formula.
+{% endhint %}
 
-Venus Protocol offers variable interest rates for markets using two different models: the Jump Rate Model and the Whitepaper Rate Model. Each market operates under one of these models with specifically set risk parameters at the market's inception. Notably, the community can update these parameters through the Governance process. Moreover, some markets feature a stable rate, introduced in Venus V4.
+An interest-rate model converts market utilization into borrow and supply rates. Venus deployments include WhitePaper, Jump Rate, and Two Kinks model families. That list describes model families found in current and legacy deployments; it does not mean that every family is active on every chain or that those are the only possible future implementations.
 
-#### **Jump Rate Model**
+The vToken's `interestRateModel()` getter is the source of truth for which model address a market used at a particular block. Governance can replace that address, and some model parameters can also be updated without replacing the model. Static documentation must not be used as a current market-to-model registry.
 
-The Jump Rate Model uses the following formulas to calculate the interest:
+## Clock and rate units
 
-For Borrow rate:
+Rates are `1e18`-scaled mantissas per accrual slot. The meaning of a slot depends on the deployed architecture:
 
-$$
-borrow\_rate (u) = b + a_1 \cdot kink + a_1 \cdot \min(0, u-kink) + a_2 \cdot \max(0,u-kink)
-$$
+* BNB Chain mainnet Core vTokens use block-based accrual and expose per-block rates; and
+* modern TimeManager-based vTokens and interest-rate models can be configured as block-based or time-based, where a time-based slot is one second.
 
-And, for Supply rate:
+Modern contracts retain ABI names such as `borrowRatePerBlock()` for compatibility even when the implementation describes the value as a per-slot rate. Read `isTimeBased()` and `blocksOrSecondsPerYear()` where the implementation exposes them. For a Core model that does not implement TimeManager, verify its deployed `blocksPerYear` assumption. Never infer the annualization unit from the function name alone.
 
-$$
-supply\_rate(u) = borrow\_rate(u) \cdot us \cdot (1 - reserve\_factor)
-$$
+## Utilization depends on the engine
 
-Where,
+Let:
 
-$$
-us = \frac{borrows}{cash + borrows - reserves + badDebt}
-$$
+* `C` be market cash;
+* `B` be active borrows;
+* `R` be reserves; and
+* `D` be recorded bad debt.
 
-The borrow rate employs different formulas when the utilization rate falls into two distinct ranges:
-
-If `u < kink`:
+BNB Chain mainnet Core Jump Rate and WhitePaper models use:
 
 $$
-borrow\_rate(u) = a_1 \cdot u + b
+u = \frac{B}{C + B - R}
 $$
 
-If `u > kink`:
+The Core Two Kinks implementation caps that ratio at one:
 
 $$
-borrow\_rate(u) = a_1 \cdot kink + a_2 \cdot (u-kink) + b
+u_{twoKinks} = \min\left(1, \frac{B}{C + B - R}\right)
 $$
 
-**Model Parameters**
-
-* `a1`: Variable interest rate slope1.
-* `a2`: Variable interest rate slope2.
-* `b`: Base rate per block (`baseRatePerYear / blocksPerYear`).
-* `kink`: Optimal utilization rate, at which the variable interest rate slope shifts from slope1 to slope2.
-* `reserve_factor`: Part of interest income withdrawn from the protocol, i.e., not distributed to suppliers.
-
-The utilization rate (`u`) is defined as:
+Modern isolated-engine models include bad debt in borrow utilization:
 
 $$
-utilization\_rate = \frac{(borrows + bad\_debt)}{(cash + borrows + bad\_debt - reserves)}
+u_{borrow} = \min\left(1, \frac{B + D}{C + B + D - R}\right)
 $$
 
-Where:
-
-* `borrows`: Amount of borrows in the market, in terms of the underlying asset, excluding bad debt.
-* `cash`: Total amount of the underlying asset owned by the market at a specific time.
-* `reserves`: Amount of the underlying asset owned by the market but unavailable for borrowers or suppliers, reserved for various uses defined by the protocol's tokenomics.
-* `bad_debt`: After liquidators repay as much debt as possible, reducing collateral to a minimal amount, the remaining debt is tagged as bad debt. Bad debt doesn’t accrue interest.
-
-#### Whitepaper Rate Model
-
-The Whitepaper Rate Model is simpler, where the borrow rate depends linearly on the utilization:
-
-For Borrow rate:
+Because bad debt does not accrue interest or produce supplier income, the corresponding supply utilization is:
 
 $$
-borrow\_rate (u) = a \cdot u + b
+u_{supply} = \frac{B}{C + B + D - R}
 $$
 
-For Supply rate:
+For those models, if `r_b` is the borrow rate per slot and `f` is the reserve factor:
 
 $$
-supply\_rate(u) = borrow\_rate(u) \cdot us \cdot (1 - reserve\_factor)
+r_s = r_b \times u_{supply} \times (1 - f)
 $$
 
-Where,
+Do not add `badDebt` to a Core formula that does not accept it, or omit it from a modern model that does. Inspect the exact ABI and source used by the target vToken.
+
+## WhitePaper model
+
+The WhitePaper model has one linear borrow-rate slope. With per-slot base rate `b` and multiplier `m`:
 
 $$
-us = \frac{borrows}{cash + borrows - reserves + badDebt}
+r_b(u) = b + m \times u
 $$
+
+The model constructor derives its per-slot values from annualized inputs and its configured slots-per-year assumption. An old WhitePaper deployment can remain relevant to an unlisted market with positions, so the family name alone is not evidence that a market can be ignored or archived.
+
+## Jump Rate model
+
+The Jump Rate model uses one slope below a utilization kink and a steeper, separately configured slope above it. With kink `k`, normal multiplier `m`, and jump multiplier `j`:
+
+$$
+r_b(u) =
+\begin{cases}
+b + m \times u, & u \leq k \\
+b + m \times k + j \times (u-k), & u > k
+\end{cases}
+$$
+
+The names `baseRatePerBlock`, `multiplierPerBlock`, and `jumpMultiplierPerBlock` are retained in some modern contracts even when TimeManager makes them per-second values. Treat the deployed clock configuration, rather than the storage-variable name, as authoritative.
+
+## Two Kinks model
+
+The Two Kinks family divides utilization into three segments around `kink1` and `kink2`. It supports a separately configured slope in each segment, including an increasing or decreasing middle segment, and then a final jump slope above the second kink.
+
+Do not approximate a Two Kinks deployment as a one-kink Jump Rate model. Read both kink points, all slope and base components, the time basis, and the exact implementation. Existing general-design articles are not a substitute for the deployed model source and state.
+
+## Integration checklist
+
+For a rate or APY calculation at a historical or current block, record:
+
+* chain, pool, Comptroller, and vToken address;
+* the vToken implementation and `interestRateModel()` address at that block;
+* the model implementation family and parameter values;
+* whether the accrual slot is a block or a second, plus slots per year;
+* cash, active borrows, reserves, bad debt where applicable, and reserve factor; and
+* whether the displayed result adds rewards or other incentives to the base supply or borrow rate.
+
+The [deployed markets](../deployed-contracts/markets.md) page helps locate markets but is not a complete historical model/version map. For mantissa conversion, checkpoint behavior, and APR/APY display math, see [Protocol math](../guides/protocol-math.md).
+
+Current source boundaries used for the architecture distinctions on this page are [`venus-protocol@v10.3.0`](https://github.com/VenusProtocol/venus-protocol/tree/46afc66b1dbd61a707d0a3492b3ec21bf90fc17a/contracts/InterestRateModels) and [`isolated-pools@943e7db`](https://github.com/VenusProtocol/isolated-pools/tree/943e7db1855c8ab4a09104f1d09e2b2db0506b95/contracts).


### PR DESCRIPTION
## Summary

- replace BEP-20, fixed-decimal, and BNB-only assumptions with deployment-scoped vToken and underlying units
- document exact raw exchange-rate rounding and stored versus current checkpoint behavior
- distinguish block-based and time-based accrual and correct the elapsed-slot catch-up explanation
- separate model-normalized APR, client display APR, frontend 365-day APY, and the pinned API base-market 364-day convention
- add WhitePaper, Jump Rate, and Two Kinks model selection boundaries without treating static docs as a live market registry

## Verification

- source boundaries: venus-protocol v10.3.0, isolated-pools 943e7db, venus-protocol-interface 532895b, venus-protocol-api d61125f
- three independent final reviews reported no remaining must-fix
- zero-rate, frontend reference-vector, 364/365, and exchange-rate integer tests
- git diff --check
- remark on both changed files
- all local Markdown targets resolve