### PR TITLE
docs: correct Fixed Term Vault supplier guidance

### DIFF
--- a/guides/fixed-rate-vaults/README.md
+++ b/guides/fixed-rate-vaults/README.md
@@ -1,19 +1,25 @@
 # Fixed Term Vaults
 
-Fixed Term Vaults let institutions borrow stablecoins for a fixed term at a fixed interest rate, backing the loan with on-chain collateral. Suppliers fund the loan during a fundraising window and earn the target APR at maturity. Each vault funds a single loan and closes once settlement is complete.
+Fixed Term Vaults facilitate fixed-term loans between an institution and on-chain suppliers. The institution borrows a configured supply asset against collateral at a scheduled rate and duration. Suppliers receive transferable vault shares representing a claim on the assets available when that vault reaches a terminal state.
+
+{% hint style="warning" %}
+**Principal and target return are not guaranteed.** A target APR is a scheduled display value, not a promise of payment. Counterparty performance, collateral value, liquidation, pause state, token behavior, shared system dependencies, administrative actions, and the assets actually available at settlement can affect when and how much a supplier can redeem.
+{% endhint %}
+
+Each loan uses a separate vault clone with its own assets, debt accounting, configuration, and supplier shares. It does not share liquidity with Venus Core Pool or another vault clone, but its on-chain behavior relies on shared controller, oracle, liquidation, ProtocolShareReserve, and access-control components. Users also depend operationally on the interface and its indexed data.
 
 The product has two sides:
 
-* **Institution** (borrower) — deposits collateral, claims the raised funds, repays at maturity, and recovers any remaining collateral.
-* **Supplier** (lender) — supplies the loan asset during fundraising, holds through the lock period, and redeems principal plus the target yield once the institution has repaid.
+* **Institution** (borrower) — deposits collateral and may claim raised funds, repay debt, and recover collateral subject to the vault state and health checks.
+* **Supplier** — supplies the loan asset during fundraising and later redeems a pro-rata share of the assets available in a terminal state.
 
-Available on BNB Chain.
+Current published production deployments are on BNB Chain. Deployment addresses, vault registry entries, implementations, state, terms, risk parameters, pause level, and permissions are live data. A vault card or documentation page does not prove that a vault is currently open for supply: an instance can be pre-fundraising, locked, settling, terminal, or closed. Verify the selected vault before signing.
 
 ## Pick Your Guide
 
 | Role | Guide |
 | --- | --- |
 | **Institution** — you want to borrow against collateral at a fixed rate and need to get a vault from Venus and walk through the full lifecycle | [Institution Guide](institution-guide.md) |
-| **Supplier** — you want to supply during fundraising and earn the target yield at maturity | [Supplier Guide](supplier-guide.md) |
+| **Supplier** — you want to supply during fundraising and understand the lock, settlement, and recovery paths | [Supplier Guide](supplier-guide.md) |
 
-For the contract-level details, see the [Fixed Term Vaults Technical Reference](../../technical-reference/reference-technical-articles/fixed-rate-vaults.md).
+For contract behavior, see the [Fixed Term Vaults Technical Reference](../../technical-reference/reference-technical-articles/fixed-rate-vaults.md). For address discovery, start with [Deployed Contracts](../../deployed-contracts/fixed-rate-vaults.md) and then confirm the controller registry and chain explorer at a recorded block.

--- a/guides/fixed-rate-vaults/supplier-guide.md
+++ b/guides/fixed-rate-vaults/supplier-guide.md
@@ -1,108 +1,98 @@
 # Supplier Guide
 
-This guide walks through how to participate in a Fixed Term Vault as a supplier. You supply the loan asset during the fundraising window, hold through the lock period, and redeem principal plus the target yield at maturity.
+This guide explains how to supply an asset to a Fixed Term Vault and later redeem the resulting vault shares. Supplying funds a single institutional loan; it is not a deposit into Venus Core Pool or shared liquidity.
 
