### PR TITLE
docs: correct security audit catalog and links

### DIFF
--- a/security-and-audits.md
+++ b/security-and-audits.md
@@ -1,10 +1,20 @@
 # Security & Audits
 
-At Venus, our utmost dedication lies in ensuring the highest levels of security for our users. Throughout the entire Smart Contract development lifecycle, we strictly adhere to industry best practices to uphold the integrity of our platform. To further fortify our security measures, we collaborate with renowned auditing firms in the field. These partnerships enable us to conduct comprehensive security assessments of our protocol, thereby safeguarding our users' funds effectively.
+This page catalogs published security reviews of specific Venus code changes. Each report is bounded by the repository revision, pull request, files, assumptions, and dates in its scope. It is not an audit of every Venus deployment, and it does not establish that the reviewed code is the code currently executing on-chain.
 
-The security of the Venus Protocol stands as our highest priority. Our development team, in conjunction with third-party auditors and consultants, has invested substantial efforts to create a protocol that we confidently deem safe and dependable. We prioritize transparency by making all contract code and balances publicly verifiable. Moreover, we offer a bug bounty program to security researchers who report undiscovered vulnerabilities, encouraging continuous improvement and vigilance.
+{% hint style="danger" %}
+An audit reduces risk; it does not make a protocol, contract, market, oracle, bridge, or integration safe or dependable. Auditors can miss defects, later upgrades can invalidate earlier conclusions, and governance configuration or external dependencies may be outside a report's scope. Users and integrators remain responsible for their own technical and economic risk assessment.
+{% endhint %}
 
-We firmly believe that the true test of a smart contract's security lies in its size, visibility, and time. Consequently, we urge users to exercise caution and make independent assessments of the security and suitability of our protocol.
+Before relying on a report:
+
+1. resolve the live proxy implementation, diamond facets, beacon, or clone implementation at a recorded block;
+2. map that deployed code to the exact reviewed commit and read the report's in-scope and out-of-scope sections;
+3. review findings, acknowledged risks, remediation status, assumptions, and any later code changes—not only the auditor name or report count;
+4. verify live permissions, pause state, oracle configuration, risk parameters, and external dependencies separately; and
+5. check whether a newer deployment or audit supersedes the listed artifact.
+
+The catalog is an evidence index, not a claim of complete coverage. Historical feature names, PRs, VIPs, and file lists below describe the review scope at that time; they do not prove that a feature is currently enabled or unchanged.
 
 ## Audits
 
@@ -45,7 +55,7 @@ We firmly believe that the true test of a smart contract's security lies in its 
 
 ### Risk Stewards V1 and Core Pool Comptroller Interface Compatibility with Isolated Pools
 
