### PR TITLE
docs: refresh resources and community links

### DIFF
--- a/links/brand-kit.md
+++ b/links/brand-kit.md
@@ -38,6 +38,6 @@
 
 ## VTokens logo
 
-<figure><img src="../.gitbook/assets/brand_kit/vTokens/preview.png" alt="VAI logo"><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/brand_kit/vTokens/preview.png" alt="vTokens logos"><figcaption></figcaption></figure>
 
 [[ZIP](../.gitbook/assets/brand_kit/vTokens/vTokens_set.zip)]

--- a/links/community-resources.md
+++ b/links/community-resources.md
@@ -1,19 +1,30 @@
 # Community Resources
 
-## Monitoring
+The links on this page were reviewed on August 27, 2026. Channel ownership, availability, and data coverage can change.
 
-* [Dune dashboard](https://dune.com/xvslove\_team/venus-protocol-dashboard)
-* [Chaos labs analytics](https://community.chaoslabs.xyz/venus/risk/overview)
-* [Messari dashboard](https://messari.io/project/venus/protocols/venus)
+{% hint style="danger" %}
+Community bots and third-party dashboards are not sources of truth for balances, positions, market parameters, governance state, or contract addresses. Cross-check important data against the live contracts and official Venus interfaces. Never connect a wallet, reveal a recovery phrase, or sign a transaction requested by a Telegram bot or direct message.
+{% endhint %}
 
-## Telegram Groups
+## Official community channels
 
-* [Venus Discussion Group](https://t.me/venusprotocol)
-* [Venus Announcement Channel](https://t.me/VenusNewsBroadcast)
+* [Venus website](https://venus.io/) — use the community links in the website footer to verify official handles
+* [Governance and community forum](https://community.venus.io/)
+* [Venus discussion group](https://t.me/venusprotocol)
+* [Venus Discord](https://discord.gg/venus-protocol-912811548651708448)
+* [Venus announcement channel](https://t.me/VenusNewsBroadcast) — also identified from the official Telegram discussion group profile
 
-### Telegram Bots
+## External data and monitoring
 
-* [Venus Stats](https://t.me/venusstats). Total supply, total borrow, total reserves, XVS Vault stats, Prime holders, etc.
-* [Venus Whales](https://t.me/venuswhaleswatch). Watching for significant sum movement (> $1M) on Venus Protocol
-* [Venus Liquidations](https://t.me/venusliqwatch). Watching on liquidation events of Venus Protocol
-* [Venus Governance](https://t.me/venusgovwatch). Watching governance proposals (VIP) of Venus Protocol
+These services are operated outside the Venus documentation and can be delayed, incomplete, or use different accounting definitions.
+
+* [Chaos Labs risk analytics](https://community.chaoslabs.xyz/venus/risk/overview)
+* [DeFiLlama Venus dashboard](https://defillama.com/protocol/venus)
+* [Community-created Dune dashboard](https://dune.com/xvslove_team/venus-protocol-dashboard)
+* [Messari Venus profile](https://messari.io/project/venus)
+
+## Community-maintained Telegram feeds
+
+* [Venus Stats](https://t.me/venusstats) — automated summaries of supply, borrow, reserves, XVS Vaults, and Prime holders
+
+This feed is not listed as an official Venus channel. Treat every value as informational and verify it independently before acting.

--- a/resources.md
+++ b/resources.md
@@ -1,10 +1,34 @@
 # Resources
 
-We have compiled a list of helpful resources to provide you with the necessary information. Whether you are a new user or an experienced one, this page is designed to address the most frequently asked questions and concerns about our protocol. We understand that sometimes you may need additional support beyond this page, so we encourage you to visit our [community forum](https://community.venus.io/). There, you can engage with our community and ask any additional questions. We hope you find this resource helpful and informative
+Use the versioned documentation below for current procedures. Blog posts, videos, and screenshots describe the interface and deployments at the time they were published and may no longer match the live protocol.
 
-* [How to Use Venus Protocol Mini Program on Binance App?](https://medium.com/venusprotocol/how-to-use-venus-protocol-mini-program-on-binance-app-226b76a85312)
-* [How To Use Venus Guide?](https://medium.com/venusprotocol/how-to-use-venus-protocol-71cb09703fbf)
-* [How to setup BNB Chain on MetaMask?](https://medium.com/venusprotocol/venus-protocol-main-network-launched-52ea9929091f)
-* [How to use XVS Vault? How to stake XVS?](https://medium.com/@Venus_protocol/venus-vault-user-guide-cd1042b18401)
-* [How do liquidations work?](https://community.venus.io/t/liquidation-guide-for-venus-protocol/2930)
-* [Venus All Social Media Links](https://linktr.ee/venusprotocol)
+{% hint style="warning" %}
+Verify the network, market, token, contract address, and transaction details before signing. Do not rely on search results, direct messages, or an old tutorial for an app URL or contract address.
+{% endhint %}
+
+## User guides
+
+* [Venus overview](README.md)
+* [Venus interface](guides/market-interaction/interface.md)
+* [Supplying and borrowing](guides/market-interaction/supply-borrow.md)
+* [Liquidations](guides/market-interaction/liquidation.md)
+* [XVS Vault](guides/vaults.md)
+* [Governance](guides/governance/README.md)
+* [Protocol math](guides/protocol-math.md)
+
+## Protocol and developer references
+
+* [Contracts overview](technical-reference/contracts-overview.md)
+* [Deployed markets](deployed-contracts/markets.md)
+* [API](services/api.md)
+* [Subgraphs](services/subgraphs.md)
+* [Security and audits](security-and-audits.md)
+
+## Support and project links
+
+* [Venus app](https://app.venus.io)
+* [Venus website](https://venus.io/)
+* [Governance and community forum](https://community.venus.io/)
+* [Venus Protocol on GitHub](https://github.com/VenusProtocol)
+* [Community-maintained resources](links/community-resources.md)
+* [Brand kit](links/brand-kit.md)


### PR DESCRIPTION
## Summary

- replace 2020-2022 single-chain and legacy-interface tutorials with current versioned guides in this repository
- separate official community channels from external dashboards and community-maintained feeds
- remove three Telegram monitoring feeds whose latest public updates stopped in November 2025
- update the redirected Messari destination and add explicit third-party data and wallet-safety boundaries
- correct the vTokens brand-kit image description and missing final newline

## Verification

- checked every local link and brand asset target
- verified current official website, forum, GitHub, Discord, and Telegram destinations
- verified current external dashboard destinations; Chaos Labs, DeFiLlama, and Messari resist or throttle command-line clients but load through normal web access
- confirmed the retained Venus Stats feed published current data on August 27, 2026
- targeted Remark: no issues found
- git diff --check