### PR TITLE
docs: correct Fixed Term Vault institution guidance

### DIFF
--- a/guides/fixed-rate-vaults/institution-guide.md
+++ b/guides/fixed-rate-vaults/institution-guide.md
@@ -1,109 +1,140 @@
 # Institution Guide
 
-This guide walks through the institution's lifecycle in a Fixed Term Vault. It covers getting allocated a vault by Venus, depositing the margin, topping up collateral during fundraising, claiming the raised funds, repaying the loan, and recovering any remaining collateral.
+This guide explains the institution side of a Fixed Term Vault: accepting a vault allocation, posting margin and collateral, claiming the raised supply asset, servicing the debt, and recovering eligible collateral.
 
-## Getting a Vault
+{% hint style="danger" %}
+A Fixed Term Vault is a time-sensitive, collateralized obligation. Missing a funding, collateral, or repayment deadline can make funds unavailable, forfeit the configured margin, or expose collateral to liquidation. Contract state, permissions, prices, and pause status are authoritative; an interface label or off-chain agreement does not override them.
+{% endhint %}
 
-To get started, reach out to the Venus team. Once the terms are agreed upon off-chain, Venus will deploy a vault for you.
+## Before You Operate a Vault
 
-After deployment, you receive two things:
+Vault allocation, eligibility, and commercial terms are coordinated off-chain. Before moving funds, obtain the current terms through the official Venus process and independently verify the resulting on-chain vault.
 
-* The **vault address**: the target of every later action.
-* A **position NFT** minted to the operator address you nominated. The NFT is the credential for all institution-side actions. Whoever holds it controls the vault.
+For the specific vault clone, record and check:
 
-NFT transfers are blocked unless Venus approves a specific recipient. The vault is now ready for your first action.
+* the vault and controller addresses against the controller registry, rather than relying on a screenshot or an address copied from a message;
+* the current owner and token ID of the position NFT;
+* the supply and collateral token addresses, symbols, and decimals;
+* the margin rate, ideal collateral amount, caps, fundraising duration, lock duration, settlement window, and scheduled rate;
+* the liquidation threshold, liquidation incentive, late-penalty rate, oracle, stored state, timestamps, outstanding debt, and pause level; and
+* the clone implementation and whether it supports the functions described in this guide.
 
-> Every institution action below is called directly on **your vault** contract. Opening and cancelling the vault happen on the **InstitutionalVaultController** and are performed by Venus governance, with no action from you.
+Use [Deployed Contracts](../../deployed-contracts/fixed-rate-vaults.md) as a starting point, then verify the live controller registry and clone at a recorded block. Repository deployments and frontend data are useful references, but neither proves current on-chain state by itself.
+
+The institution-side functions `depositCollateral`, `claimRaisedFunds`, and `withdrawCollateral` require `msg.sender` to be the **current owner** of the vault's position NFT. An ERC-721 approval or delegated operator is not a substitute for ownership in the published implementation. The NFT is therefore the control credential for the position.
+
+Every NFT transfer requires an ACM-authorized controller caller to approve one exact recipient first. That approval is consumed by the matching transfer. After transfer, the new owner immediately controls the institution-side functions and receives any later cancellation refund; the prior owner loses that control.
 
 ## Step 1: Deposit the Margin
 
-Deposit the margin into the vault in a single transaction. Partial deposits below the required threshold are rejected.
+The vault begins in `WaitingForMargin`. Approve the vault clone—not the controller—to spend the configured collateral asset, then call:
 
-The margin is a fixed percentage of the ideal collateral amount set at vault deployment.
-If you never deposit the margin, the vault simply sits idle. Venus can cancel and clean it up.
+```text
+depositCollateral(amount)
+```
 
-* **Function:** `depositCollateral(amount)` (approve the collateral asset to the vault first)
-* **Callable in:** `WaitingForMargin` (the same function is also used in `Fundraising` and `Lock`)
-* **Keep in mind:** `amount` must cover the full margin (`marginRate × idealCollateralAmount`) in one transaction; anything below the threshold reverts. On success the vault advances to `MarginDeposited`.
+The first call must make `totalCollateralDeposited` at least:
+
+```text
+floor(idealCollateralAmount × marginRate / 1e18)
+```
+
+Because a sub-threshold call reverts, post at least the full required margin in one transaction. The function accepts collateral-token base units and does not cap the amount at the threshold, so check the asset address and decimals before approving or submitting. The published implementation does not support fee-on-transfer or rebasing collateral tokens.
+
+On success, the state changes to `MarginDeposited`. Check the receipt, `CollateralDeposited` event, recorded collateral total, and remaining allowance. Reduce or revoke an allowance that is no longer needed.
+
+If the vault is not opened, an ACM-authorized controller caller may cancel it while it is still `WaitingForMargin` or `MarginDeposited`. Cancellation sends the recorded collateral to the current position-NFT owner and moves the vault to `Failed`.
 
 ## Step 2: Wait for the Vault to Open
 