-**Scope**: Venus Risk Steward contracts, compatible with the Risk Oracle contracts from Chaos Labs. These stewards are authorized to perform risk parameter changes (initially, only increasing the supply and borrow caps) without requiring VIPs. Additionally, the interface of the Comptroller contract on BNB Chain is extended with the functions defined in the Comptroller contract for Isolated Pools, simplifying interactions with both Comptroller contracts. Enabled in [VIP-544](https://app.venus.io/#/governance/proposal/544?chainId=56).
+**Scope**: Venus Risk Steward contracts, compatible with the Risk Oracle contracts from Chaos Labs. These stewards are authorized to perform risk parameter changes (initially, only increasing the supply and borrow caps) without requiring VIPs. Additionally, the interface of the Comptroller contract on BNB Chain is extended with the functions defined in the Comptroller contract for Isolated Pools, simplifying interactions with both Comptroller contracts. Enabled in [VIP-544](https://venus.io/governance/proposal/544?chainId=56).
 
 * [Certik audit report (2025/02/19)](https://github.com/VenusProtocol/governance-contracts/blob/210d1e54f0c9136a805977b41077567b0883a4e0/audits/120_risk_stewards_v1_certik_20250219.pdf)
 * [Quantstamp audit report (2025/02/13)](https://github.com/VenusProtocol/governance-contracts/blob/210d1e54f0c9136a805977b41077567b0883a4e0/audits/121_risk_stewards_v1_quantstamp_20250213.pdf)
@@ -77,7 +87,7 @@ We firmly believe that the true test of a smart contract's security lies in its 
 
 ### Risk Stewards V2
 
-**Scope**: Expansion of the Venus Risk Steward framework. In addition to supply and borrow caps, the stewards can now update collateral factors (with their liquidation thresholds) and interest rate models, governed by safe-delta and timelock controls. Recommendations are published to a Venus-owned Risk Oracle by whitelisted risk parameter providers, and updates can be executed locally on BNB Chain or forwarded cross-chain via LayerZero to destination receivers on other supported chains. Enabled in [VIP-592](https://app.venus.io/#/governance/proposal/592?chainId=56).
+**Scope**: Expansion of the Venus Risk Steward framework. In addition to supply and borrow caps, the stewards can now update collateral factors (with their liquidation thresholds) and interest rate models, governed by safe-delta and timelock controls. Recommendations are published to a Venus-owned Risk Oracle by whitelisted risk parameter providers, and updates can be executed locally on BNB Chain or forwarded cross-chain via LayerZero to destination receivers on other supported chains. Enabled in [VIP-592](https://venus.io/governance/proposal/592?chainId=56).
 
 * [Quantstamp audit report (2025/12/15)](https://github.com/VenusProtocol/governance-contracts/blob/b4b9fc4d3d4f3a8b5ecb3308693a0180399f8dec/audits/166_risk_steward_v2_quantstamp_20251215.pdf)
 * [Certik audit report (2025/12/29)](https://github.com/VenusProtocol/governance-contracts/blob/b4b9fc4d3d4f3a8b5ecb3308693a0180399f8dec/audits/167_risk_steward_v2_certik_20251229.pdf)
@@ -102,9 +112,9 @@ We firmly believe that the true test of a smart contract's security lies in its 
 
 ### Native Token Gateway upgrade
 
-**Scope**: [NativeTokenGateway contract](https://github.com/VenusProtocol/venus-periphery/blob/95e157b5b498ab80fe2715ca5ecf64203f6727fb/contracts/Gateway/NativeTokenGateway.sol) upgrade, to make it compatible with the Core pool on BNB Chain. Enabled in [VIP-543](https://app.venus.io/#/governance/proposal/543?chainId=56)
+**Scope**: [NativeTokenGateway contract](https://github.com/VenusProtocol/venus-periphery/blob/95e157b5b498ab80fe2715ca5ecf64203f6727fb/contracts/Gateway/NativeTokenGateway.sol) upgrade, to make it compatible with the Core pool on BNB Chain. Enabled in [VIP-543](https://venus.io/governance/proposal/543?chainId=56)
 
-- [Certik audit report (2024/09/11)](https://github.com/VenusProtocol/venus-periphery/blob/95e157b5b498ab80fe2715ca5ecf64203f6727fb/audits/152_nativeTokenGateway_certik_20250911.pdf)
+- [Certik audit report (2025/09/11)](https://github.com/VenusProtocol/venus-periphery/blob/95e157b5b498ab80fe2715ca5ecf64203f6727fb/audits/152_nativeTokenGateway_certik_20250911.pdf)
 
 <details>
 <summary>Detailed scope</summary>
@@ -218,11 +228,11 @@ We firmly believe that the true test of a smart contract's security lies in its 
 
 ### TwoKinksInterestRate
 
-**Scope**: Develop new interest rate model for the core pool ([here](https://github.com/VenusProtocol/venus-protocol/blob/main/contracts/InterestRateModels/TwoKinksInterestRateModel.sol)) and for the isolated pools ([here](https://github.com/VenusProtocol/isolated-pools/blob/main/contracts/TwoKinksInterestRateModel.sol)), supporting two different kinks and therefore three different slopes. Enabled in [VIP-385](https://app-alt.venus.io/#/governance/proposal/385).
+**Scope**: Develop new interest rate model for the core pool ([here](https://github.com/VenusProtocol/venus-protocol/blob/main/contracts/InterestRateModels/TwoKinksInterestRateModel.sol)) and for the isolated pools ([here](https://github.com/VenusProtocol/isolated-pools/blob/main/contracts/TwoKinksInterestRateModel.sol)), supporting two different kinks and therefore three different slopes. Enabled in [VIP-385](https://venus.io/governance/proposal/385?chainId=56).
 
 - [Certik audit report (2024/07/31)](https://github.com/VenusProtocol/venus-protocol/blob/8be0034819eef313d6ffe216e5ba0f1152dbdcc0/audits/113_twoKinks_certik_20240731.pdf)
 - [Fairyproof audit report (2024/08/04)](https://github.com/VenusProtocol/venus-protocol/blob/8be0034819eef313d6ffe216e5ba0f1152dbdcc0/audits/114_twoKinks_fairyproof_20240804.pdf)
-- [Quanstamp audit report (2024/08/19)](https://github.com/VenusProtocol/venus-protocol/blob/8be0034819eef313d6ffe216e5ba0f1152dbdcc0/audits/115_twoKinks_quantstamp_20240819.pdf)
+- [Quantstamp audit report (2024/08/19)](https://github.com/VenusProtocol/venus-protocol/blob/8be0034819eef313d6ffe216e5ba0f1152dbdcc0/audits/115_twoKinks_quantstamp_20240819.pdf)
 
 <details>
 <summary>Detailed scope</summary>
@@ -244,7 +254,7 @@ Support for the Isolated pools
 
 ### Unlist markets
 
-**Scope**: Changes in the [isolated pools](https://github.com/VenusProtocol/isolated-pools) and [core](https://github.com/VenusProtocol/venus-protocol) contracts to support unlisting markets. Fix in the core pool the behaviour of borrow caps set to zero. Enabled in [VIP-361](https://app-alt.venus.io/#/governance/proposal/361).
+**Scope**: Changes in the [isolated pools](https://github.com/VenusProtocol/isolated-pools) and [core](https://github.com/VenusProtocol/venus-protocol) contracts to support unlisting markets. Fix in the core pool the behaviour of borrow caps set to zero. Enabled in [VIP-361](https://venus.io/governance/proposal/361?chainId=56).
 
 - [Certik audit report (2024/04/09)](https://github.com/VenusProtocol/venus-protocol/blob/e4c4dfe1b78945ea87dca5b7e0c724b6bd317359/audits/099_unlistMarkets_certik_20240409.pdf)
 - [Fairyproof audit report (2024/03/28)](https://github.com/VenusProtocol/venus-protocol/blob/e4c4dfe1b78945ea87dca5b7e0c724b6bd317359/audits/102_unlistMarkets_fairyproof_20240328.pdf)
@@ -274,7 +284,7 @@ Fix Borrow Cap 0 Logic
 
 ### Oracle for Ether.fi LRT tokens (weETHs and weETHk) on Ethereum
 
-**Scope**: specific oracle for the tokens [weETHs](https://etherscan.io/token/0x917ceE801a67f933F2e6b33fC0cD1ED2d5909D88) and [weETHk](https://etherscan.io/address/0x7223442cad8e9cA474fC40109ab981608F8c4273) on Ethereum, using an `Accountant` contract under the hood, provided by the [Ether.fi](https://www.ether.fi/) project. Enabled in [VIP-355](https://app-alt.venus.io/#/governance/proposal/355).
+**Scope**: specific oracle for the tokens [weETHs](https://etherscan.io/token/0x917ceE801a67f933F2e6b33fC0cD1ED2d5909D88) and [weETHk](https://etherscan.io/address/0x7223442cad8e9cA474fC40109ab981608F8c4273) on Ethereum, using an `Accountant` contract under the hood, provided by the [Ether.fi](https://www.ether.fi/) project. Enabled in [VIP-355](https://venus.io/governance/proposal/355?chainId=56).
 
 - [Certik audit report (2024/08/23)](https://github.com/VenusProtocol/oracle/blob/93a79c97e867f61652fc063abb5df323acc9bed4/audits/116_WeETHAccountantOracle_certik_20240823.pdf)
 
@@ -289,7 +299,7 @@ Fix Borrow Cap 0 Logic
 
 ### VBNBAdmin: new function setInterestRateModel
 
-**Scope**: Update of the VBNBAdmin contract to integrate the AccessControlManager within the `setInterestRateModel` function. This will allow to authorize more timelocks (not only the Normal timelock) to execute this function, so Fast-track and Critical VIP's will be able to update the interest rate model on the VBNB market. Enabled in [VIP-343](https://app-alt.venus.io/#/governance/proposal/343).
+**Scope**: Update of the VBNBAdmin contract to integrate the AccessControlManager within the `setInterestRateModel` function. This will allow more timelocks (not only the Normal Timelock) to execute this function, so Fast-track and Critical VIPs will be able to update the interest rate model on the VBNB market. Enabled in [VIP-343](https://venus.io/governance/proposal/343?chainId=56).
 
 - [Certik audit report (2024/07/17)](https://github.com/VenusProtocol/venus-protocol/blob/5e4563ab0f2f98a04659e065b6c49acebf00df3b/audits/112_VBNBAdmin_certik_20240717.pdf)
 
@@ -304,10 +314,10 @@ Fix Borrow Cap 0 Logic
 
 ### Oracle for sfrxETH on Ethereum
 
-**Scope**: specific oracle for the token [sfrxETH](https://etherscan.io/token/0xac3e018457b222d93114458476f3e3416abbe38f) on Ethereum, using the `SfrxEthFraxOracle` oracle under the hood, provided by the [FRAX project](https://docs.frax.finance/frax-oracle/advanced-concepts#frax-oracles). Enabled in [VIP-329](https://app.venus.io/#/governance/proposal/329).
+**Scope**: specific oracle for the token [sfrxETH](https://etherscan.io/token/0xac3e018457b222d93114458476f3e3416abbe38f) on Ethereum, using the `SfrxEthFraxOracle` oracle under the hood, provided by the [FRAX project](https://docs.frax.finance/frax-oracle/advanced-concepts#frax-oracles). Enabled in [VIP-329](https://venus.io/governance/proposal/329?chainId=56).
 
 - [Certik audit report (2024/05/17)](https://github.com/VenusProtocol/oracle/blob/0b221a7bb7d8e04fd8b013806facb93bcb4038b9/audits/110_sfrxETHOracle_certik_20240517.pdf)
-- [Quantstamp audit report (2024/05/20)](https://github.com/VenusProtocol/oracle/blob/0b221a7bb7d8e04fd8b013806facb93bcb4038b9/audits/111_sfrxETHOracle_quantstamp_20240530.pdf)
+- [Quantstamp audit report (2024/05/30)](https://github.com/VenusProtocol/oracle/blob/0b221a7bb7d8e04fd8b013806facb93bcb4038b9/audits/111_sfrxETHOracle_quantstamp_20240530.pdf)
 
 <details>
 <summary>Detailed scope</summary>
@@ -319,9 +329,9 @@ Fix Borrow Cap 0 Logic
 
 ### Multichain Governance
 
-**Scope**: Cross chain messaging, execution of VIP on non-BNB chains. Integration of [Multichain Governance](https://github.com/VenusProtocol/governance-contracts/pull/21) in Venus. Enabled in [VIP-330](https://app.venus.io/#/governance/proposal/330) and [VIP-331](https://app.venus.io/#/governance/proposal/331).
+**Scope**: Cross-chain messaging and execution of VIPs on non-BNB chains. Integration of [Multichain Governance](https://github.com/VenusProtocol/governance-contracts/pull/21) in Venus. Enabled in [VIP-330](https://venus.io/governance/proposal/330?chainId=56) and [VIP-331](https://venus.io/governance/proposal/331?chainId=56).
 
-* [Openzepplin audit report - 2024/01/19](https://github.com/VenusProtocol/governance-contracts/blob/2915ea772d86d9cc63f88fb6e804eaae53193879/audits/084_multichainGovernance_openzeppelin_20240119.pdf)
+* [OpenZeppelin audit report - 2024/01/19](https://github.com/VenusProtocol/governance-contracts/blob/2915ea772d86d9cc63f88fb6e804eaae53193879/audits/084_multichainGovernance_openzeppelin_20240119.pdf)
 * [Certik audit report - 2024/02/26](https://github.com/VenusProtocol/governance-contracts/blob/2915ea772d86d9cc63f88fb6e804eaae53193879/audits/085_multichainGovernance_certik_20240226.pdf)
 * [Cantina audit report - 2024/04/25](https://github.com/VenusProtocol/governance-contracts/blob/2915ea772d86d9cc63f88fb6e804eaae53193879/audits/105_multichainGovernance_cantina_20240425.pdf)
 * [Quantstamp audit report - 2024/04/29](https://github.com/VenusProtocol/governance-contracts/blob/2915ea772d86d9cc63f88fb6e804eaae53193879/audits/106_multichainGovernance_quantstamp_20240429.pdf)
@@ -338,7 +348,6 @@ Fix Borrow Cap 0 Logic
     - contracts/Cross-chain/interfaces/IGovernananceBravoDelegate.sol
     - contracts/Cross-chain/interfaces/ITimelock.sol
     - contracts/Governance/TimelockV8.sol
->>>>>>> main
 
 </details>
 
@@ -387,7 +396,7 @@ Fix Borrow Cap 0 Logic
 - Change: Seize XVS rewards
     - contracts/Comptroller/Diamond/facets/RewardFacet.sol
 
-- Pull request [#410] https://github.com/VenusProtocol/venus-protocol/pull/410 in the `venus-protocol` repo
+- Pull request [#410](https://github.com/VenusProtocol/venus-protocol/pull/410) in the `venus-protocol` repo
 - Change: Dynamically Set Addresses for XVS and XVSVToken
     - contracts/Comptroller/ComptrollerStorage.sol
     - contracts/Comptroller/Diamond/Diamond.sol
@@ -399,7 +408,7 @@ Fix Borrow Cap 0 Logic
 
 ### VAI Controller
 
-**Scope**: `VAIController` contract, fixing how the seized amounts during a VAI liquidations are calculated, considering the original VAI debt plus the interests generated. Enabled in [VIP-299](https://app.venus.io/#/governance/proposal/299).
+**Scope**: `VAIController` contract, fixing how seized amounts during VAI liquidations are calculated by considering the original VAI debt plus accrued interest. Enabled in [VIP-299](https://venus.io/governance/proposal/299?chainId=56).
 
 - [Certik audit report (2024/04/26)](https://github.com/VenusProtocol/venus-protocol/blob/0000b6b7bb9eaf1d6827993c306b776c371d41b7/audits/107_vaiController_certik_20240426.pdf)
 - [Pessimistic audit report (2024/05/02)](https://github.com/VenusProtocol/venus-protocol/blob/c01162eac8a911cd3a45c3d55b91e418e5ec2e6a/audits/109_vaiController_pessimistic_20240502.pdf)
@@ -415,13 +424,13 @@ Fix Borrow Cap 0 Logic
 
 ### XVS bridge - Mesh architecture
 
-**Scope**: enable XVS transfers between networks different to the BNB Chain, for example, between Ethereum mainnet and opBNB mainnet. [Detailed scope](https://github.com/VenusProtocol/vips/pull/255). Enabled in [VIP-292](https://app.venus.io/#/governance/proposal/292).
+**Scope**: Enable XVS transfers between networks other than BNB Chain, for example, between Ethereum mainnet and opBNB mainnet. [Detailed scope](https://github.com/VenusProtocol/vips/pull/255). Enabled in [VIP-292](https://venus.io/governance/proposal/292?chainId=56).
 
 - [Certik audit report (2024/04/19)](https://github.com/VenusProtocol/token-bridge/blob/7e13d370fbb8e9fcd6c8e0fde5943e44e0b64bfa/audits/104_mesh_architecture_certik_20240419.pdf)
 
 ### Correlated token oracles
 
-**Scope**: set of oracles for tokens whose price is highly correlated with the price of another token. This definition includes Liquid Staked Tokens (like [wsETH](https://etherscan.io/token/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0), [weETH](https://etherscan.io/token/0xcd5fe23c85820f7b72d0926fc9b05b43e359b7ee), [WBETH](https://bscscan.com/address/0xa2e3356610840701bdf5611a53974510ae27e2e1), [ankrBNB](https://bscscan.com/address/0x52F24a5e03aee338Da5fd9Df68D2b6FAe1178827), [BNBx](https://bscscan.com/address/0x1bdd3Cf7F79cfB8EdbB955f20ad99211551BA275), [slisBNB](https://bscscan.com/address/0xB0b84D294e0C75A6abe60171b70edEb2EFd14A1B), [stkBNB](https://bscscan.com/address/0xc2E9d07F66A89c44062459A47a0D2Dc038E4fb16)), [ERC-4226 tokens](https://eips.ethereum.org/EIPS/eip-4626) (like [sFRAX](https://etherscan.io/token/0xa663b02cf0a4b149d2ad41910cb81e23e1c41c32), [sfrxETH](https://etherscan.io/token/0xac3e018457b222d93114458476f3e3416abbe38f)) and any token covertible to other token onchain (like the [Pendle](https://www.pendle.finance) PT tokens). `WeETHOracle` enabled in [VIP-290](https://app.venus.io/#/governance/proposal/290?chainId=56). `AnkrBNBOracle`, `BNBxOracle`, `SlisBNBOracle` and `StkBNBOracle` enabled in [VIP-293](https://app.venus.io/#/governance/proposal/293?chainId=56).
+**Scope**: Set of oracles for tokens whose price is highly correlated with the price of another token. This definition includes liquid staked tokens (like [wstETH](https://etherscan.io/token/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0), [weETH](https://etherscan.io/token/0xcd5fe23c85820f7b72d0926fc9b05b43e359b7ee), [WBETH](https://bscscan.com/address/0xa2e3356610840701bdf5611a53974510ae27e2e1), [ankrBNB](https://bscscan.com/address/0x52F24a5e03aee338Da5fd9Df68D2b6FAe1178827), [BNBx](https://bscscan.com/address/0x1bdd3Cf7F79cfB8EdbB955f20ad99211551BA275), [slisBNB](https://bscscan.com/address/0xB0b84D294e0C75A6abe60171b70edEb2EFd14A1B), [stkBNB](https://bscscan.com/address/0xc2E9d07F66A89c44062459A47a0D2Dc038E4fb16)), [ERC-4626 tokens](https://eips.ethereum.org/EIPS/eip-4626) (like [sFRAX](https://etherscan.io/token/0xa663b02cf0a4b149d2ad41910cb81e23e1c41c32), [sfrxETH](https://etherscan.io/token/0xac3e018457b222d93114458476f3e3416abbe38f)) and any token convertible to another token on-chain (like the [Pendle](https://www.pendle.finance) PT tokens). `WeETHOracle` was enabled in [VIP-290](https://venus.io/governance/proposal/290?chainId=56). `AnkrBNBOracle`, `BNBxOracle`, `SlisBNBOracle`, and `StkBNBOracle` were enabled in [VIP-293](https://venus.io/governance/proposal/293?chainId=56).
 
 - [Certik audit report (2024/04/12)](https://github.com/VenusProtocol/oracle/blob/5cd52976a4c4d24e11ab34ca3aa5f99837eef593/audits/098_correlated_token_oracles_certik_20240412.pdf)
 - [Quantstamp audit report (2024/04/12)](https://github.com/VenusProtocol/oracle/blob/5cd52976a4c4d24e11ab34ca3aa5f99837eef593/audits/100_correlated_token_oracles_quantstamp_20240412.pdf)
@@ -448,7 +457,7 @@ Fix Borrow Cap 0 Logic
 
 ### Native token gateway
 
-**Scope**: [NativeTokenGateway contract](https://github.com/VenusProtocol/isolated-pools//blob/develop/contracts/Gateway/NativeTokenGateway.sol), that facilitates the interaction (borrow, supply, repay and redeem) with markets where the underlying token is a wrapped version of the native token (for example WETH on Ethereum, or BNB on BNB chain). Enabled in [VIP-276](https://app.venus.io/#/governance/proposal/276).
+**Scope**: [NativeTokenGateway contract](https://github.com/VenusProtocol/isolated-pools/blob/develop/contracts/Gateway/NativeTokenGateway.sol), which facilitates interaction (borrow, supply, repay, and redeem) with markets where the underlying token is a wrapped version of the native token (for example, WETH on Ethereum or WBNB on BNB Chain). Enabled in [VIP-276](https://venus.io/governance/proposal/276?chainId=56).
 
 - [Certik audit report (2024/02/26)](https://github.com/VenusProtocol/isolated-pools/blob/652459fed7269dab84628f70c44d8fa56b34203e/audits/092_nativeTokenGateway_certik_20240226.pdf)
 - [Pessimistic audit report (2024/02/29)](https://github.com/VenusProtocol/isolated-pools/blob/652459fed7269dab84628f70c44d8fa56b34203e/audits/095_nativeTokenGateway_pessimistic_20240229.pdf)
@@ -489,7 +498,7 @@ Fix Borrow Cap 0 Logic
 
 ### Token converters
 
-**Scope**: [Token converter contracts](https://github.com/VenusProtocol/protocol-reserve/pull/9). These contracts will allow the protocol to convert the income generated to the needed tokens, following the [Tokenomics](https://snapshot.org/#/venus-xvs.eth/proposal/0xc9d270ccecb7b91c75b95b8d9af24fc7c20cd38c0c0c44888ed4e7724f4e7ce9). Enabled in [VIP-245](https://app.venus.io/#/governance/proposal/245) and [VIP-248](https://app.venus.io/#/governance/proposal/248).
+**Scope**: [Token converter contracts](https://github.com/VenusProtocol/protocol-reserve/pull/9). These contracts will allow the protocol to convert the income generated to the needed tokens, following the [Tokenomics](https://snapshot.org/#/venus-xvs.eth/proposal/0xc9d270ccecb7b91c75b95b8d9af24fc7c20cd38c0c0c44888ed4e7724f4e7ce9). Enabled in [VIP-245](https://venus.io/governance/proposal/245?chainId=56) and [VIP-248](https://venus.io/governance/proposal/248?chainId=56).
 
 - Token converters
     - [OpenZeppelin audit report (2023/10/10)](https://github.com/VenusProtocol/protocol-reserve/blob/f31dc8bb433f1cff6c2124d27742004d82b24c32/audits/066_tokenConverter_openzeppelin_20231010.pdf)
@@ -529,7 +538,7 @@ Fix Borrow Cap 0 Logic
 
 ### XVS bridge and multichain deployment
 
-**Scope**: [token-bridge](https://github.com/VenusProtocol/token-bridge) repository, with contracts to allow the bridge of XVS tokens from/to BNB to/from other EVM compatible networks, like Ethereum. Extend the OFTV2 LayerZero contracts, adding custom security rules. XVS and TokenController contract, to be used on the destination chains (initially Ethereum mainnet, Arbitrum one, Polygon zkEVM and opBNB). Moreover, the audit scope included: a new [`VTreasuryV8`](https://github.com/VenusProtocol/venus-protocol/pull/345) contract, and changes in the [Resilient Oracle](https://github.com/VenusProtocol/oracle/pull/124) and Isolated pools](https://github.com/VenusProtocol/isolated-pools/pull/294) to make them compatible with other networks. Enabled in [VIP-232](https://app.venus.io/#/governance/proposal/232).
+**Scope**: [token-bridge](https://github.com/VenusProtocol/token-bridge) repository, with contracts to bridge XVS between BNB Chain and other EVM-compatible networks, such as Ethereum. Extend the OFTV2 LayerZero contracts by adding custom security rules. XVS and TokenController contracts to be used on the destination chains (initially Ethereum mainnet, Arbitrum One, Polygon zkEVM, and opBNB). Moreover, the audit scope included a new [`VTreasuryV8`](https://github.com/VenusProtocol/venus-protocol/pull/345) contract and changes in the [Resilient Oracle](https://github.com/VenusProtocol/oracle/pull/124) and [Isolated Pools](https://github.com/VenusProtocol/isolated-pools/pull/294) to make them compatible with other networks. Enabled in [VIP-232](https://venus.io/governance/proposal/232?chainId=56).
 
 - [Certik audit report (2023/12/26)](https://github.com/VenusProtocol/token-bridge/blob/323e95fa3c0167cca2fc1d2807e911e0bae54de9/audits/083_multichain_token_bridge_certik_20231226.pdf)
 
@@ -586,7 +595,7 @@ Fix Borrow Cap 0 Logic
 
 **Scope**: `Prime` and `PrimeLiquidityProvider` contracts, to manage the eligibility of Prime tokens and the rewards distributions.
 
-Enabled in [VIP-201](https://app.venus.io/#/governance/proposal/201), [VIP-202](https://app.venus.io/#/governance/proposal/202), [VIP-203](https://app.venus.io/#/governance/proposal/203), [VIP-206](https://app.venus.io/#/governance/proposal/206) and [VIP-210](https://app.venus.io/#/governance/proposal/210). Updated in [VIP-225](https://app.venus.io/#/governance/proposal/225).
+Enabled in [VIP-201](https://venus.io/governance/proposal/201?chainId=56), [VIP-202](https://venus.io/governance/proposal/202?chainId=56), [VIP-203](https://venus.io/governance/proposal/203?chainId=56), [VIP-206](https://venus.io/governance/proposal/206?chainId=56) and [VIP-210](https://venus.io/governance/proposal/210?chainId=56). Updated in [VIP-225](https://venus.io/governance/proposal/225?chainId=56).
 
 - [OpenZeppelin audit report (2023/10/03)](https://github.com/VenusProtocol/venus-protocol/blob/e02832bb2716bc0a178d910f6698877bf1b191e1/audits/065_prime_openzeppelin_20231003.pdf)
 - [Certik audit report (2023/11/13)](https://github.com/VenusProtocol/venus-protocol/blob/2425501070d28c36a73861d9cf6970f641403735/audits/060_prime_certik_20231113.pdf)
@@ -619,7 +628,7 @@ Enabled in [VIP-201](https://app.venus.io/#/governance/proposal/201), [VIP-202](
         - contracts/Tokens/Prime/libs/FixedMath.sol
         - contracts/Tokens/Prime/libs/FixedMath0x.sol
 
-- Venus Prime update. Enabled in [VIP-225](https://app.venus.io/#/governance/proposal/225).
+- Venus Prime update. Enabled in [VIP-225](https://venus.io/governance/proposal/225?chainId=56).
 
   - Pull request [#407](https://github.com/VenusProtocol/venus-protocol/pull/407)
     - contracts/Tokens/Prime/IPrime.sol
@@ -640,7 +649,7 @@ Enabled in [VIP-201](https://app.venus.io/#/governance/proposal/201), [VIP-202](
 
 ### Automatic income allocation
 
-**Scope**: Changes in the VToken contracts of the Core and IL pools (including the VBNB market), to send automatically the interest reserves to the new ProtocolShareReserve contract, where configured rules will distribute the income following the tokenomics of the project. Enabled in [VIP-189](https://app.venus.io/#/governance/proposal/189), [VIP-192](https://app.venus.io/#/governance/proposal/192), [VIP-193](https://app.venus.io/#/governance/proposal/193) and [VIP-194](https://app.venus.io/#/governance/proposal/194).
+**Scope**: Changes in the VToken contracts of the Core and IL pools (including the VBNB market), to send automatically the interest reserves to the new ProtocolShareReserve contract, where configured rules will distribute the income following the tokenomics of the project. Enabled in [VIP-189](https://venus.io/governance/proposal/189?chainId=56), [VIP-192](https://venus.io/governance/proposal/192?chainId=56), [VIP-193](https://venus.io/governance/proposal/193?chainId=56) and [VIP-194](https://venus.io/governance/proposal/194?chainId=56).
 
 - [Quantstamp audit report (2023/09/13)](https://github.com/VenusProtocol/venus-protocol/blob/9ef8901dfef84a11338751881fd10a2d36c576ad/audits/058_automatic_income_allocation_quantstamp_20230913.pdf)
 - [Certik audit report (2023/09/12)](https://github.com/VenusProtocol/venus-protocol/blob/90f913fd345c24c60efa613ab5ab7e633b7aa07a/audits/059_automatic_income_allocation_certik_20230912.pdf)
@@ -681,13 +690,13 @@ Enabled in [VIP-201](https://app.venus.io/#/governance/proposal/201), [VIP-202](
 
 ### Diamond Comptroller
 
-**Scope**: Upgrade of the Comptroller contract in the Core pool, implementing the Diamond pattern. Enabled in the [VIP-174](https://app.venus.io/#/governance/proposal/174).
+**Scope**: Upgrade of the Comptroller contract in the Core pool, implementing the Diamond pattern. Enabled in the [VIP-174](https://venus.io/governance/proposal/174?chainId=56).
 
 - [Fairyproof audit report (2023/06/25)](https://github.com/VenusProtocol/venus-protocol/blob/8553387f2277be152883b4ee22211b77a8cbe5f6/audits/040_diamondComptroller_fairyproof_20230625.pdf)
-- [Peckshield audit report (2023/07/28)](https://github.com/VenusProtocol/venus-protocol/blob/8553387f2277be152883b4ee22211b77a8cbe5f6/audits/042_diamondComptroller_peckshield_20230718.pdf)
+- [Peckshield audit report (2023/07/18)](https://github.com/VenusProtocol/venus-protocol/blob/8553387f2277be152883b4ee22211b77a8cbe5f6/audits/042_diamondComptroller_peckshield_20230718.pdf)
 - [Certik audit report (2023/08/03)](https://github.com/VenusProtocol/venus-protocol/blob/8553387f2277be152883b4ee22211b77a8cbe5f6/audits/044_diamondComptroller_certik_20230803.pdf)
 - [OpenZeppelin audit report (2023/08/17)](https://github.com/VenusProtocol/venus-protocol/blob/8553387f2277be152883b4ee22211b77a8cbe5f6/audits/049_diamondComptroller_openzeppelin_20230817.pdf)
-- [Quantstamp audit report (2023/09/20)](https://github.com/VenusProtocol/venus-protocol/blob/8553387f2277be152883b4ee22211b77a8cbe5f6/audits/047_diamondComptroller_quantstamp_20230919.pdf)
+- [Quantstamp audit report (2023/09/19)](https://github.com/VenusProtocol/venus-protocol/blob/8553387f2277be152883b4ee22211b77a8cbe5f6/audits/047_diamondComptroller_quantstamp_20230919.pdf)
 
 <details>
 <summary>Detailed scope</summary>
@@ -716,7 +725,7 @@ Files in the scope of the audit:
 
 ### BUSDLiquidator
 
-**Scope**: Contract to forcibly liquidate BUSD positions after enabling the ["forced liquidations" feature](./guides/market-interaction/liquidation.md#forced-liquidations) in the BUSD market, in the [VIP-191](https://app.venus.io/#/governance/proposal/191)
+**Scope**: Contract to forcibly liquidate BUSD positions after enabling the ["forced liquidations" feature](./guides/market-interaction/liquidation.md#forced-liquidations) in the BUSD market, in the [VIP-191](https://venus.io/governance/proposal/191?chainId=56)
 
 * [Peckshield audit report (2023/10/20)](https://github.com/VenusProtocol/venus-protocol/blob/b9dff61b16c4002db4cc01d3f25db160209a3d8d/audits/077_busdLiquidator_peckshield_20231020.pdf)
 
@@ -730,29 +739,29 @@ Files in the scope of the audit:
 
 ### Forced liquidations in the Isolated pools
 
-**Scope**: Upgrade of the Comptroller contract in the Isolated pools, adding the ["forced liquidations" feature](./guides/market-interaction/liquidation.md#forced-liquidations), enabled on [VIP-186](https://app.venus.io/#/governance/proposal/186)
+**Scope**: Upgrade of the Comptroller contract in the Isolated pools, adding the ["forced liquidations" feature](./guides/market-interaction/liquidation.md#forced-liquidations), enabled on [VIP-186](https://venus.io/governance/proposal/186?chainId=56)
 
 * [Certik audit report (2023/10/16)](https://github.com/VenusProtocol/isolated-pools/blob/41a96ca24b0e32b8087ea7b916ae2864cbf1a05f/audits/078_forcedLiquidations_certik_20231016.pdf)
 
 ### Forced liquidations in the Core pool
 
-**Scope**: Upgrade of the Comptroller contract in the Core pool, adding the ["forced liquidations" feature](./guides/market-interaction/liquidation.md#forced-liquidations), enabled on [VIP-172](https://app.venus.io/#/governance/proposal/172)
+**Scope**: Upgrade of the Comptroller contract in the Core pool, adding the ["forced liquidations" feature](./guides/market-interaction/liquidation.md#forced-liquidations), enabled on [VIP-172](https://venus.io/governance/proposal/172?chainId=56)
 
 * [Certik audit report (2023/09/16)](https://github.com/VenusProtocol/venus-protocol/blob/80cf9b36ea900d71c5e97a5b1d5e2706ecefb9c3/audits/072_forcedLiquidations_certik_20230916.pdf)
 * [Peckshield audit report (2023/09/16)](https://github.com/VenusProtocol/venus-protocol/blob/80cf9b36ea900d71c5e97a5b1d5e2706ecefb9c3/audits/073_forcedLiquidations_peckshield_20230916.pdf)
 
 ### RiskFund and Shortfall handling
 
-**Scope**: `RiskFund`, `Shortfall` and `ProtocolShareReserve` contracts in the [isolated-pools repo](https://github.com/VenusProtocol/isolated-pools), enabled on [VIP-170](https://app.venus.io/#/governance/proposal/170)
+**Scope**: `RiskFund`, `Shortfall` and `ProtocolShareReserve` contracts in the [isolated-pools repo](https://github.com/VenusProtocol/isolated-pools), enabled on [VIP-170](https://venus.io/governance/proposal/170?chainId=56)
 
-These contracts were in the scope of the audits done before the launch of Isolated Pools in the [VIP-134](https://app.venus.io/#/governance/proposal/134). Some upgrades were done on these contracts, and a new round of audits were done focused on these changes.
+These contracts were in the scope of the audits done before the launch of Isolated Pools in the [VIP-134](https://venus.io/governance/proposal/134?chainId=56). Some upgrades were done on these contracts, and a new round of audits were done focused on these changes.
 
 * [Certik audit report - 2023/08/24](https://github.com/VenusProtocol/isolated-pools/blob/1116c02c253e82cb0483afc47fb1fa104152601e/audits/061_riskFundShortfall_certik_20230824.pdf)
 * [Peckshield audit report - 2023/08/25](https://github.com/VenusProtocol/isolated-pools/blob/1116c02c253e82cb0483afc47fb1fa104152601e/audits/062_riskFundShortfall_peckshield_20230825.pdf)
 
 ### Peg Stability Module (PSM)
 
-**Scope**: Peg Stability Module [contract](https://github.com/VenusProtocol/venus-protocol/blob/develop/contracts/PegStability/PegStability.sol) for VAI/USDT, enabled on [VIP-157](https://app.venus.io/#/governance/proposal/157)
+**Scope**: Peg Stability Module [contract](https://github.com/VenusProtocol/venus-protocol/blob/develop/contracts/PegStability/PegStability.sol) for VAI/USDT, enabled on [VIP-157](https://venus.io/governance/proposal/157?chainId=56)
 
 * [Quantstamp audit report - 2023/08/07](https://github.com/VenusProtocol/venus-protocol/blob/90dfde3af29470938032c88ad7f9b31b3a4c503b/audits/057_psm_quantstamp_20230807.pdf)
 * [Certik audit report - 2023/05/24](https://github.com/VenusProtocol/venus-protocol/blob/90dfde3af29470938032c88ad7f9b31b3a4c503b/audits/021_psm_certik_20230524.pdf)
@@ -761,16 +770,16 @@ These contracts were in the scope of the audits done before the launch of Isolat
 
 ### Oracles upgrade (2023/07/24)
 
-**Scope**: Upgrade of the Resilient Price Feeds, enabled on [VIP-145](https://app.venus.io/governance/proposal/145).
+**Scope**: Upgrade of the Resilient Price Feeds, enabled on [VIP-145](https://venus.io/governance/proposal/145?chainId=56).
 
 * [Peckshield audit report - 2023/07/12](https://github.com/VenusProtocol/oracle/blob/fb02cdd3865fb5c34e0cd65cbeda02f87841371a/audits/045_getPrice_peckshield_20230712.pdf)
 * [Certik audit report - 2023/07/17](https://github.com/VenusProtocol/oracle/blob/fb02cdd3865fb5c34e0cd65cbeda02f87841371a/audits/043_getPrice_certik_20230717.pdf)
 
 ### Oracles
 
-**Scope**: New Resilient Price Feeds, enabled on [VIP-123](https://app.venus.io/governance/proposal/123).
+**Scope**: New Resilient Price Feeds, enabled on [VIP-123](https://venus.io/governance/proposal/123?chainId=56).
 
-* [OpenZeppeling audit report - 2023/06/06](https://github.com/VenusProtocol/oracle/blob/6f7a3d8769c28881661953e7ee3299b1d5b31e17/audits/026_oracles_openzeppelin_20230606.pdf)
+* [OpenZeppelin audit report - 2023/06/06](https://github.com/VenusProtocol/oracle/blob/6f7a3d8769c28881661953e7ee3299b1d5b31e17/audits/026_oracles_openzeppelin_20230606.pdf)
 * [Peckshield audit report - 2023/04/24](https://github.com/VenusProtocol/oracle/blob/6f7a3d8769c28881661953e7ee3299b1d5b31e17/audits/013_oracles_peckshield_20230424.pdf)
 * [Certik audit report - 2023/05/22](https://github.com/VenusProtocol/oracle/blob/6f7a3d8769c28881661953e7ee3299b1d5b31e17/audits/024_oracles_certik_20230522.pdf)
 * [Hacken audit report - 2023/04/26](https://github.com/VenusProtocol/oracle/blob/6f7a3d8769c28881661953e7ee3299b1d5b31e17/audits/016_oracles_hacken_20230426.pdf)
@@ -778,7 +787,7 @@ These contracts were in the scope of the audits done before the launch of Isolat
 
 ### Vaults
 
-**Scope**: Upgrade of the XVSVault, VAIVault and VRTVault, enabled on [VIP-127](https://app.venus.io/governance/proposal/127).
+**Scope**: Upgrade of the XVSVault, VAIVault and VRTVault, enabled on [VIP-127](https://venus.io/governance/proposal/127?chainId=56).
 
 * [Quantstamp audit report - 2023/05/19](https://github.com/VenusProtocol/venus-protocol/blob/cb91c322f9d267cac11f532924b07a4b1991be64/audits/031_vaults_quantstamp_20230519.pdf)
 * [Peckshield audit report 1 - 2023/03/22](https://github.com/VenusProtocol/venus-protocol/blob/cb91c322f9d267cac11f532924b07a4b1991be64/audits/012_vaults_peckshield_20230322.pdf)
@@ -788,7 +797,7 @@ These contracts were in the scope of the audits done before the launch of Isolat
 
 ### Isolated pools
 
-**Scope**: Isolated pools, first enabled on [VIP-134](https://app.venus.io/governance/proposal/134).
+**Scope**: Isolated pools, first enabled on [VIP-134](https://venus.io/governance/proposal/134?chainId=56).
 
 * [Certik audit report](https://github.com/VenusProtocol/isolated-pools/blob/1d60500e28d4912601bac461870c754dd9e72341/audits/036_isolatedPools_certik_20230619.pdf)
 * [Certik audit report (RewardsDistributor)](https://github.com/VenusProtocol/isolated-pools/blob/95b1c8906774e5d849dd1e00ba7c608c679f8977/audits/051_rewardsDistributor_certik_20230610.pdf)
@@ -817,7 +826,7 @@ These contracts were in the scope of the audits done before the launch of Isolat
 
 ### Swap router
 
-**Scope**: SwapRouter contract, enabled on [VIP-131](https://app.venus.io/governance/proposal/131).
+**Scope**: SwapRouter contract, enabled on [VIP-131](https://venus.io/governance/proposal/131?chainId=56).
 
 * [OpenZeppelin audit report - 2023/06/16](https://github.com/VenusProtocol/venus-protocol/blob/develop/audits/027_swapRouter_openzeppelin_20230616.pdf)
 * [Certik audit report - 2023/05/30](https://github.com/VenusProtocol/venus-protocol/blob/develop/audits/030_swapRouter_certik_20230530.pdf)
@@ -826,6 +835,6 @@ These contracts were in the scope of the audits done before the launch of Isolat
 
 ### VToken
 
-**Scope**: Delegate Borrowing in Venus. Upgrade of BUSD, USDC, USDT, BTCB and ETH markets, to reduce the risks on Venus that resulted from the September 2022 BNB Bridge incident. Executed on [VIP-99](https://app.venus.io/governance/proposal/99).
+**Scope**: Delegate Borrowing in Venus. Upgrade of BUSD, USDC, USDT, BTCB and ETH markets, to reduce the risks on Venus that resulted from the September 2022 BNB Bridge incident. Executed on [VIP-99](https://venus.io/governance/proposal/99?chainId=56).
 
 * [Peckshield audit report - 2023/02/27](https://github.com/VenusProtocol/venus-protocol/blob/develop/audits/009_vtoken_peckshield_20230227.pdf)


### PR DESCRIPTION
## Summary

- replace broad safety assurances with explicit audit-scope and deployed-code verification boundaries
- repair 42 legacy governance proposal deep links and remove an unresolved conflict marker
- fix a malformed pull-request link, four incorrect report dates, auditor names, and several objective protocol/link typos
- remove the unsupported bug-bounty claim instead of pointing readers to an unverified program

## Verification

- audited all 225 unique Markdown link destinations; all resolved except six BscScan pages that reject automated clients with HTTP 403
- verified all 40 unique current governance proposal URLs return HTTP 200
- cross-checked corrected report dates against artifact filenames and PDF metadata
- verified both relative documentation links and the forced-liquidations anchor
- Remark semantic warnings are resolved; 40 pre-existing list indentation warnings remain unchanged
- git diff --check