-{% hint style="warning" %}
-**Capital is at risk.** The target APR is set at vault deployment and is not a guaranteed return. Actual proceeds at settlement depend on counterparty performance and may be less than the amount supplied. This product is not available to retail investors or persons in restricted jurisdictions (US, UK, Canada, mainland China, or OFAC-sanctioned countries).
+{% hint style="danger" %}
+**Capital and availability are at risk.** The displayed Target APR is not guaranteed, and a supplier can receive less than the amount supplied. There is no contract withdrawal after you deposit during Fundraising or while the loan is active. Redemption depends on the vault reaching a terminal state, its current pause level, and the assets available for settlement.
 {% endhint %}
 
-## Finding a Vault
+The official interface and deployed state can change after this page is published. Treat screenshots, examples, and static address lists as illustrative only. Verify the selected vault in the live app, controller registry, and chain explorer.
 
-Fixed Term Vaults live on the Venus **Vaults** page: [venus.io/#/vaults?chainId=56](https://venus.io/#/vaults?chainId=56). Open the app, make sure your network is set to BNB Chain, and select **Vaults** in the top navigation.
+## What the vault shares represent
 
-Each vault is shown as a card. A Fixed Term Vault is labelled **Fixed-Term** next to the supply asset (for example, *USDT Fixed-Term*) and shows its headline terms — the target APR, total supplied against the cap, the minimum requested raise, when the supply period ends, and the venue.
+Each Fixed Term Vault is a separate ERC-4626-based clone with vault-specific overrides. When you supply the configured asset, the vault mints ERC-20 shares representing your pro-rata claim on that clone's settlement assets.
 
-<figure><img src="../../.gitbook/assets/frv-supplier-vaults-page.png" alt="Venus Vaults page with a Fixed-Term vault card in the middle"><figcaption><p>The Vaults page. The middle card is a Fixed-Term vault — note the <code>Fixed-Term</code> label, the target APR, and the supply period.</p></figcaption></figure>
+The shares can be transferred, but transferability is not an early redemption mechanism. Venus does not guarantee a buyer, secondary market, price, or liquidity for the shares. A transfer moves the on-chain claim to the recipient and can introduce separate operational, legal, and counterparty risks.
 
-## Reading the Vault Terms
+## Before supplying
 
-Click the vault card to open its detail panel, and review the terms before committing — they are fixed at deployment and cannot change once the vault is live.
+1. Open the official [Venus Vaults page](https://app.venus.io/#/vaults?chainId=56), select BNB Chain, and identify a card that the current interface labels **Fixed-Term**.
+2. Verify the InstitutionalVaultController and candidate vault through [Deployed Contracts](../../deployed-contracts/fixed-rate-vaults.md), the controller's current `allVaults` registry or `VaultCreated` events, and a BNB Chain explorer. A static list may omit vaults created later, while the app's indexed inventory can lag the on-chain registry.
+3. Confirm that the exact vault is in **Fundraising**, its pause level is **Unpaused**, the supply deadline has not passed, and `maxDeposit(yourAddress)` is greater than zero.
+4. Verify the supply token, collateral token, both token addresses and decimals, vault address, institution, fundraising minimum and maximum, current total raised, lock end, settlement deadline, and risk disclosures.
+5. Review the live **Target APR**. The official interface already displays this value net of the vault's reserve factor. Do not deduct the reserve factor a second time.
+6. Read the current [Fixed Term Vault Terms of Use](https://app.venus.io/#/fixed-term-vault-terms-of-use) shown by the app and determine whether you are eligible. Do not rely on a jurisdiction list copied into a guide, because the applicable terms can change.
 
-The **Position** tab shows the **Target APR** (net of the protocol reserve factor) and the **Supply period ends** deadline.
+Some commercial configuration, including the supply and collateral assets, scheduled rate, reserve factor, caps, and lifecycle durations, is set when a clone is created. An existing EIP-1167 clone keeps its original implementation; changing the controller's vault template affects future clones, not existing ones. Other state and dependencies remain live: the controller can update per-vault liquidation parameters and institution metadata, controller and shared-component implementations or addresses can change, and authorized callers can pause or administer a vault.
 
-<figure><img src="../../.gitbook/assets/frv-supplier-position.png" alt="Fixed-Term vault Position tab showing Target APR and supply period"><figcaption><p>Position tab: target APR and the supply-period deadline.</p></figcaption></figure>
+Fee-on-transfer and rebasing tokens are not supported as the supply or collateral asset. Do not infer support from a familiar token symbol; verify the exact address and implementation.
 
-The **Overview** tab shows total supplied and the **campaign timeline** — Supply → Locked → Repaying → Claim. The gap between the supply close and the lock end is your lock duration.
+## Supply during Fundraising
 
-<figure><img src="../../.gitbook/assets/frv-supplier-overview.png" alt="Overview tab showing total supplied and the campaign timeline"><figcaption><p>Overview tab: total supplied and the campaign timeline (Supply → Locked → Repaying → Claim).</p></figcaption></figure>
+1. Connect the intended wallet and open the vault's **Position** tab.
+2. Enter an amount. The form limits the input using the wallet balance and remaining vault capacity; a configured minimum supplier amount can also apply. The minimum is waived for a final deposit that fills the residual capacity.
+3. Approve the **vault clone** to spend the exact supply token. The controller, LiquidationAdapter, institution, and frontend address are not valid substitutes for this spender.
+4. Review the approval separately. Confirm the chain, token, spender, and allowance before signing.
+5. Accept the current Fixed Term Vault Terms in the form and submit **Supply**. The cited interface implementation calls `depositWithConsent(assets, yourAddress, consentHash)` for compatible vaults. This emits a `ConsentRecorded` event containing the hash of the displayed consent text before completing the deposit; if the deposit reverts, the event also rolls back. Historical clones can retain an older implementation without this selector, so verify the exact clone's implementation and ABI.
+6. Verify the confirmed receipt, actual supply assets transferred, shares minted, vault state, and remaining allowance. Reduce or revoke an allowance you no longer need.
 
-**Market info** shows the venue (the institution that borrows the funds), the collateral backing the loan, and the risk disclosures.
+The contract clamps an oversized deposit to the capacity remaining at execution. Another transaction can change capacity before yours is mined, so the assets accepted and shares minted can be lower than the amount first requested. Do not treat wallet confirmation as proof of the final amount; inspect the receipt and balances.
 
-<figure><img src="../../.gitbook/assets/frv-supplier-market-info.png" alt="Market info showing venue, collateral, and risk disclosures"><figcaption><p>Market info: the venue (recipient), the collateral asset, and the risk disclosures.</p></figcaption></figure>
+{% hint style="warning" %}
+Once a deposit succeeds, `withdraw` and `redeem` are unavailable even if the fundraising window is still open. They become available only in the terminal **Matured**, **Failed**, or **Liquidated** states. Do not supply funds that you may need before the latest plausible settlement or recovery date.
+{% endhint %}
 
-## Step 1: Supply During Fundraising
+## Monitor the lifecycle
 
-While the supply period is open, connect your wallet using **Connect wallet** in the top-right, then open the vault and go to the **Position** tab.
+Vault states advance in one direction, but time passing alone does not write a new state on-chain. A relevant transaction, including the permissionless `updateVaultState()`, must persist a transition. The app can derive a display status from timestamps, so verify the stored state and the result of your transaction rather than relying only on a badge.
 
-1. Enter the amount of the supply asset you want to deposit, or use the percentage slider. The **Available** balance is shown above the input.
-2. Tick the box confirming you agree to the Fixed-Term Vault Terms of Use and that you are not a restricted person.
-3. If this is your first supply of this asset, approve the token spend, then click **Supply** and confirm the transaction in your wallet.
+* **Fundraising** — new deposits can be accepted while the deadline, cap, minimum, token approval, and pause checks pass. Existing suppliers cannot withdraw.
+* **Lock** — if both the funding and collateral requirements are met, the loan begins. Scheduled interest for the full term is calculated from the actual raise. Suppliers still cannot withdraw.
+* **PendingSettlement / SettlementDeadlineExceeded** — debt repayment or liquidation is still pending. Passing the deadline does not itself give suppliers an exit or guarantee liquidation proceeds.
+* **Matured / Failed / Liquidated** — supplier `withdraw` and `redeem` paths are enabled, subject to balances and the pause level. A Partial pause does not block terminal supplier exits; a Complete pause does.
+* **Closed** — deposits, withdrawals, and redemptions are disabled by the vault state. The published design expects authorized callers to close only after suppliers have exited, but the source does not enforce a zero share supply before closure. Verify your redemption before assuming closure is safe.
 
-You receive vault share tokens representing your claim. The shares are freely transferable, so you can hold them in any wallet. A **minimum supply floor** applies unless you're filling the final residual capacity, in which case the floor is waived so the cap can actually be reached.
+You do not service the institution's debt, but you should monitor repayments, collateral and oracle conditions, the settlement deadline, liquidations, pause changes, administrative events, and the amount currently previewed for your shares.
 
-<figure><img src="../../.gitbook/assets/frv-supplier-supply-form.png" alt="Supply form on a Fixed-Term vault showing the amount input, terms checkbox, and Supply button"><figcaption><p>The supply form: enter an amount, accept the terms, then Supply. Funds are locked once the lock period begins.</p></figcaption></figure>
+## Redeem or withdraw in a terminal state
 
-## Step 2: Hold Through the Lock Period
+When the current interface shows **Claim**, **Refund**, or a liquidated withdrawal state:
 
-When the supply window closes with the raise above the minimum, the vault enters the lock period. At this point:
+1. Confirm the stored state is **Matured**, **Failed**, or **Liquidated**, or simulate that the exit call will advance a stale state to one of them in the same transaction. Confirm the vault is not completely paused.
+2. If the stored state is already terminal, read `maxRedeem(yourAddress)`, `maxWithdraw(yourAddress)`, `previewRedeem(shares)`, and `previewWithdraw(assets)` immediately before submission. If the state is stale, simulate the exact exit transaction and read the views again after the state advances. Quotes can change as settlement and other redemptions are processed.
+3. In the app, use **Claim** or **Withdraw**. Confirm the vault address, share amount, receiver, and previewed assets in your wallet or transaction simulation.
+4. Verify the receipt, shares burned, supply asset received, and any collateral compensation received.
 
-* **Supplying and withdrawing are blocked.** There is no early exit.
-* **The yield amount is fixed.** Interest is calculated upfront on the full raise for the entire lock duration.
-* **Shares remain transferable.** You can move or sell them at any time, even while funds are locked.
+The outcome depends on the terminal path:
 
-In the app, the vault's badge changes to **Locked** and the **Position** tab shows your **Currently supplied** balance, the **Target APR**, your **Total target rewards**, and the **Lock end date**. The action buttons are gone — funds can only be claimed once the vault reaches the Claim or Refund period.
-
-<figure><img src="../../.gitbook/assets/frv-supplier-locked.png" alt="Position tab of a locked vault showing supplied balance, target rewards, and lock end date"><figcaption><p>A locked position. Funds are committed until maturity — there is no early exit.</p></figcaption></figure>
-
-## Step 3: Wait for Settlement
-
-When the lock duration elapses, the loan is due and the institution has until the settlement deadline to repay in full. Suppliers cannot withdraw during this window.
-
-Either the institution repays in full and the vault matures, or the settlement deadline passes with debt outstanding and the vault becomes eligible for overdue liquidation at the late-penalty rate. Either way, no action is required from the supplier.
-
-## Step 4: Redeem at Maturity
-
-Once the institution has repaid the full debt, the vault matures and its badge changes to **Claim**. Open the vault, go to the **Position** tab, and click **Claim** to burn your shares and receive principal plus your share of the interest. Confirm the transaction in your wallet.
-
-<figure><img src="../../.gitbook/assets/frv-supplier-claim.png" alt="Position tab of a matured vault showing the Claim button"><figcaption><p>A matured vault. Click <strong>Claim</strong> to burn your shares and withdraw principal plus interest.</p></figcaption></figure>
-
-### Example: Estimating Your Payout
-
-A vault raises 100,000 USDC at an 8% target APR for a 90-day lock. You supply 10,000 USDC and receive shares representing 10% of the vault.
-
-* Total interest at maturity: $$100{,}000 \times 0.08 \times 90/365 \approx 1{,}972.60 \text{ USDC}$$
-* Assume a 10% protocol fee on interest: $$1{,}972.60 \times 0.10 \approx 197.26 \text{ USDC}$$
-* Net target interest paid to suppliers: $$1{,}972.60 - 197.26 \approx 1{,}775.34 \text{ USDC}$$
-* Settlement pool: $$100{,}000 + 1{,}775.34 = 101{,}775.34 \text{ USDC}$$
-* Your share (10%): **~10,177.53 USDC**. That should be a return of ~1.78% over the 90-day term on your 10,000 USDC principal.
-
-## Key Risks You Must Understand
-
-A Fixed Term Vault is a fixed-term commitment. Be aware of the following before participating:
-
-* **No early exit during the lock period.** Funds are locked until maturity.
-* **Fundraising shortfall.** If the raise falls short of the minimum, the vault fails and you get your principal back with no interest.
-* **Collateral underdelivery.** If the institution doesn't top up collateral in time, you get your principal back plus a pro-rata share of the confiscated margin in the collateral asset.
-* **Overdue liquidation.** If the institution misses the settlement deadline, the vault is liquidated at the late-penalty rate, which can reduce the amount available for suppliers.
-* **Liquidation may reduce recovery.** If collateral didn't fully cover the debt, your payout may be less than the target rewards.
-
-## Best Practices
-
-* **Read the vault terms carefully.** Target APR, lock duration, and the minimum-raise threshold determine your worst-case outcome.
-* **Track the settlement deadline.** Once it approaches, watch for repayment activity. If the institution misses it, you'll need to wait for either a catch-up repayment or a liquidation to settle the vault.
-* **Redeem as soon as possible.** If funds remain unclaimed for too long, Venus may sweep the remaining assets and close the vault.
-
-## Recovering Your Funds
-
-A vault has three end states — **Matured**, **Failed**, and **Liquidated**. In any of them your shares become redeemable: open the vault, go to the **Position** tab, and click **Claim**. This burns your shares and pays you a share of the vault's assets proportional to how much of the vault you hold. What that payout consists of depends on how the vault ended.
-
-| End state | What you receive |
+| Terminal state | Contract settlement path |
 | --- | --- |
-| **Matured** — institution repaid in full | Your principal plus your pro-rata share of the interest, paid in the supply asset. |
-| **Failed** — raise stayed below the minimum | Your full principal back in the supply asset. No interest, because no loan was made. |
-| **Failed** — institution didn't post enough collateral | Your full principal back in the supply asset, **plus** your pro-rata share of the institution's confiscated margin, paid in the collateral asset. |
-| **Liquidated** — bad debt was repaid to settle the vault | Your pro-rata share of whatever supply asset the vault holds. This can be less than your principal if the collateral didn't cover the full debt. |
+| **Matured** | Suppliers redeem a pro-rata share of the supply asset available after settlement and the protocol reserve. With full repayment and no asset shortfall, this targets principal plus the displayed net interest; use the live preview for the actual amount. |
+| **Failed — funding below minimum** | No loan is made. Suppliers redeem their pro-rata share of the supply asset held for refunds, with no scheduled interest. |
+| **Failed — collateral below requirement** | Suppliers redeem supply assets and receive a pro-rata distribution of the remaining confiscated margin in the collateral token. Each distribution rounds down to token units. |
+| **Liquidated** | Suppliers redeem a pro-rata share of the supply asset in `settlementAmount`. In the current published bad-debt path, the principal portion of debt must be covered before the transition, but suppliers still receive only the terminal settlement assets and do not have a guaranteed direct claim on all remaining collateral. Do not convert that source-level condition into an unconditional principal guarantee. |
 
----
+All outcomes remain contingent on the vault's actual token balances, settlement accounting, pause level, and successful transaction execution. “Principal” in the first two failure descriptions is the intended accounting outcome when the expected assets remain available, not a guarantee by Venus or another party.
 
-For the on-chain details, including the full state machine, function signatures, math, and liquidation paths, see the [Fixed Term Vaults Technical Reference](../../technical-reference/reference-technical-articles/fixed-rate-vaults.md).
+## Estimate target interest correctly
+
+Suppose the app displays an **8% Target APR**, the lock duration is 90 days, and you supply 10,000 units of the supply asset. The displayed Target APR is already net of the reserve factor:
+
+$$
+\text{target net interest} \approx 10{,}000 \times 0.08 \times \frac{90}{365} \approx 197.26
+$$
+
+The corresponding target payout is approximately `10,197.26` supply-asset units. Do **not** subtract the reserve factor again. This estimate assumes full scheduled settlement, unchanged share ownership, and enough vault assets. The contract rounds gross scheduled interest and the protocol fee down in supply-token base units; `previewRedeem` rounds assets down, while `previewWithdraw` rounds shares up. Read `asset()`, token and share decimals, `maxRedeem()`, and the previews from the exact vault; do not assume every stablecoin uses six decimals. The live terminal preview, not this estimate, determines the current on-chain quote.
+
+## Risks and administrative authority
+
+* **Counterparty and settlement risk** — the institution can fail to claim, repay late, or fail to repay enough for the target outcome.
+* **Collateral and oracle risk** — price movements, oracle behavior, risk-parameter changes, liquidation timing, incentives, and collateral liquidity can reduce recovery.
+* **Lock and market-liquidity risk** — the vault offers no supplier exit before a terminal state, and transferable shares may have no buyer or reliable price.
+* **Smart-contract and shared-component risk** — a clone also depends on the controller, oracle, PositionToken, LiquidationAdapter, ProtocolShareReserve, token contracts, permissions, frontend, and network.
+* **Pause risk** — Partial pause blocks new deposits; Complete pause also blocks supplier withdrawals, redemptions, repayment, and liquidation until unpaused. The current source does not add the vault pause modifiers to ordinary ERC-20 share transfers.
+* **Administrative recovery risk** — the controller exposes an ACM-gated `sweep(vault, token)` path that transfers the vault's full balance of the selected ERC-20 to the configured treasury. The published source does not impose a waiting period or exclude supply and collateral tokens. Verify live permissions and events; do not rely on an assumed grace period.
+* **Approval and token risk** — wrong-token approvals, unlimited allowances, nonstandard token behavior, and malicious lookalike vaults or interfaces can cause loss.
+* **Terms and eligibility risk** — the current app terms, not a static summary here, govern access to the interface and can change.
+
+For the full state machine, settlement waterfall, rounding, pause system, and liquidation paths, see the [Fixed Term Vaults Technical Reference](../../technical-reference/reference-technical-articles/fixed-rate-vaults.md). Source boundaries for the current consent-enabled flow are [`fixed-rate-vaults@91611be`](https://github.com/VenusProtocol/fixed-rate-vaults/tree/91611be77036e05d16f1ce43890b160cb4bc7228), the official interface's [consent-enabled deposit mutation](https://github.com/VenusProtocol/venus-protocol-interface/blob/c51133cb99c6881b96f9636b9cbec3bcf9c5e572/apps/evm/src/clients/api/mutations/useStakeIntoInstitutionalVault/index.ts), and its [Fixed Term Vault UI](https://github.com/VenusProtocol/venus-protocol-interface/tree/c51133cb99c6881b96f9636b9cbec3bcf9c5e572/apps/evm/src/containers/VaultCard/InstitutionalVaultModal). Source snapshots describe code behavior; immutable historical clones can use an earlier implementation. Verify the live clone, shared contracts, configuration, balances, state, and permissions at a recorded block.


### PR DESCRIPTION
Depends on #387. Please review and merge this PR only after #387; once #387 lands, this branch should be rebased and its cross-links rechecked.

## Summary

- replace guaranteed-principal and guaranteed-return wording with the actual terminal-state settlement outcomes
- clarify that deposits cannot be withdrawn or redeemed during the active lifecycle and that transferable shares do not guarantee liquidity
- correct the target APR description and example: the displayed target is already net of the configured reserve percentage
- document the consent-enabled deposit path, cap clamping, exact approval spender, allowance cleanup, state transitions, pause modes, and asset-sweep risk
- direct readers to live terms and registry/controller data instead of treating screenshots or static addresses as authoritative

## Verification

- checked the consent-enabled source boundary against `fixed-rate-vaults@91611be` and the historical `main@31fb898`
- checked the official interface flow at `venus-protocol-interface@c51133c`
- checked the BNB Chain controller registry, clone implementations, states, pause flags, caps, and redemption preview at a fixed block
- completed three independent final reviews with no remaining content must-fix findings
- `npx remark guides/fixed-rate-vaults/README.md guides/fixed-rate-vaults/supplier-guide.md --frail`
- `git diff --check`