-After the margin lands, Venus opens the vault and starts the fundraising window. Suppliers can now supply the loan asset. No action is required from you in this step.
+An ACM-authorized caller opens a `MarginDeposited` vault through `InstitutionalVaultController.openVault(vault)`. Opening sets the absolute fundraising end, lock end, and settlement deadline from the clone's configured durations and moves the vault to `Fundraising`.
 
-* **Function:** `openVault(vault)`, called on the **InstitutionalVaultController** by Venus governance, not by you. (Governance can instead `cancelVault(vault)` from `MarginDeposited` if needed, which refunds your margin.)
+Do not calculate deadlines from an expected opening time. Read the timestamps emitted and stored by the live vault after `openVault` succeeds.
 
-## Step 3: Top Up Collateral During Fundraising
+## Step 3: Complete the Collateral During Fundraising
 
-While fundraising is open, bring the collateral balance up from the margin to the full ideal collateral amount.
+Before the fundraising end, call `depositCollateral(amount)` as needed to bring `totalCollateralDeposited` to at least `idealCollateralAmount`. Use the vault clone as the collateral-token approval spender for every top-up.
 
-The full amount must be in place **before the fundraising window closes**. If it isn't, the vault fails, and the outcome depends on the raise:
+At the fundraising deadline, the vault evaluates both sides:
 
-* **The raise also fell short of the minimum:** you recover all deposited collateral, including the margin.
-* **The raise succeeded but collateral was underdelivered:** the margin is confiscated and distributed to suppliers. You recover only the remaining non-margin collateral.
+| Result | Institution outcome |
+| --- | --- |
+| Raised amount meets `minBorrowCap` and collateral meets `idealCollateralAmount` | The vault can enter `Lock` |
+| Raised amount is below `minBorrowCap` | The vault enters `Failed`; the position holder can recover all recorded collateral, including the margin |
+| Raise succeeds but collateral is below `idealCollateralAmount` | The vault enters `Failed`; the configured margin is reserved for supplier compensation, and only the remaining collateral is recoverable by the position holder |
 
-* **Function:** `depositCollateral(amount)` (same call as the margin deposit; approve the collateral asset first)
-* **Callable in:** `Fundraising`
-* **Keep in mind:** bring `totalCollateralDeposited` up to the full `idealCollateralAmount` **before the fundraising window closes**. Falling short here is what triggers the failure outcomes above.
-
-{% hint style="warning" %}
-If fundraising succeeds but you don't top up the collateral in time, the margin is confiscated. There is no recovery path once that happens.
-{% endhint %}
-
-## Step 4: Claim the Raised Funds
-
-Once fundraising closes successfully, the vault enters the lock period and the raised funds become available.
-
-* **Function:** `claimRaisedFunds()` (transfers the entire raised amount to you)
-* **Callable in:** `Lock`
-* **Keep in mind:** one-shot, all-or-nothing, with no partial draw.
-
-**During the lock period**, you can add collateral at any time to defend the position's health if the collateral price drops. You can also withdraw any collateral above the minimum floor, as long as the position stays within the liquidation threshold. If either constraint is breached, the withdrawal is rejected.
-
-* **Add collateral:** `depositCollateral(amount)`, callable in `Lock`; the most direct way to restore health when the collateral price falls.
-* **Withdraw collateral:** `withdrawCollateral(amount)`, callable in `Lock` (and later in `Matured` / `Failed`); in `Lock` it must keep collateral above the minimum floor and the position within the liquidation threshold, or it reverts.
-
-If you don't claim before the lock period ends, the funds stay in the vault. Interest is still owed at maturity either way, so claiming late means paying interest on capital you never used.
-
-## Step 5: Repay Before the Settlement Deadline
-
-When the lock period ends, repayment is due. You have until the settlement deadline to repay in full.
-
-Repayments can be partial, and any wallet can repay on your behalf. Once the debt clears, the vault matures and suppliers can begin redeeming.
-
-* **Function:** `repay(amount)` (approve the supply asset to the vault first)
-* **Callable in:** `Lock`, `PendingSettlement`, `SettlementDeadlineExceeded`
-* **Keep in mind:** the call is **permissionless**, so any wallet can call it on your behalf. Partial repayments are allowed and overpayment is clamped to the outstanding debt. Interest is fixed for the full lock duration, so repaying early does not reduce what you owe, but it frees collateral and removes late-payment risk.
+The stored state does not advance merely because time passes. Anyone may call `updateVaultState()` to apply a ready transition. However, calling `depositCollateral` after the deadline does not create a grace period. If collateral was below the ideal amount at the boundary, the call evaluates the failure condition and the late top-up cannot rescue it. If both requirements were already met at the boundary, the same selector can instead serve as a `Lock`-state top-up after state advancement.
 
 {% hint style="warning" %}
