### PR TITLE
docs: update API and subgraph service guidance

### DIFF
--- a/services/api.md
+++ b/services/api.md
@@ -2,38 +2,56 @@
 description: The Venus Protocol API providing access to indexed protocol data.
 ---
 
-# API
+API
+===
 
-Venus Protocol API provides three groups of endpoints
+The Venus Protocol API exposes indexed lending-market, pool, and governance data. The OpenAPI specification embedded below currently documents two endpoint families:
 
-**Market Data -** Endpoints relating to lending markets
+* **Market and pool data** — listed markets, pool configuration, historical market snapshots, and aggregate TVL
+* **Governance data** — proposals, votes, and voter activity
 
-**Activity -** Endpoints relating to user interactions with markets
+{% hint style="warning" %}
+API responses are derived from indexed data and can lag the chain, omit a recent event, or temporarily fail. Do not treat them as authoritative for transaction simulation, balances, permissions, market pause state, prices, or liquidation safety. Read the relevant contracts through an RPC endpoint at a recorded block when correctness depends on live state.
+{% endhint %}
 
-**Governance -** Endpoints providing information about proposals and voter activity
+The live [Swagger playground](https://api.venus.io/docs/playground) and [OpenAPI JSON](https://api.venus.io/docs/swagger.json) are the source of truth for the currently published request parameters and response schemas. The checked-in specification rendered on this page is a snapshot and should be resynchronized when the live JSON changes.
 
-## Base URL
+Base URL
+---
 
-The API is available without authentication for testnet and mainnet.
+The documented read endpoints are available without authentication at these origins. Endpoint paths are appended directly to the origin; there is no `/api` prefix.
 
-mainnet: [https://api.venus.io](https://api.venus.io/api/governance/venus)\
-testnet: [https://testnetapi.venus.io](https://testnetapi.venus.io/api/transactions/)
+```text
+mainnet: https://api.venus.io
+testnet: https://testnetapi.venus.io
+```
 
-## Versioning
+For example, a BNB Chain mainnet request to the default `stable` pools route is:
 
-Endpoints are versioned using the `accept-version` header. The values for this header can be `stable` or `next`. By default the `stable` version is returned. When a `next` version is available, a `Warning - 299` header will be added to the `stable` version with a message of breaking changes. To receive this new version the `accept-version` header can be set to `next`.
+```bash
+curl --get 'https://api.venus.io/pools' \
+  --data-urlencode 'chainId=56'
+```
 
-When the latest `next` version is made stable and the previous stable version is deprecated, both values for `accept-version` will return the latest version. Using the `next` header at this point will add a `Warning - 299` header alerting the client to remove `accept-version: next` to avoid receiving unexpected changes in the future.
+Versioning
+---
 
-#### Versioning Choreography
+Routes that declare the `accept-version` request header support `stable` and `next`. Omitting the header selects `stable`; an unsupported value is rejected. Do not assume every API route is versioned—check the OpenAPI entry for the specific path.
 
-These steps describe the process of upgrading endpoints to new versions as they are released
+`stable` and `next` can have different required query parameters and response shapes. In the published specification, this is material for `/markets` and `/pools`; read the schema for the selected version instead of deserializing both as the same object.
 
-1. A `next` version is made available, accessible with the `accept-version: next` header. A `Warning - 299` header is added to the stable version with details about breaking changes.
-2. Clients will be given adequate time to upgrade to use the next version.
-3. The previous stable version will be deprecated, the next version becomes stable and using the `accept-version: next` header will add a warning to remove the header or use the stable version.
-4. Clients remove the `accept-version: next` header to avoid receiving unexpected changes.
-5. The endpoint is now ready to release another version.
+The current `stable` responses for those routes include an HTTP `Warning: 299` header instructing clients to migrate to `accept-version: next`. Test the `next` schema before switching and monitor response warnings during every rollout:
+
+```bash
+curl --get 'https://api.venus.io/markets' \
+  --header 'accept-version: next' \
+  --data-urlencode 'chainId=56' \
+  --data-urlencode 'limit=1'
+```
+
+When `next` is promoted, the server can make both header values resolve to the newly stable implementation and warn clients to remove `accept-version: next`. Removing that opt-in after promotion avoids silently receiving a later preview. Pin client expectations with contract tests; the header name is not a permanent schema version identifier.
+
+This page was checked against the live v1.73.0 specification. Live service behavior and the live OpenAPI document take precedence over the checked-in snapshot rendered below.
 
 ### Pool Endpoints
 
@@ -90,4 +108,3 @@ These steps describe the process of upgrading endpoints to new versions as they 
 {% swagger src="../.gitbook/assets/swagger.json" path="/governance/proposals/{proposalId}" method="get" %}
 [swagger.json](../.gitbook/assets/swagger.json)
 {% endswagger %}
-

--- a/services/subgraphs.md
+++ b/services/subgraphs.md
@@ -1,85 +1,84 @@
 # Subgraphs
 
-Venus Protocol official supports a few subgraphs for querying protocol activity and data using GraphQl. The subgraphs are currently deployed in the [The Graph](https://thegraph.com/hosted-service) hosted service.
+Venus publishes GraphQL subgraphs that index selected protocol events into queryable entities. Most deployments listed here are on **The Graph Network**, not the retired Hosted Service. The `chain=arbitrum-one` parameter in an Explorer URL identifies the network on which The Graph operates; the Explorer page's **Network** field identifies the blockchain whose Venus events are indexed.
+
+{% hint style="warning" %}
+A subgraph is a derived, eventually consistent view. It can lag the chain, stop indexing, encounter a deterministic error, or reflect a different deployment version than a client expects. Do not use subgraph output alone for transaction safety, balances, permissions, prices, pause state, or liquidation decisions. Check the index status and latest indexed block, then confirm critical state through an RPC endpoint.
+{% endhint %}
+
+## Querying a Deployment
+
+Open an Explorer link below and verify its title, indexed network, subgraph ID, current version, deployment ID, and index status. For deployments on The Graph Network, create a Graph API key and use the subgraph ID shown by Explorer:
+
+```text
+https://gateway.thegraph.com/api/<GRAPH_API_KEY>/subgraphs/id/<SUBGRAPH_ID>
+```
+
+See The Graph's [querying documentation](https://thegraph.com/docs/en/subgraphs/querying/introduction/) for the current gateway and key-management flow. Do not embed unrestricted provider keys in public client code. The opBNB links use NodeReal instead and require a NodeReal API key in the `{apikey}` path segment.
+
+Provider availability, routing, rate limits, and deployment versions are external runtime state. Treat the links below as discovery entries rather than uptime guarantees, and keep a direct-chain fallback for production integrations.
 
 ## Isolated Pools
 
-The Isolated Pools subgraphs provides endpoints for querying data related to Isolated Pools and lending activities.
+Indexes Isolated Pool configuration and lending activity on the listed networks.
 
-[Code](https://github.com/VenusProtocol/subgraphs/tree/master/subgraphs/isolated-pools)
+[Source](https://github.com/VenusProtocol/subgraphs/tree/main/subgraphs/isolated-pools)
 
 ### Deployments
 
-[BNB Chain](https://thegraph.com/explorer/subgraphs/H2a3D64RV4NNxyJqx9jVFQRBpQRzD6zNZjLDotgdCrTC?view=Query\&chain=arbitrum-one)
-
-[Ethereum](https://thegraph.com/explorer/subgraphs/Htf6Hh1qgkvxQxqbcv4Jp5AatsaiY5dNLVcySkpCaxQ8?view=Query\&chain=arbitrum-one)
-
-[\* ](subgraphs.md#requires-creating-an-api-key-with-nodereal-https-nodereal.io)[OpBnB](https://open-platform-ap.nodereal.io/%7Bapikey%7D/opbnb-mainnet-graph-query/subgraphs/name/venusprotocol/venus-isolated-pools-opbnb/graphql)
-
-[Arbitrum](https://thegraph.com/explorer/subgraphs/2zqpTYBL3X1E2eb129bKno1pJdx6xBawr8urp61w33Z8?view=Query\&chain=arbitrum-one)
-
-[zkSync](https://thegraph.com/explorer/subgraphs/GAGNaWNCDmWvjr217vjtQrh3uSkV2bjXPzJSfnGAuxfz?view=Query\&chain=arbitrum-one)
-
-[Optimism](https://thegraph.com/explorer/subgraphs/6vdC1Qpr5kobLEJCdDVUsGK6yG6aFscaQKvNZt2SspSz?view=Query\&chain=arbitrum-one)
-
-[Base](https://thegraph.com/explorer/subgraphs/7VHvieXwv5SWSmVppmi4QkSCFVxiECgcFdng2er73Q97?view=Query&chain=arbitrum-one)
-
-[Unichain](https://thegraph.com/explorer/subgraphs/7N1UtVizkc1EbqNvHh8xfKbSanBtksnap1JxVdpogrMJ?view=Query&chain=arbitrum-one)
+* [BNB Chain](https://thegraph.com/explorer/subgraphs/H2a3D64RV4NNxyJqx9jVFQRBpQRzD6zNZjLDotgdCrTC?view=Query&chain=arbitrum-one)
+* [Ethereum](https://thegraph.com/explorer/subgraphs/Htf6Hh1qgkvxQxqbcv4Jp5AatsaiY5dNLVcySkpCaxQ8?view=Query&chain=arbitrum-one)
+* [opBNB (NodeReal; API key required)](https://open-platform-ap.nodereal.io/%7Bapikey%7D/opbnb-mainnet-graph-query/subgraphs/name/venusprotocol/venus-isolated-pools-opbnb/graphql)
+* [Arbitrum One](https://thegraph.com/explorer/subgraphs/2zqpTYBL3X1E2eb129bKno1pJdx6xBawr8urp61w33Z8?view=Query&chain=arbitrum-one)
+* [zkSync Era](https://thegraph.com/explorer/subgraphs/GAGNaWNCDmWvjr217vjtQrh3uSkV2bjXPzJSfnGAuxfz?view=Query&chain=arbitrum-one)
+* [Optimism](https://thegraph.com/explorer/subgraphs/6vdC1Qpr5kobLEJCdDVUsGK6yG6aFscaQKvNZt2SspSz?view=Query&chain=arbitrum-one)
+* [Base](https://thegraph.com/explorer/subgraphs/7VHvieXwv5SWSmVppmi4QkSCFVxiECgcFdng2er73Q97?view=Query&chain=arbitrum-one)
+* [Unichain](https://thegraph.com/explorer/subgraphs/7N1UtVizkc1EbqNvHh8xfKbSanBtksnap1JxVdpogrMJ?view=Query&chain=arbitrum-one)
 
 ## Core Pool
 
-The Core Pool subgraph is responsible for indexing and aggregating events related to market and lending activities in the Core Pool
+Indexes market and lending events for the BNB Chain Core Pool.
 
-[Code](https://github.com/VenusProtocol/subgraphs/tree/master/subgraphs/venus)
+[Source](https://github.com/VenusProtocol/subgraphs/tree/main/subgraphs/venus)
 
 ### Deployments
 
-[BNB Chain](https://thegraph.com/explorer/subgraphs/7h65Zf3pXXPmf8g8yZjjj2bqYiypVxems5d8riLK1DyR?view=Query\&chain=arbitrum-one)
+* [BNB Chain](https://thegraph.com/explorer/subgraphs/7h65Zf3pXXPmf8g8yZjjj2bqYiypVxems5d8riLK1DyR?view=Query&chain=arbitrum-one)
 
 ## Governance
 
-The Governance subgraph will index events related to Governance including proposals and voting activity.
+Indexes BNB Chain governance proposals, votes, and related governance activity.
 
-[Code](https://github.com/VenusProtocol/subgraphs/tree/master/subgraphs/venus-governance)
-
-### Deployments
-
-[BNB Chain](https://thegraph.com/explorer/subgraphs/5ygYHxpnJ7EbQ6LBv39bjc4XmeTH1bQMdXw3uAnFF7iR?view=Query\&chain=arbitrum-one)
-
-## Crosschain Governance
-
-The Crosschain Governance subgraph indexes receiving of messages and execution of proposals on remote chains
-
-[Code](https://github.com/VenusProtocol/subgraphs/tree/master/subgraphs/cross-chain-governance)
+[Source](https://github.com/VenusProtocol/subgraphs/tree/main/subgraphs/venus-governance)
 
 ### Deployments
 
-[Ethereum](https://thegraph.com/explorer/subgraphs/33SALoS8mD2PxLR2utd6TXBekhp3Ra3T3uCyHks5wV3W?view=Query\&chain=arbitrum-one)
+* [BNB Chain](https://thegraph.com/explorer/subgraphs/5ygYHxpnJ7EbQ6LBv39bjc4XmeTH1bQMdXw3uAnFF7iR?view=Query&chain=arbitrum-one)
 
-[Arbitrum](https://thegraph.com/explorer/subgraphs/4uZXx9tZRbHcSoJp4prF4ankfL1dyTHrm6dNuQp5pdJw?view=Query\&chain=arbitrum-one)
+## Cross-Chain Governance
 
-[\* ](subgraphs.md#requires-creating-an-api-key-with-nodereal-https-nodereal.io)[OpBnB](https://open-platform-ap.nodereal.io/%7Bapikey%7D/opbnb-mainnet-graph-query/subgraphs/name/venusprotocol/venus-governance-opbnb/graphql)
+Indexes governance messages received and proposal executions on remote chains.
 
-[zkSync](https://thegraph.com/explorer/subgraphs/FGFYdyEMfD3BrXJZFZtNdGdi7RwVahqzxvK1BtDdk8Kb?view=Query\&chain=arbitrum-one)
+[Source](https://github.com/VenusProtocol/subgraphs/tree/main/subgraphs/cross-chain-governance)
 
-[Optimism](https://thegraph.com/explorer/subgraphs/4WESjRqo3TcdL3eUCTbbT4h2dLFwn3sKVi4PdWJDC118?view=Query\&chain=arbitrum-one)
+### Deployments
 
-[Base](https://thegraph.com/explorer/subgraphs/88XyqtD22FYVzENf3aJhRrtQx7yncfWF22ryMpFNMSNP?view=Query&chain=arbitrum-one)
+* [Ethereum](https://thegraph.com/explorer/subgraphs/33SALoS8mD2PxLR2utd6TXBekhp3Ra3T3uCyHks5wV3W?view=Query&chain=arbitrum-one)
+* [Arbitrum One](https://thegraph.com/explorer/subgraphs/4uZXx9tZRbHcSoJp4prF4ankfL1dyTHrm6dNuQp5pdJw?view=Query&chain=arbitrum-one)
+* [opBNB (NodeReal; API key required)](https://open-platform-ap.nodereal.io/%7Bapikey%7D/opbnb-mainnet-graph-query/subgraphs/name/venusprotocol/venus-governance-opbnb/graphql)
+* [zkSync Era](https://thegraph.com/explorer/subgraphs/FGFYdyEMfD3BrXJZFZtNdGdi7RwVahqzxvK1BtDdk8Kb?view=Query&chain=arbitrum-one)
+* [Optimism](https://thegraph.com/explorer/subgraphs/4WESjRqo3TcdL3eUCTbbT4h2dLFwn3sKVi4PdWJDC118?view=Query&chain=arbitrum-one)
+* [Base](https://thegraph.com/explorer/subgraphs/88XyqtD22FYVzENf3aJhRrtQx7yncfWF22ryMpFNMSNP?view=Query&chain=arbitrum-one)
 
 ## Protocol Share Reserve
 
-The Protocol Share Reserve subgraph
+Indexes selected Protocol Share Reserve and token-converter activity.
 
-[Code](https://github.com/VenusProtocol/subgraphs/tree/develop/subgraphs/protocol-reserve)
+[Source](https://github.com/VenusProtocol/subgraphs/tree/main/subgraphs/protocol-reserve)
 
 ### Deployments
 
-[BNB Chain Mainnet](https://thegraph.com/explorer/subgraphs/2ZCWgaBc8KoWW8kh7MRzf9KPdr7NTZ5cda9bxpFDk4wG?view=Query\&chain=arbitrum-one)
+* [BNB Chain](https://thegraph.com/explorer/subgraphs/2ZCWgaBc8KoWW8kh7MRzf9KPdr7NTZ5cda9bxpFDk4wG?view=Query&chain=arbitrum-one)
+* [Ethereum](https://thegraph.com/explorer/subgraphs/bnwTFv6yd4FojhPFf5Hw4pzb8GwW25Du12yrnpD6erw?view=Query&chain=arbitrum-one)
 
-[Ethereum](https://thegraph.com/explorer/subgraphs/bnwTFv6yd4FojhPFf5Hw4pzb8GwW25Du12yrnpD6erw?view=Query\&chain=arbitrum-one)
-
-
-
-
-
-#### \* Requires creating an api key with \[NodeReal]\(https://nodereal.io/)
+The source-tree boundary checked for this page is [`VenusProtocol/subgraphs@68f1cb9`](https://github.com/VenusProtocol/subgraphs/tree/68f1cb98a719454282277e920fdd67f0af5788a7). The repository defines schemas and mappings; it does not by itself prove that a provider is serving a healthy, fully synced deployment.


### PR DESCRIPTION
## Summary

- remove the stale Activity endpoint family and correct the public base URLs to use root paths without `/api`
- document the current `stable`/`next` schema boundary and live `Warning: 299` migration signal
- distinguish indexed API data from authoritative live contract state
- replace the retired The Graph Hosted Service description with the current Graph Network gateway model
- repair all five source links from nonexistent `master`/`develop` branches to the public default branch
- clarify Graph versus NodeReal API-key requirements, index-health checks, provider availability, and RPC fallback

## Verification

- normalized live `https://api.venus.io/docs/swagger.json` is byte-equivalent to the checked-in v1.73.0 specification after JSON formatting
- exercised mainnet/testnet `/pools`, `stable` warning behavior, and `accept-version: next` for `/markets`
- checked all public documentation, source, and Explorer links; each returned HTTP 200
- confirmed every listed The Graph Explorer ID resolves to the expected Venus deployment page
- `npx remark services/api.md services/subgraphs.md --frail`
- `git diff --check`