-Missing the settlement deadline makes the vault liquidatable at the late-penalty rate, even if your collateral is healthy.
+Partial and complete pause both block collateral deposits. Monitor the pause level and leave operational time before the deadline; a transaction submitted near the boundary may execute too late.
 {% endhint %}
 
-## Key Risks You Must Understand
+## Step 4: Claim During the Lock Window
 
-A Fixed Term Vault is a fixed-term commitment with a few timing-sensitive obligations. Be aware of the following before participating:
+After a successful fundraise, state advancement enters `Lock`. At that point the vault records the scheduled full-term interest as debt. The current position-NFT owner may make one all-or-nothing claim:
 
-1. **Margin confiscation**
+```text
+claimRaisedFunds()
+```
 
-   If fundraising clears the minimum but you don't top up the collateral to the ideal amount before the fundraising window closes, the margin is permanently confiscated and distributed to suppliers.
+The call is available only from `lockStartTime` inclusive to `lockEndTime` exclusive, while the effective state is `Lock` and the vault is unpaused. Before transferring the entire raised supply-asset amount, it simulates the post-claim debt—scheduled interest plus principal—against the current collateral and liquidation threshold. It reverts if the claim would create an LT shortfall.
 
-2. **Overdue liquidation**
+Check `getHypotheticalVaultLiquidity(0, totalRaised)` and current oracle data before claiming, but treat a simulation as a point-in-time estimate. Prices, risk parameters, balances, state, and pause status can change before execution. Adding collateral or repaying existing interest can improve the check; confirm the result again immediately before the claim.
 
-   Missing the settlement deadline makes the vault liquidatable at the late-penalty rate, even if your collateral is healthy.
+If the lock end passes before the claim succeeds, the principal stays in the vault and can no longer be claimed through this path. The institution still owes the scheduled interest that was recorded at lock entry, but it does **not** owe unclaimed principal. There is no “late claim”: state advancement moves the vault to settlement states and `claimRaisedFunds()` then reverts.
 
-3. **Health-based liquidation**
+After a successful claim, outstanding debt becomes the raised principal plus the full scheduled interest. Repaying early does not discount that interest.
 
-   If the collateral price drops during the lock period and pushes the position below the liquidation threshold, the vault is liquidatable at the standard incentive rate.
+## Step 5: Manage Health and Repay
 
-4. **No early changes to terms**
+During `Lock`, the position-NFT owner can add collateral with `depositCollateral(amount)`. It can withdraw only collateral that remains above both:
 
-   Target APR, lock duration, settlement window, and the borrow caps are all set at deployment and cannot be renegotiated on-chain. Confirm the terms with Venus off-chain before the vault is created.
+1. the minimum collateral floor, scaled to the actual amount raised; and
+2. the liquidation-threshold health requirement after the proposed withdrawal.
 
-## Best Practices
+Use `getVaultLiquidity()` and `getHypotheticalVaultLiquidity(withdrawAmount, 0)` before attempting a withdrawal. Oracle movement between simulation and execution can still cause a revert or create liquidation exposure after the transaction.
 
-* **Monitor collateral price during the lock period.** Top up early when the price moves against you. Once the funds are claimed, that is the only way to defend the position.
+Debt service is a separate defense. Any address—not only the NFT owner—may approve the **supply asset** to the vault clone and call:
 
-* **Repay as soon as you can.** Interest is fixed for the full lock duration regardless of when you repay, but repaying early frees up your collateral and removes the late-payment risk.
+```text
+repay(amount)
+```
 
-* **Keep the position NFT in a wallet you control.** Whoever holds the NFT controls the vault. If you delegate it to an operator, treat that wallet with the same security as a treasury wallet.
+Repayment is accepted in `Lock`, `PendingSettlement`, and `SettlementDeadlineExceeded`, and an amount above `outstandingDebt()` is clamped to the debt at execution. The published implementation does not support fee-on-transfer or rebasing supply assets.
 
-For the on-chain details, including the full state machine, function signatures, math, and liquidation paths, see the [Fixed Term Vaults Technical Reference](../../technical-reference/reference-technical-articles/fixed-rate-vaults.md).
+A partial repayment reduces debt and can improve health, but it does not necessarily unlock collateral below the minimum floor and does not eliminate remaining liquidation or late-payment risk. Only full repayment clears the debt. Even after full early repayment, the vault remains in `Lock` until the lock end; it does not mature early or release the entire collateral immediately.
+
+At the lock end, the vault enters `PendingSettlement`. If the debt is zero, it can advance to `Matured`; otherwise repayment remains available through the settlement window. Once the settlement deadline passes with debt outstanding, whitelisted settlement actors can use the overdue-liquidation path even if the vault has no LT shortfall. Health-based liquidation can also occur in active debt states when an LT shortfall exists.
+
+Partial pause still allows repayment and liquidation. Complete pause blocks both until unpaused. Check the live pause level before relying on a defensive transaction.
+
+## Step 6: Recover Eligible Collateral
+
+The current position-NFT owner can call `withdrawCollateral(amount)`:
+
+* in `Lock`, only for an amount allowed by both the floor and LT checks;
+* in `Matured`, up to the remaining recorded collateral; or
+* in `Failed`, up to the recoverable balance after any confiscated margin is reserved.
+
+It cannot use `withdrawCollateral` in `PendingSettlement`, `SettlementDeadlineExceeded`, `Liquidated`, or `Closed`. Do not transfer or discard the position NFT before all intended institution-side recovery is complete. Verify the terminal state, recorded collateral, token balance, recipient, and pause level, and avoid assuming that a successful supplier settlement automatically sends collateral back to the institution.
+
+An ACM-authorized controller caller can move a `Matured`, `Failed`, or `Liquidated` vault to `Closed`. The published `closeVault` path does not verify that the institution has recovered its collateral, and `withdrawCollateral` is unavailable after closing. Recover eligible collateral promptly and monitor controller actions.
+
+## Parameters That Can Change
+
+The supply asset, collateral asset, scheduled rate, reserve factor, caps, minimum supplier deposit, lifecycle durations, ideal collateral amount, and margin rate are fixed in an existing clone. A renewed deal requires another clone.
+
+The liquidation threshold, liquidation incentive, late-penalty rate, and institution display name can be changed for an existing vault through ACM-gated controller calls. Shared controller, oracle, LiquidationAdapter, treasury, ProtocolShareReserve, pause, whitelist, and ACM configuration can also change. Monitor the live values throughout the position rather than relying only on the creation terms.
+
+The controller also exposes an ACM-gated `sweep(vault, token)` path that transfers the vault's full balance of the specified ERC-20 to the configured treasury. The published source does not exclude the supply or collateral asset. Treat the live controller implementation, treasury, and effective ACM grants as material administrative authorities.
+
+## Operational Checklist
+
+* Keep the position NFT in a wallet whose transaction process can meet short deadlines; custody transfer changes contract control.
+* Verify the exact vault, asset, amount, decimals, spender, state, deadline, pause level, and oracle health before every transaction.
+* Leave time for approvals, multisig execution, state finalization, and retries before fundraising and settlement boundaries.
+* Monitor both health and debt. Collateral top-ups and repayments affect different sides of the risk calculation.
+* Confirm receipts and events, then reduce unnecessary token allowances.
+* Escalate a pause, stale oracle, failed health simulation, or unexpected state through official Venus channels before moving more funds.
+
+For the complete state machine, settlement waterfall, rounding, pause rules, liquidation paths, and administrative authorities, see the [Fixed Term Vaults Technical Reference](../../technical-reference/reference-technical-articles/fixed-rate-vaults.md). The current source boundary used for this guide is [`InstitutionalLoanVault.sol@91611be`](https://github.com/VenusProtocol/fixed-rate-vaults/blob/91611be77036e05d16f1ce43890b160cb4bc7228/src/institutional-vault/InstitutionalLoanVault.sol) together with [`BaseVault.sol@91611be`](https://github.com/VenusProtocol/fixed-rate-vaults/blob/91611be77036e05d16f1ce43890b160cb4bc7228/src/BaseVault.sol). Immutable historical clones may use an earlier implementation. Verify the live clone, shared contracts, configuration, state, balances, and permissions at a recorded block before acting.


### PR DESCRIPTION
Depends on #387. Please review and merge this PR only after #387; once #387 lands, this branch should be rebased and its technical-reference cross-link rechecked.

## Summary

- replace governance-only wording with the controller's actual ACM-gated authorization model
- document exact position-NFT ownership, approval spender, token-decimal, allowance, and unsupported-token boundaries
- correct the claim window: there is no late claim, and unclaimed principal is not added to debt
- distinguish partial from full repayment and explain why early full repayment does not mature the vault or free the collateral floor early
- add stored-state finalization, pause, oracle, liquidation, terminal collateral recovery, close, and sweep risks
- separate clone-fixed commercial parameters from mutable per-vault and shared-system risk controls

## Verification

- mapped each money-moving path to `InstitutionalLoanVault.sol` and `BaseVault.sol` at `fixed-rate-vaults@91611be`
- cross-checked controller ACM, position-transfer, close, sweep, and risk-update paths in the same source snapshot
- checked the published BNB Chain controller registry and current/legacy clone implementation boundary at a fixed block
- `npx remark guides/fixed-rate-vaults/institution-guide.md --frail`
- `git diff --check`
