### PR TITLE
docs: map core economics and vault versions

### DIFF
--- a/technical-reference/reference-core-pool/interestratemodels/README.md
+++ b/technical-reference/reference-core-pool/interestratemodels/README.md
@@ -1,2 +1,27 @@
-# InterestRateModels
+# BNB Core Interest Rate Models
 
+Each BNB Core market stores its own interest-rate-model address. Model families and annualization constants have changed over time, so the market address and block determine the applicable implementation.
+
+## Model selection
+
+1. Read `interestRateModel()` from the vToken.
+2. Identify whether the returned address is a model or a `CheckpointView` wrapper.
+3. For a wrapper, resolve the active target at the relevant checkpoint.
+4. Read `blocksPerYear` or `BLOCKS_PER_YEAR` from the effective model before annualizing a per-block rate.
+5. Use the exact deployed ABI and parameters; do not infer them from the model family name.
+
+At BNB Chain block `118,364,540`, the active vUSDC and vUSDT markets both pointed to `CheckpointView` `0x2CF0e211c99dFd28892cf80D142aA27a9042Dbf4`, whose active TwoKinks target exposed `BLOCKS_PER_YEAR = 70,080,000`.
+
+{% hint style="warning" %}
+Checkpoint wrappers can switch their underlying model at a configured timestamp while keeping the same address in the vToken. Historical rate reconstruction must resolve the target for the historical block, not only inspect the wrapper's current result.
+{% endhint %}
+
+## Model families
+
+* [JumpRateModel](jumpmodel.md) — one kink and a jump slope.
+* [TwoKinksInterestRateModel](twokinksinterestratemodel.md) — three curve segments separated by two kinks.
+* [WhitePaperInterestRateModel](whitepapermodel.md) — older linear model; some unlisted markets retain balances or debt, so its legacy reference must remain available.
+
+The previously published [InterestRateModelLens page](interestratemodellens.md) has no resolved canonical source or deployment and must not be treated as a supported integration address.
+
+Current market addresses are listed in [Deployed Markets](../../../deployed-contracts/markets.md). For interest, exchange-rate, and APR/APY equations, see [Protocol Math](../../../guides/protocol-math.md).

--- a/technical-reference/reference-core-pool/interestratemodels/interestratemodellens.md
+++ b/technical-reference/reference-core-pool/interestratemodels/interestratemodellens.md
@@ -1,36 +1,22 @@
-# InterestRateModelLens
+# InterestRateModelLens — Unverified Legacy Reference
 
-Lens for querying interest rate model simulations
-
-# Solidity API
+The former page described this function:
 
 ```solidity
-struct SimulationResponse {
-  uint256[] borrowSimulation;
-  uint256[] supplySimulation;
-}
+function getNextInterestRates(
+    uint256 cash,
+    uint256 borrows,
+    uint256 reserves,
+    uint256 reserveFactorMantissa,
+    uint256 badDebt,
+    InterestRateModel interestRateModel
+) external view returns (uint256 borrowRate, uint256 supplyRate)
 ```
 
-### getSimulationResponse
+No canonical source file, deployed address, supported network, or current consumer for `InterestRateModelLens` has been identified in the stable Venus repositories or deployment registries.
 
-Simulate interest rate curve fo a specific interest rate model given a reference borrow amount and reserve factor
+{% hint style="danger" %}
+Do not assume this contract is deployed or supported. Simulate rates by calling the exact model selected by the target market, after resolving any `CheckpointView` wrapper. See [BNB Core Interest Rate Models](README.md).
+{% endhint %}
 
-```solidity
-function getSimulationResponse(uint256 referenceAmountInWei, address interestRateModel, uint256 reserveFactorMantissa) external view returns (struct InterestRateModelLens.SimulationResponse)
-```
-
-#### Parameters
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| referenceAmountInWei | uint256 | Borrow amount to use in simulation |
-| interestRateModel | address | Address for interest rate model to simulate |
-| reserveFactorMantissa | uint256 | Reserve Factor to use in simulation |
-
-#### Return Values
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| \[0] | struct InterestRateModelLens.SimulationResponse |  |
-
----
+This page is retained only to prevent old links from silently implying that the unverified ABI is current. It can be archived after integrations and ownership are conclusively ruled out.

--- a/technical-reference/reference-core-pool/interestratemodels/jumpmodel.md
+++ b/technical-reference/reference-core-pool/interestratemodels/jumpmodel.md
@@ -1,13 +1,29 @@
 # JumpRateModel
 
+This page describes the BNB Core `JumpRateModel` source in venus-protocol v10.3.0. A market can point to this model directly or through a `CheckpointView` wrapper.
+
+{% hint style="warning" %}
+Resolve `interestRateModel()` on the target vToken and read the effective model's `blocksPerYear` before annualizing. Model address, parameters, and annualization basis are market- and block-specific.
+{% endhint %}
+
 # Solidity API
+
+### blocksPerYear
+
+Approximate blocks per year used to convert annual constructor parameters to per-block rates.
+
+```solidity
+uint256 blocksPerYear
+```
+
+---
 
 ### constructor
 
 Construct an interest rate model
 
 ```solidity
-constructor(uint256 baseRatePerYear, uint256 multiplierPerYear, uint256 jumpMultiplierPerYear, uint256 kink_) public
+constructor(uint256 baseRatePerYear, uint256 multiplierPerYear, uint256 jumpMultiplierPerYear, uint256 kink_, uint256 blocksPerYear_) public
 ```
 
 #### Parameters
@@ -18,6 +34,7 @@ constructor(uint256 baseRatePerYear, uint256 multiplierPerYear, uint256 jumpMult
 | multiplierPerYear | uint256 | The rate of increase in interest rate wrt utilization (scaled by 1e18) |
 | jumpMultiplierPerYear | uint256 | The multiplierPerBlock after hitting a specified utilization point |
 | kink\_ | uint256 | The utilization point at which the jump multiplier is applied |
+| blocksPerYear\_ | uint256 | The approximate number of blocks per year assumed by this model |
 
 ---
 

--- a/technical-reference/reference-core-pool/interestratemodels/twokinksinterestratemodel.md
+++ b/technical-reference/reference-core-pool/interestratemodels/twokinksinterestratemodel.md
@@ -2,7 +2,21 @@
 
 An interest rate model with two different slope increase or decrease each after a certain utilization threshold called **kink** is reached.
 
+{% hint style="warning" %}
+BNB Core model reference. Resolve the vToken's live model and any `CheckpointView` wrapper before using this ABI. Read `BLOCKS_PER_YEAR` from the effective target; the value is not a universal BNB constant.
+{% endhint %}
+
 # Solidity API
+
+### BLOCKS_PER_YEAR
+
+Approximate blocks per year used to convert annual constructor parameters to per-block rates.
+
+```solidity
+int256 BLOCKS_PER_YEAR
+```
+
+---
 
 ### MULTIPLIER_PER_BLOCK
 
@@ -12,7 +26,7 @@ The multiplier of utilization rate per block that gives the slope 1 of the inter
 int256 MULTIPLIER_PER_BLOCK
 ```
 
-- - -
+---
 
 ### BASE_RATE_PER_BLOCK
 
@@ -22,7 +36,7 @@ The base interest rate per block which is the y-intercept when utilization rate 
 int256 BASE_RATE_PER_BLOCK
 ```
 
-- - -
+---
 
 ### KINK_1
 
@@ -32,7 +46,7 @@ The utilization point at which the multiplier2 is applied
 int256 KINK_1
 ```
 
-- - -
+---
 
 ### MULTIPLIER_2_PER_BLOCK
 
@@ -42,7 +56,7 @@ The multiplier of utilization rate per block that gives the slope 2 of the inter
 int256 MULTIPLIER_2_PER_BLOCK
 ```
 
-- - -
+---
 
 ### BASE_RATE_2_PER_BLOCK
 
@@ -52,7 +66,7 @@ The base interest rate per block which is the y-intercept when utilization rate 
 int256 BASE_RATE_2_PER_BLOCK
 ```
 
-- - -
+---
 
 ### RATE_1
 
@@ -62,7 +76,7 @@ The maximum kink interest rate scaled by EXP_SCALE
 int256 RATE_1
 ```
 
-- - -
+---
 
 ### KINK_2
 
@@ -72,7 +86,7 @@ The utilization point at which the jump multiplier is applied
 int256 KINK_2
 ```
 
-- - -
+---
 
 ### JUMP_MULTIPLIER_PER_BLOCK
 
@@ -82,7 +96,7 @@ The multiplier of utilization rate per block that gives the slope 3 of interest 
 int256 JUMP_MULTIPLIER_PER_BLOCK
 ```
 
-- - -
+---
 
 ### RATE_2
 
@@ -92,14 +106,14 @@ The maximum kink interest rate scaled by EXP_SCALE
 int256 RATE_2
 ```
 
-- - -
+---
 
 ### constructor
 
 Construct an interest rate model
 
 ```solidity
-constructor(int256 baseRatePerYear_, int256 multiplierPerYear_, int256 kink1_, int256 multiplier2PerYear_, int256 baseRate2PerYear_, int256 kink2_, int256 jumpMultiplierPerYear_) public
+constructor(int256 baseRatePerYear_, int256 multiplierPerYear_, int256 kink1_, int256 multiplier2PerYear_, int256 baseRate2PerYear_, int256 kink2_, int256 jumpMultiplierPerYear_, int256 blocksPerYear_) public
 ```
 
 #### Parameters
@@ -112,8 +126,9 @@ constructor(int256 baseRatePerYear_, int256 multiplierPerYear_, int256 kink1_, i
 | baseRate2PerYear_ | int256 | The additional base APR after hitting KINK_1, as a mantissa (scaled by EXP_SCALE) |
 | kink2_ | int256 | The utilization point at which the jump multiplier is applied |
 | jumpMultiplierPerYear_ | int256 | The multiplier after hitting KINK_2 |
+| blocksPerYear_ | int256 | The approximate number of blocks per year assumed by this model |
 
-- - -
+---
 
 ### getBorrowRate
 
@@ -133,9 +148,9 @@ function getBorrowRate(uint256 cash, uint256 borrows, uint256 reserves) external
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | uint256 | The borrow rate percentage per slot (block) as a mantissa (scaled by EXP_SCALE) |
+| \[0\] | uint256 | The borrow rate percentage per slot (block) as a mantissa (scaled by EXP_SCALE) |
 
-- - -
+---
 
 ### getSupplyRate
 
@@ -156,9 +171,9 @@ function getSupplyRate(uint256 cash, uint256 borrows, uint256 reserves, uint256 
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | uint256 | The supply rate percentage per slot (block) as a mantissa (scaled by EXP_SCALE) |
+| \[0\] | uint256 | The supply rate percentage per slot (block) as a mantissa (scaled by EXP_SCALE) |
 
-- - -
+---
 
 ### utilizationRate
 
@@ -178,7 +193,6 @@ function utilizationRate(uint256 cash, uint256 borrows, uint256 reserves) public
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | uint256 | The utilization rate as a mantissa between [0, EXP_SCALE] |
+| \[0\] | uint256 | The utilization rate as a mantissa between \[0, EXP_SCALE\] |
 
-- - -
-
+---

--- a/technical-reference/reference-core-pool/interestratemodels/whitepapermodel.md
+++ b/technical-reference/reference-core-pool/interestratemodels/whitepapermodel.md
@@ -2,14 +2,28 @@
 
 The parameterized model described in section 2.4 of the original Venus Protocol whitepaper
 
+{% hint style="warning" %}
+Legacy BNB Core model reference. Some unlisted markets still retain supply or debt, so the ABI remains operationally relevant. Resolve the market's exact model and `blocksPerYear` at the historical block; do not use this page to infer that a market is active or deprecated.
+{% endhint %}
+
 # Solidity API
+
+### blocksPerYear
+
+Approximate blocks per year used to convert annual constructor parameters to per-block rates.
+
+```solidity
+uint256 blocksPerYear
+```
+
+---
 
 ### constructor
 
 Construct an interest rate model
 
 ```solidity
-constructor(uint256 baseRatePerYear, uint256 multiplierPerYear) public
+constructor(uint256 baseRatePerYear, uint256 multiplierPerYear, uint256 blocksPerYear_) public
 ```
 
 #### Parameters
@@ -18,6 +32,7 @@ constructor(uint256 baseRatePerYear, uint256 multiplierPerYear) public
 | ---- | ---- | ----------- |
 | baseRatePerYear | uint256 | The approximate target base APR, as a mantissa (scaled by 1e18) |
 | multiplierPerYear | uint256 | The rate of increase in interest rate wrt utilization (scaled by 1e18) |
+| blocksPerYear\_ | uint256 | The approximate number of blocks per year assumed by this model |
 
 ---
 

--- a/technical-reference/reference-core-pool/prime/README.md
+++ b/technical-reference/reference-core-pool/prime/README.md
@@ -1,12 +1,38 @@
-# Prime
+# Prime Contract Versions
 
-The Venus Prime program is implemented by three core contracts, plus a read-only lens:
+Venus Prime has two deployed contract generations. BNB Chain uses PrimeV2 with a leaderboard; the other current mainnet rows still use Prime V1.
 
-* [PrimeV2](prime.md) — the Soulbound Prime token and boosted-reward engine.
-* [PrimeLeaderboard](prime-leaderboard.md) — time-weighted XVS staking tracker that decides eligibility.
-* [PrimeLiquidityProvider](prime-liquidity-provider.md) — funds PrimeV2 with the reward tokens.
-* [PrimeLens](prime-lens.md) — read-only helper for off-chain APR queries against PrimeV2.
+## Mainnet version map
 
-Storage layouts: [PrimeV2Storage](prime-storage.md), [PrimeLeaderboardStorage](prime-leaderboard-storage.md).
+The following state was read on 2026-08-27:
 
-See the [Venus Prime technical article](../../reference-technical-articles/prime.md) for how these fit together.
+| Network | Prime consumer | Generation | PLP mode | PLP paused |
+| --- | --- | --- | --- | --- |
+| BNB Chain | `0x059EabA8676b03e4e8f009eFb7F587C28450F50f` | PrimeV2 | block, 70,080,000/year | No |
+| Ethereum | `0x14C4525f47A7f7C984474979c57a2Dccb8EACB39` | Prime V1 | block, 2,628,000/year | No |
+| Arbitrum | `0xFE69720424C954A2da05648a0FAC84f9bf11Ef49` | Prime V1 | second, 31,536,000/year | Yes |
+| ZKsync | `0xdFe62Dcba3Ce0A827439390d7d45Af8baE599978` | Prime V1 | second, 31,536,000/year | Yes |
+| Optimism | `0xE76d2173546Be97Fa6E18358027BdE9742a649f7` | Prime V1 | second, 31,536,000/year | Yes |
+| Base | `0xD2e84244f1e9Fca03Ff024af35b8f9612D5d7a30` | Prime V1 | second, 31,536,000/year | Yes |
+| Unichain | `0x600aFf613d40D87C8Fe90Cb2e78e8e6667c0C872` | Prime V1 | second, 31,536,000/year | Yes |
+
+PLP means PrimeLiquidityProvider. A paused PLP does not by itself prove that the Prime deployment is deprecated; it proves only that PLP transfers were paused at the observed block. Check current product support, the Prime contract, and all funding paths before assigning a lifecycle state.
+
+{% hint style="danger" %}
+The child PrimeV2 and PrimeLeaderboard pages apply only to BNB Chain. Do not use their ABI, leaderboard eligibility, or permissionless minting model for a Prime V1 deployment.
+{% endhint %}
+
+## BNB PrimeV2 components
+
+At BNB Chain block `118,364,540`, PrimeV2 was unpaused and resolved to:
+
+| Component | Proxy or address | Implementation |
+| --- | --- | --- |
+| [PrimeV2](prime.md) | `0x059EabA8676b03e4e8f009eFb7F587C28450F50f` | `0x18cb7198cbb6d6e94001458cf3cf47c106d83a1b` |
+| [PrimeLeaderboard](prime-leaderboard.md) | `0x55e2ccF68B7A276dc28AfA107997b8B1Be932c0b` | `0xd80de9ecb6596df95dd67af73b67122054c2d1a1` |
+| [PrimeLiquidityProvider](prime-liquidity-provider.md) | `0x23c4F844ffDdC6161174eB32c770D4D8C07833F2` | `0x46bed43b29d73835ff075bba1a0002a1ed1e4de8` |
+| [PrimeLens](prime-lens.md) | `0x2f8c5e4562E22DB7908C56Bf99961C053436473c` | Non-proxy lens |
+
+Storage references: [PrimeV2Storage](prime-storage.md) and [PrimeLeaderboardStorage](prime-leaderboard-storage.md). See the [Venus Prime technical article](../../reference-technical-articles/prime.md) for the BNB V2 flow.
+
+Current addresses are listed in [Deployed Funds](../../../deployed-contracts/funds.md).

--- a/technical-reference/reference-core-pool/prime/prime-leaderboard-storage.md
+++ b/technical-reference/reference-core-pool/prime/prime-leaderboard-storage.md
@@ -1,6 +1,10 @@
 # PrimeLeaderboardStorageV1
 Storage layout for the PrimeLeaderboard contract
 
+{% hint style="warning" %}
+BNB PrimeLeaderboard only. Upgrade review must include inherited storage and the proxy's exact implementation. Source: [PrimeLeaderboardStorage.sol](https://github.com/VenusProtocol/venus-protocol/blob/v10.3.0/contracts/Tokens/Prime/PrimeLeaderboardStorage.sol).
+{% endhint %}
+
 # Solidity API
 
 ```solidity
@@ -98,6 +102,16 @@ Whether staker initialization is complete (prevents further initialization calls
 
 ```solidity
 bool stakersInitialized
+```
+
+- - -
+
+### __gap
+
+Reserved storage for future upgrades.
+
+```solidity
+uint256[45] __gap
 ```
 
 - - -

--- a/technical-reference/reference-core-pool/prime/prime-leaderboard.md
+++ b/technical-reference/reference-core-pool/prime/prime-leaderboard.md
@@ -1,7 +1,21 @@
 # PrimeLeaderboard
 PrimeLeaderboard manages Prime V2 eligibility with time-weighted scoring. It tracks per-deposit timestamps for LIFO withdrawals and computes each user's Prime Score. It is called by the `XVSVault` via the existing `xvsUpdated()` callback. Governance reads `getEffectiveStakeBatch()` off-chain, ranks users by Prime Score, and either sets a mint threshold on PrimeV2 (for permissionless minting) or calls `PrimeV2.issue()` / `burn()` directly.
 
+{% hint style="warning" %}
+BNB PrimeV2 only. At block `118,364,540`, proxy `0x55e2ccF68B7A276dc28AfA107997b8B1Be932c0b` used implementation `0xd80de9ecb6596df95dd67af73b67122054c2d1a1`. Resolve the live proxy and Access Control Manager before using an administrative function.
+{% endhint %}
+
 # Solidity API
+
+### constructor
+
+Sets immutable XVS Vault references and disables initialization on the implementation.
+
+```solidity
+constructor(address xvsVault_, address xvsVaultRewardToken_, uint256 xvsVaultPoolId_)
+```
+
+---
 
 ### xvsVault
 
@@ -11,7 +25,7 @@ Address of XVSVault contract
 address xvsVault
 ```
 
-- - -
+---
 
 ### xvsVaultRewardToken
 
@@ -21,7 +35,7 @@ Reward token address in XVSVault
 address xvsVaultRewardToken
 ```
 
-- - -
+---
 
 ### xvsVaultPoolId
 
@@ -31,7 +45,7 @@ Pool ID in XVSVault
 uint256 xvsVaultPoolId
 ```
 
-- - -
+---
 
 ### initialize
 
@@ -47,7 +61,7 @@ function initialize(address accessControlManager_, uint256 loopsLimit_) external
 | accessControlManager_ | address | Address of AccessControlManager |
 | loopsLimit_ | uint256 | Maximum number of loops allowed in a single transaction |
 
-- - -
+---
 
 ### initializeStakers
 
@@ -75,7 +89,7 @@ function initializeStakers(address[] users, uint256[] amounts, uint64[] timestam
 * Throw LengthMismatch if array lengths don't match
 * Throw InvalidTimestamp if a seeded timestamp is zero or in the future
 
-- - -
+---
 
 ### finalizeInitialization
 
@@ -94,7 +108,7 @@ function finalizeInitialization() external
 #### ❌ Errors
 * Throw StakersAlreadyInitialized if already finalized
 
-- - -
+---
 
 ### xvsUpdated
 
@@ -121,7 +135,7 @@ function xvsUpdated(address user) external
 * Throw OnlyXVSVaultAllowed if caller is not XVSVault
 * Throw ZeroAddress if user address is zero
 
-- - -
+---
 
 ### getEffectiveStake
 
@@ -141,7 +155,7 @@ function getEffectiveStake(address user) public view returns (uint256 effectiveS
 | ---- | ---- | ----------- |
 | effectiveStake | uint256 | The user's Prime Score (time-weighted) |
 
-- - -
+---
 
 ### getEffectiveStakeBatch
 
@@ -161,7 +175,7 @@ function getEffectiveStakeBatch(address[] users) external view returns (uint256[
 | ---- | ---- | ----------- |
 | scores | uint256[] | Array of Prime Scores |
 
-- - -
+---
 
 ### getTotalStaked
 
@@ -179,9 +193,9 @@ function getTotalStaked(address user) external view returns (uint256)
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | uint256 | The total XVS staked |
+| \[0\] | uint256 | The total XVS staked |
 
-- - -
+---
 
 ### getDeposits
 
@@ -201,7 +215,7 @@ function getDeposits(address user) external view returns (struct IPrimeLeaderboa
 | ---- | ---- | ----------- |
 | deposits | struct IPrimeLeaderboard.Deposit[] | Array of deposits (index 0 = oldest) |
 
-- - -
+---
 
 ### getDepositCount
 
@@ -221,7 +235,7 @@ function getDepositCount(address user) external view returns (uint256 count)
 | ---- | ---- | ----------- |
 | count | uint256 | Number of deposit tranches |
 
-- - -
+---
 
 ### getMultiplier
 
@@ -241,7 +255,7 @@ function getMultiplier(uint256 holdingDuration) external view returns (uint256 m
 | ---- | ---- | ----------- |
 | multiplier | uint256 | The multiplier (scaled by 1e18) |
 
-- - -
+---
 
 ### getMultiplierTiers
 
@@ -257,7 +271,7 @@ function getMultiplierTiers() external view returns (uint256[] durations, uint25
 | durations | uint256[] | Array of duration thresholds |
 | multipliers | uint256[] | Array of multiplier values |
 
-- - -
+---
 
 ### setMultiplierTiers
 
@@ -284,7 +298,7 @@ function setMultiplierTiers(uint256[] durations, uint256[] multipliers) external
 * Throw InvalidValue if durations array is empty
 * Throw InvalidMultiplierTiers if tiers are not in ascending order or multipliers below base
 
-- - -
+---
 
 ### setPrimeV2
 
@@ -308,7 +322,7 @@ function setPrimeV2(address primeV2_) external
 #### ❌ Errors
 * Throw ZeroAddress if address is zero
 
-- - -
+---
 
 ### setMaxLoopsLimit
 
@@ -329,5 +343,4 @@ function setMaxLoopsLimit(uint256 loopsLimit) external
 #### ⛔️ Access Requirements
 * Controlled by ACM
 
-- - -
-
+---

--- a/technical-reference/reference-core-pool/prime/prime-lens.md
+++ b/technical-reference/reference-core-pool/prime/prime-lens.md
@@ -1,6 +1,10 @@
 # PrimeLens
 PrimeLens is a read-only helper contract for off-chain APR queries against PrimeV2. It is kept separate from PrimeV2 to stay within the EVM contract-size limit. It holds an immutable reference to a PrimeV2 instance and derives values from PrimeV2 and PrimeLiquidityProvider state.
 
+{% hint style="info" %}
+BNB PrimeV2 only. The non-proxy lens `0x2f8c5e4562E22DB7908C56Bf99961C053436473c` points to BNB PrimeV2. It is not the lens or ABI for Prime V1 deployments on other networks.
+{% endhint %}
+
 # Solidity API
 
 ### primeV2

--- a/technical-reference/reference-core-pool/prime/prime-liquidity-provider.md
+++ b/technical-reference/reference-core-pool/prime/prime-liquidity-provider.md
@@ -1,7 +1,25 @@
 # PrimeLiquidityProvider
 PrimeLiquidityProvider is used to fund Prime
 
+PrimeLiquidityProvider deployments can accrue per block or per second and can fund either Prime V1 or PrimeV2. See the [Prime version map](README.md) for current consumer, clock, and pause state by network.
+
+{% hint style="warning" %}
+Distribution speeds use the deployment's `isTimeBased()` clock. Read `blocksOrSecondsPerYear()` and `paused()` from the exact proxy before annualizing a speed or assuming funds can be released.
+{% endhint %}
+
 # Solidity API
+
+### constructor
+
+Configures the immutable time basis on the implementation.
+
+```solidity
+constructor(bool timeBased_, uint256 blocksPerYear_)
+```
+
+When `timeBased_` is true, the contract uses seconds and the annualization constant is 31,536,000; otherwise it uses the supplied block count.
+
+---
 
 ### DEFAULT_MAX_DISTRIBUTION_SPEED
 
@@ -11,7 +29,7 @@ The default max token distribution speed
 uint256 DEFAULT_MAX_DISTRIBUTION_SPEED
 ```
 
-- - -
+---
 
 ### prime
 
@@ -21,17 +39,17 @@ Address of the Prime contract
 address prime
 ```
 
-- - -
+---
 
 ### tokenDistributionSpeeds
 
-The rate at which token is distributed (per block)
+The rate at which a token is distributed per block or second
 
 ```solidity
 mapping(address => uint256) tokenDistributionSpeeds
 ```
 
-- - -
+---
 
 ### maxTokenDistributionSpeeds
 
@@ -41,7 +59,7 @@ The max token distribution speed for token
 mapping(address => uint256) maxTokenDistributionSpeeds
 ```
 
-- - -
+---
 
 ### lastAccruedBlock
 
@@ -51,7 +69,7 @@ The last block or second up to which rewards were accrued for the token (view ge
 function lastAccruedBlock(address token_) external view returns (uint256)
 ```
 
-- - -
+---
 
 ### tokenAmountAccrued
 
@@ -61,7 +79,7 @@ The token accrued but not yet transferred to prime contract (view getter over th
 function tokenAmountAccrued(address token_) external view returns (uint256)
 ```
 
-- - -
+---
 
 ### initialize
 
@@ -83,7 +101,7 @@ function initialize(address accessControlManager_, address[] tokens_, uint256[] 
 #### ❌ Errors
 * Throw InvalidArguments on different length of tokens and speeds array
 
-- - -
+---
 
 ### initializeTokens
 
@@ -101,7 +119,7 @@ function initializeTokens(address[] tokens_) external
 #### ⛔️ Access Requirements
 * Only Governance
 
-- - -
+---
 
 ### pauseFundsTransfer
 
@@ -114,7 +132,7 @@ function pauseFundsTransfer() external
 #### ⛔️ Access Requirements
 * Controlled by ACM
 
-- - -
+---
 
 ### resumeFundsTransfer
 
@@ -127,11 +145,11 @@ function resumeFundsTransfer() external
 #### ⛔️ Access Requirements
 * Controlled by ACM
 
-- - -
+---
 
 ### setTokensDistributionSpeed
 
-Set distribution speed (amount of token distribute per block)
+Set distribution speed per block or second
 
 ```solidity
 function setTokensDistributionSpeed(address[] tokens_, uint256[] distributionSpeeds_) external
@@ -149,11 +167,11 @@ function setTokensDistributionSpeed(address[] tokens_, uint256[] distributionSpe
 #### ❌ Errors
 * Throw InvalidArguments on different length of tokens and speeds array
 
-- - -
+---
 
 ### setMaxTokensDistributionSpeed
 
-Set max distribution speed for token (amount of maximum token distribute per block)
+Set maximum distribution speed per block or second
 
 ```solidity
 function setMaxTokensDistributionSpeed(address[] tokens_, uint256[] maxDistributionSpeeds_) external
@@ -171,7 +189,7 @@ function setMaxTokensDistributionSpeed(address[] tokens_, uint256[] maxDistribut
 #### ❌ Errors
 * Throw InvalidArguments on different length of tokens and speeds array
 
-- - -
+---
 
 ### setPrimeToken
 
@@ -192,7 +210,7 @@ function setPrimeToken(address prime_) external
 #### ⛔️ Access Requirements
 * Only owner
 
-- - -
+---
 
 ### setMaxLoopsLimit
 
@@ -213,11 +231,11 @@ function setMaxLoopsLimit(uint256 loopsLimit) external
 #### ⛔️ Access Requirements
 * Controlled by ACM
 
-- - -
+---
 
 ### releaseFunds
 
-Claim all the token accrued till last block
+Release the token amount accrued through the latest block or second
 
 ```solidity
 function releaseFunds(address token_) external
@@ -236,7 +254,7 @@ function releaseFunds(address token_) external
 * Throw FundsTransferIsPaused is paused
 * Throw InvalidCaller if the sender is not the Prime contract
 
-- - -
+---
 
 ### sweepToken
 
@@ -262,11 +280,11 @@ function sweepToken(contract IERC20Upgradeable token_, address to_, uint256 amou
 #### ❌ Errors
 * Throw InsufficientBalance if amount_ is greater than the available balance of the token in the contract
 
-- - -
+---
 
 ### getEffectiveDistributionSpeed
 
-Get rewards per block for token
+Get the effective reward speed per block or second for a token
 
 ```solidity
 function getEffectiveDistributionSpeed(address token_) external view returns (uint256)
@@ -280,9 +298,9 @@ function getEffectiveDistributionSpeed(address token_) external view returns (ui
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | uint256 | speed returns the per block reward |
+| \[0] | uint256 | Effective reward speed in the deployment's configured time unit |
 
-- - -
+---
 
 ### accrueTokens
 
@@ -300,7 +318,7 @@ function accrueTokens(address token_) public
 #### 📅 Events
 * Emits TokensAccrued event
 
-- - -
+---
 
 ### getBlockNumberOrTimestamp
 
@@ -313,7 +331,6 @@ function getBlockNumberOrTimestamp() public view virtual returns (uint256)
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | uint256 | blockNumberOrSecond returns the current block number or timestamp |
+| \[0\] | uint256 | blockNumberOrSecond returns the current block number or timestamp |
 
-- - -
-
+---

--- a/technical-reference/reference-core-pool/prime/prime-storage.md
+++ b/technical-reference/reference-core-pool/prime/prime-storage.md
@@ -1,6 +1,10 @@
 # PrimeV2StorageV1
 Storage layout for the PrimeV2 contract with leaderboard-based Prime token distribution
 
+{% hint style="warning" %}
+BNB PrimeV2 only. This is the direct `PrimeV2StorageV1` layout from the implementation used at block `118,364,540`; upgrade review must also include inherited storage and the proxy's exact implementation. Source: [PrimeV2Storage.sol](https://github.com/VenusProtocol/venus-protocol/blob/v10.3.0/contracts/Tokens/Prime/PrimeV2Storage.sol).
+{% endhint %}
+
 # Solidity API
 
 ```solidity
@@ -79,6 +83,16 @@ Mapping of vToken -> user -> interest info
 
 ```solidity
 mapping(address => mapping(address => struct PrimeV2StorageV1.Interest)) interests
+```
+
+- - -
+
+### _allMarkets
+
+Internal array of all Prime-participating markets. This field is stored between `interests` and `vTokenForAsset`.
+
+```solidity
+address[] _allMarkets
 ```
 
 - - -
@@ -219,6 +233,16 @@ Unix timestamp after which permissionless minting is closed (0 = no deadline)
 
 ```solidity
 uint256 mintDeadline
+```
+
+- - -
+
+### __gap
+
+Reserved storage for future upgrades.
+
+```solidity
+uint256[40] __gap
 ```
 
 - - -

--- a/technical-reference/reference-core-pool/prime/prime.md
+++ b/technical-reference/reference-core-pool/prime/prime.md
@@ -1,6 +1,10 @@
 # PrimeV2
 PrimeV2 is the Prime token contract with leaderboard-based distribution. Prime status is decided by the `PrimeLeaderboard` contract based on time-weighted XVS staking, and boosted rewards are distributed to Prime holders across supported markets.
 
+{% hint style="warning" %}
+BNB Chain only. At block `118,364,540`, proxy `0x059EabA8676b03e4e8f009eFb7F587C28450F50f` used implementation `0x18cb7198cbb6d6e94001458cf3cf47c106d83a1b` and was unpaused. Other mainnets currently use Prime V1; see [Prime Contract Versions](README.md).
+{% endhint %}
+
 # Solidity API
 
 ### WRAPPED_NATIVE_TOKEN
@@ -11,7 +15,7 @@ Address of wrapped native token
 address WRAPPED_NATIVE_TOKEN
 ```
 
-- - -
+---
 
 ### NATIVE_MARKET
 
@@ -21,7 +25,7 @@ Address of native market vToken
 address NATIVE_MARKET
 ```
 
-- - -
+---
 
 ### xvsVault
 
@@ -31,7 +35,7 @@ Address of XVSVault contract
 address xvsVault
 ```
 
-- - -
+---
 
 ### xvsVaultRewardToken
 
@@ -41,7 +45,7 @@ Reward token address in XVSVault
 address xvsVaultRewardToken
 ```
 
-- - -
+---
 
 ### xvsVaultPoolId
 
@@ -51,7 +55,7 @@ Pool ID in XVSVault
 uint256 xvsVaultPoolId
 ```
 
-- - -
+---
 
 ### constructor
 
@@ -75,7 +79,7 @@ constructor(address wrappedNativeToken_, address nativeMarket_, address xvsVault
 #### ❌ Errors
 * Throw InvalidAddress if xvsVault_ or xvsVaultRewardToken_ is the zero address
 
-- - -
+---
 
 ### initialize
 
@@ -100,7 +104,7 @@ function initialize(uint128 alphaNumerator_, uint128 alphaDenominator_, address 
 * Throw InvalidAddress if any of the address is zero
 * Throw InvalidAlphaArguments if alpha arguments are invalid
 
-- - -
+---
 
 ### claimPrime
 
@@ -128,7 +132,7 @@ function claimPrime(address user) external
 * Throw InvalidLimit if mint limit would be exceeded
 * Throw MintWindowClosed if the minting deadline has passed
 
-- - -
+---
 
 ### claimPrimeBatch
 
@@ -155,7 +159,7 @@ function claimPrimeBatch(address[] users) external
 * Throw InvalidLimit if mint limit would be exceeded
 * Throw MaxLoopsLimitExceeded if the batch is larger than loopsLimit
 
-- - -
+---
 
 ### issue
 
@@ -182,7 +186,7 @@ function issue(address user) external
 * Throw UserAlreadyHasPrimeToken if user already has a token
 * Throw ScoreUpdateInProgress if a score update round is active
 
-- - -
+---
 
 ### issueBatch
 
@@ -209,7 +213,7 @@ function issueBatch(address[] users) external
 * Throw ScoreUpdateInProgress if a score update round is active
 * Throw MaxLoopsLimitExceeded if the batch is larger than loopsLimit
 
-- - -
+---
 
 ### burn
 
@@ -234,7 +238,7 @@ function burn(address user) external
 * Throw UserHasNoPrimeToken if user has no prime token
 * Throw ScoreUpdateInProgress if a score update round is active
 
-- - -
+---
 
 ### burnBatch
 
@@ -259,7 +263,7 @@ function burnBatch(address[] users) external
 * Throw ScoreUpdateInProgress if a score update round is active
 * Throw MaxLoopsLimitExceeded if the batch is larger than loopsLimit
 
-- - -
+---
 
 ### isUserPrimeHolder
 
@@ -277,9 +281,9 @@ function isUserPrimeHolder(address user) external view returns (bool)
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | bool | whether the user has a Prime token |
+| \[0\] | bool | whether the user has a Prime token |
 
-- - -
+---
 
 ### claimInterest
 
@@ -297,7 +301,7 @@ function claimInterest(address vToken) external returns (uint256)
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | uint256 | amount claimed |
+| \[0\] | uint256 | amount claimed |
 
 #### 📅 Events
 * Emits InterestClaimed event
@@ -305,7 +309,7 @@ function claimInterest(address vToken) external returns (uint256)
 #### ❌ Errors
 * Throw MarketNotSupported if market is not supported (only when the vToken is not a current Prime market — never added, or since removed — and the user has no residual accrued balance)
 
-- - -
+---
 
 ### claimInterest
 
@@ -324,7 +328,7 @@ function claimInterest(address vToken, address user) external returns (uint256)
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | uint256 | amount claimed |
+| \[0\] | uint256 | amount claimed |
 
 #### 📅 Events
 * Emits InterestClaimed event
@@ -332,7 +336,7 @@ function claimInterest(address vToken, address user) external returns (uint256)
 #### ❌ Errors
 * Throw MarketNotSupported if market is not supported (only when the vToken is not a current Prime market — never added, or since removed — and the user has no residual accrued balance)
 
-- - -
+---
 
 ### accrueInterest
 
@@ -350,7 +354,7 @@ function accrueInterest(address vToken) public
 #### ❌ Errors
 * Throw MarketNotSupported if market is not supported
 
-- - -
+---
 
 ### accrueInterestAndUpdateScore
 
@@ -366,7 +370,7 @@ function accrueInterestAndUpdateScore(address user, address market) external
 | user | address | User address |
 | market | address | Market address |
 
-- - -
+---
 
 ### accrueInterestAndUpdateScore
 
@@ -384,7 +388,7 @@ function accrueInterestAndUpdateScore(address user) external
 #### ❌ Errors
 * Throw OnlyPrimeLeaderboard if caller is not the PrimeLeaderboard contract
 
-- - -
+---
 
 ### getPendingRewards
 
@@ -404,7 +408,7 @@ function getPendingRewards(address user) external returns (struct PrimeV2Storage
 | ---- | ---- | ----------- |
 | pendingRewards | struct PrimeV2StorageV1.PendingReward[] | Array of pending rewards per market |
 
-- - -
+---
 
 ### getPendingRewardsStatic
 
@@ -424,7 +428,7 @@ function getPendingRewardsStatic(address user) external view returns (struct Pri
 | ---- | ---- | ----------- |
 | pendingRewards | struct PrimeV2StorageV1.PendingReward[] | Array of pending rewards per market |
 
-- - -
+---
 
 ### getLifetimeAccruedByMarket
 
@@ -445,7 +449,7 @@ function getLifetimeAccruedByMarket(address market, address[] users) external vi
 | ---- | ---- | ----------- |
 | amounts | uint256[] | Lifetime accrued amounts, indexed parallel to `users` |
 
-- - -
+---
 
 ### getLifetimeAccruedByUser
 
@@ -466,7 +470,7 @@ function getLifetimeAccruedByUser(address user, address[] markets_) external vie
 | ---- | ---- | ----------- |
 | amounts | uint256[] | Lifetime accrued amounts, indexed parallel to `markets_` |
 
-- - -
+---
 
 ### updateScores
 
@@ -488,7 +492,7 @@ function updateScores(address[] users) external
 * Throw NoScoreUpdatesRequired if no score updates are required
 * Throw MaxLoopsLimitExceeded if the batch is larger than loopsLimit
 
-- - -
+---
 
 ### getAllMarkets
 
@@ -501,9 +505,9 @@ function getAllMarkets() external view returns (address[])
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | address[] | Array of market addresses |
+| \[0\] | address[] | Array of market addresses |
 
-- - -
+---
 
 ### xvsBalanceOfUser
 
@@ -521,9 +525,9 @@ function xvsBalanceOfUser(address user) external view returns (uint256)
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | uint256 | User's XVS balance |
+| \[0\] | uint256 | User's XVS balance |
 
-- - -
+---
 
 ### addMarket
 
@@ -555,7 +559,7 @@ function addMarket(address market, uint256 supplyMultiplier, uint256 borrowMulti
 * Throw MaxLoopsLimitExceeded if listing this market would exceed loopsLimit
 * Throw UnsupportedUnderlyingDecimals if underlying token has decimals > 18
 
-- - -
+---
 
 ### removeMarket
 
@@ -580,7 +584,7 @@ function removeMarket(address market) external
 * Throw MarketNotSupported if market doesn't exist
 * Throw MarketHasActiveMembers if market still has members with scores
 
-- - -
+---
 
 ### setLimit
 
@@ -604,7 +608,7 @@ function setLimit(uint256 tokenLimit_) external
 #### ❌ Errors
 * Throw InvalidLimit if limit is less than current count
 
-- - -
+---
 
 ### updateAlpha
 
@@ -630,7 +634,7 @@ function updateAlpha(uint128 alphaNumerator_, uint128 alphaDenominator_) externa
 #### ❌ Errors
 * Throw InvalidAlphaArguments if alpha arguments are invalid
 
-- - -
+---
 
 ### updateMultipliers
 
@@ -658,7 +662,7 @@ function updateMultipliers(address market, uint256 supplyMultiplier, uint256 bor
 * Throw MarketNotSupported if market is not supported
 * Throw InvalidMultipliers if both multipliers are zero
 
-- - -
+---
 
 ### pause
 
@@ -674,7 +678,7 @@ function pause() external
 #### ⛔️ Access Requirements
 * Controlled by ACM
 
-- - -
+---
 
 ### unpause
 
@@ -690,7 +694,7 @@ function unpause() external
 #### ⛔️ Access Requirements
 * Controlled by ACM
 
-- - -
+---
 
 ### setMaxLoopsLimit
 
@@ -711,7 +715,7 @@ function setMaxLoopsLimit(uint256 loopsLimit) external
 #### ⛔️ Access Requirements
 * Controlled by ACM
 
-- - -
+---
 
 ### setPrimeLeaderboard
 
@@ -735,7 +739,7 @@ function setPrimeLeaderboard(address primeLeaderboard_) external
 #### ❌ Errors
 * Throw InvalidAddress if address is zero
 
-- - -
+---
 
 ### setMintThreshold
 
@@ -760,7 +764,7 @@ function setMintThreshold(uint256 mintThreshold_, uint256 mintDeadline_) externa
 #### ❌ Errors
 * Throw InvalidDeadline if mintDeadline_ is non-zero and not strictly in the future
 
-- - -
+---
 
 ### recordCycleSnapshot
 
@@ -779,9 +783,9 @@ function recordCycleSnapshot(uint256 cycleId) external
 * Emits CycleSnapshotRecorded(cycleId, block.number, block.timestamp)
 
 #### ⛔️ Access Requirements
-* Controlled by ACM — grant `recordCycleSnapshot(uint256)` to a keeper EOA/bot, not the Timelock (cycles fire on a recurring schedule)
+* Controlled by ACM. Check the live grantees and current operations runbook; this reference does not prescribe an EOA, bot, or Timelock as the caller.
 
-- - -
+---
 
 ### sweepUndistributed
 
@@ -808,4 +812,4 @@ function sweepUndistributed(address vToken, address to) external
 
 Note: for a removed Prime market the call does not revert; it returns without transferring once the market's `undistributedReward` slice is zero. Passing an address that is not a vToken at all reverts when resolving its underlying token.
 
-- - -
+---

--- a/technical-reference/reference-core-pool/psm/peg-stability.md
+++ b/technical-reference/reference-core-pool/psm/peg-stability.md
@@ -1,329 +1,67 @@
-# PSM
+# Peg Stability Module
 
-## Peg Stability Contract.
+The BNB Chain Peg Stability Module (PSM) swaps USDT and VAI. It is a transparent proxy at [`0xC138aa4E424D1A8539e8F38Af5a754a2B7c3Cc36`](https://bscscan.com/address/0xC138aa4E424D1A8539e8F38Af5a754a2B7c3Cc36).
 
-Contract for swapping stable token for VAI token and vice versa to maintain the peg stability between them.
+## Live version and configuration
 
-## Solidity API
+At BNB Chain block `118,364,540`:
 
-```solidity
-enum FeeDirection {
-  IN,
-  OUT
-}
-```
+| Field | Value |
+| --- | --- |
+| Implementation | `0x9664568e5131e85f67d87fcd55b249f5d25fa43e` |
+| Paused | No |
+| Stable token | USDT `0x55d398326f99059fF775485246999027B3197955` |
+| VAI | `0x4BD17003473389A42DAF6a0a729f6Fdb328BbBd7` |
+| Fee in | 0 basis points |
+| Fee out | 10 basis points |
+| VAI mint cap | 5,000,000 VAI |
+| VAI attributed to PSM mints | 465,696.242314352647832029 VAI |
+| Treasury | `0xF322942f644A996A617BD29c16BD7d231d9F35E9` |
+| Access Control Manager | `0x4788629ABc6cFCA10F9f969efdEAa1cF70c23555` |
 
-#### BASIS\_POINTS\_DIVISOR
+These values are governance-configurable. Read the proxy at the relevant block before constructing a swap.
 
-The divisor used to convert fees to basis points.
+## Swap API
 
-```solidity
-uint256 BASIS_POINTS_DIVISOR
-```
-
-***
-
-#### MANTISSA\_ONE
-
-The mantissa value representing 1 (used for calculations).
+### `swapStableForVAI`
 
 ```solidity
-uint256 MANTISSA_ONE
+function swapStableForVAI(address receiver, uint256 stableTknAmount)
+    external
+    returns (uint256 vaiOut)
 ```
 
-***
+The caller must approve the PSM to transfer USDT. The PSM supports fee-on-transfer accounting by measuring the amount actually received. It mints the net VAI to `receiver`, not necessarily to the caller. The gross USD value counts against `vaiMintCap`; any fee is minted to the treasury.
 
-#### ONE\_DOLLAR
-
-The value representing one dollar in the stable token.
+### `swapVAIForStable`
 
 ```solidity
-uint256 ONE_DOLLAR
+function swapVAIForStable(address receiver, uint256 stableTknAmount)
+    external
+    returns (uint256 vaiBurned)
 ```
 
-***
+The caller must approve the PSM to transfer any VAI fee. The requested stable-token amount is sent to `receiver`; the corresponding VAI is burned from the caller and `vaiMinted` is reduced.
 
-#### VAI
-
-VAI token contract.
-
-```solidity
-contract IVAI VAI
-```
-
-***
-
-#### STABLE\_TOKEN\_ADDRESS
-
-The address of the stable token contract.
-
-```solidity
-address STABLE_TOKEN_ADDRESS
-```
-
-***
-
-#### oracle
-
-The address of ResilientOracle contract wrapped in its interface.
-
-```solidity
-contract ResilientOracleInterface oracle
-```
-
-***
-
-#### venusTreasury
-
-The address of the Venus Treasury contract.
-
-```solidity
-address venusTreasury
-```
-
-***
-
-#### feeIn
-
-The incoming stableCoin fee. (Fee for swapStableForVAI).
-
-```solidity
-uint256 feeIn
-```
-
-***
-
-#### feeOut
-
-The outgoing stableCoin fee. (Fee for swapVAIForStable).
-
-```solidity
-uint256 feeOut
-```
-
-***
-
-#### vaiMintCap
-
-The maximum amount of VAI that can be minted through this contract.
-
-```solidity
-uint256 vaiMintCap
-```
-
-***
-
-#### vaiMinted
-
-The total amount of VAI minted through this contract.
-
-```solidity
-uint256 vaiMinted
-```
-
-***
-
-#### isPaused
-
-A flag indicating whether the contract is currently paused or not.
-
-```solidity
-bool isPaused
-```
-
-***
-
-#### initialize
-
-Initializes the contract via Proxy Contract with the required parameters.
-
-```solidity
-function initialize(address accessControlManager_, address venusTreasury_, address oracleAddress_, uint256 feeIn_, uint256 feeOut_, uint256 vaiMintCap_) external
-```
-
-**Parameters**
-
-| Name                   | Type    | Description                                                       |
-| ---------------------- | ------- | ----------------------------------------------------------------- |
-| accessControlManager\_ | address | The address of the AccessControlManager contract.                 |
-| venusTreasury\_        | address | The address where fees will be sent.                              |
-| oracleAddress\_        | address | The address of the ResilientOracle contract.                      |
-| feeIn\_                | uint256 | The percentage of fees to be applied to a stablecoin -> VAI swap. |
-| feeOut\_               | uint256 | The percentage of fees to be applied to a VAI -> stablecoin swap. |
-| vaiMintCap\_           | uint256 | The cap for the total amount of VAI that can be minted.           |
-
-***
-
-#### swapVAIForStable
-
-Swaps VAI for a stable token.
-
-```solidity
-function swapVAIForStable(address receiver, uint256 stableTknAmount) external returns (uint256)
-```
-
-**Parameters**
-
-| Name            | Type    | Description                                    |
-| --------------- | ------- | ---------------------------------------------- |
-| receiver        | address | The address where the stablecoin will be sent. |
-| stableTknAmount | uint256 | The amount of stable tokens to receive.        |
-
-**Return Values**
-
-| Name | Type    | Description                                           |
-| ---- | ------- | ----------------------------------------------------- |
-| \[0] | uint256 | The amount of VAI received and burnt from the sender. |
-
-***
-
-#### swapStableForVAI
-
-Swaps stable tokens for VAI with fees.
-
-```solidity
-function swapStableForVAI(address receiver, uint256 stableTknAmount) external returns (uint256)
-```
-
-**Parameters**
-
-| Name            | Type    | Description                                   |
-| --------------- | ------- | --------------------------------------------- |
-| receiver        | address | The address that will receive the VAI tokens. |
-| stableTknAmount | uint256 | The amount of stable tokens to be swapped.    |
-
-**Return Values**
-
-| Name | Type    | Description                         |
-| ---- | ------- | ----------------------------------- |
-| \[0] | uint256 | Amount of VAI minted to the sender. |
-
-***
-
-#### pause
-
-Pause the PSM contract.
-
-```solidity
-function pause() external
-```
-
-***
-
-#### resume
-
-Resume the PSM contract.
-
-```solidity
-function resume() external
-```
-
-***
-
-#### setFeeIn
-
-Set the fee percentage for incoming swaps.
-
-```solidity
-function setFeeIn(uint256 feeIn_) external
-```
-
-**Parameters**
-
-| Name    | Type    | Description                                |
-| ------- | ------- | ------------------------------------------ |
-| feeIn\_ | uint256 | The new fee percentage for incoming swaps. |
-
-***
-
-#### setFeeOut
-
-Set the fee percentage for outgoing swaps.
-
-```solidity
-function setFeeOut(uint256 feeOut_) external
-```
-
-**Parameters**
-
-| Name     | Type    | Description                                |
-| -------- | ------- | ------------------------------------------ |
-| feeOut\_ | uint256 | The new fee percentage for outgoing swaps. |
-
-***
-
-#### setVenusTreasury
-
-Set the address of the Venus Treasury contract.
-
-```solidity
-function setVenusTreasury(address venusTreasury_) external
-```
-
-**Parameters**
-
-| Name            | Type    | Description                                     |
-| --------------- | ------- | ----------------------------------------------- |
-| venusTreasury\_ | address | The new address of the Venus Treasury contract. |
-
-***
-
-#### setOracle
-
-Set the address of the ResilientOracle contract.
-
-```solidity
-function setOracle(address oracleAddress_) external
-```
-
-**Parameters**
-
-| Name            | Type    | Description                                      |
-| --------------- | ------- | ------------------------------------------------ |
-| oracleAddress\_ | address | The new address of the ResilientOracle contract. |
-
-***
-
-#### previewSwapVAIForStable
-
-Calculates the amount of VAI that would be burnt from the user.
-
-```solidity
-function previewSwapVAIForStable(uint256 stableTknAmount) external view returns (uint256)
-```
-
-**Parameters**
-
-| Name            | Type    | Description                                                |
-| --------------- | ------- | ---------------------------------------------------------- |
-| stableTknAmount | uint256 | The amount of stable tokens to be received after the swap. |
-
-**Return Values**
-
-| Name | Type    | Description                                          |
-| ---- | ------- | ---------------------------------------------------- |
-| \[0] | uint256 | The amount of VAI that would be taken from the user. |
-
-***
-
-#### previewSwapStableForVAI
-
-Calculates the amount of VAI that would be sent to the receiver.
+### Preview functions
 
 ```solidity
 function previewSwapStableForVAI(uint256 stableTknAmount) external view returns (uint256)
+function previewSwapVAIForStable(uint256 stableTknAmount) external view returns (uint256)
 ```
 
-**Parameters**
+Preview results can differ from execution if oracle prices or configuration change before the transaction is mined.
 
-| Name            | Type    | Description                                        |
-| --------------- | ------- | -------------------------------------------------- |
-| stableTknAmount | uint256 | The amount of stable tokens provided for the swap. |
+## Administration
 
-**Return Values**
+Every state-changing administrative function below checks its exact signature through the Access Control Manager:
 
-| Name | Type    | Description                                           |
-| ---- | ------- | ----------------------------------------------------- |
-| \[0] | uint256 | The amount of VAI that would be sent to the receiver. |
+* `pause()` and `resume()`;
+* `setFeeIn(uint256)` and `setFeeOut(uint256)`;
+* `setVAIMintCap(uint256)`;
+* `setVenusTreasury(address)`;
+* `setOracle(address)`.
 
-***
+Permission is signature-specific. Check the live ACM grantee for the target proxy rather than treating “governance” or “guardian” as a universal role.
+
+Source: [PegStability.sol in venus-protocol v10.3.0](https://github.com/VenusProtocol/venus-protocol/blob/v10.3.0/contracts/PegStability/PegStability.sol).

--- a/technical-reference/reference-core-pool/vaults/README.md
+++ b/technical-reference/reference-core-pool/vaults/README.md
@@ -1,1 +1,12 @@
-# Vaults
+# Vault Technical Reference
+
+Venus has two distinct vault families:
+
+| Vault | Network scope | Proxy model | Purpose |
+| --- | --- | --- | --- |
+| [VAI Vault](vai/README.md) | BNB Chain only | Custom `VAIVaultProxy` delegate proxy | Stake VAI and claim XVS rewards |
+| [XVS Vault](xvs/README.md) | BNB, Ethereum, opBNB, Arbitrum, ZKsync, Optimism, Base, Unichain | Custom `XVSVaultProxy` delegate proxy plus XVSStore | Stake XVS, earn configured rewards, and delegate governance votes |
+
+The proxy address is the public entry point. Resolve the custom proxy's implementation getter at the relevant block before choosing an ABI. Vault reward speed, pause state, time basis, pools, permissions, and funding are all configurable.
+
+Current proxy and store addresses are listed in [Deployed Funds](../../../deployed-contracts/funds.md).

--- a/technical-reference/reference-core-pool/vaults/vai/README.md
+++ b/technical-reference/reference-core-pool/vaults/vai/README.md
@@ -1,1 +1,11 @@
 # VAI Vault
+
+The VAI Vault exists only on BNB Chain. Its public entry point is the custom proxy at [`0x0667Eed0a0aAb930af74a3dfeDD263A73994f216`](https://bscscan.com/address/0x0667Eed0a0aAb930af74a3dfeDD263A73994f216).
+
+At BNB Chain block `118,364,540`, the proxy was unpaused, used implementation `0xA52f2a56aBb7cbDD378bC36c6088fAfEaf9AC423`, and was administered by the Normal Timelock `0x939bD8d64c0A9583A7Dcea9933f7b21697ab6396`.
+
+The vault still holds user VAI and reward XVS, so its user and recovery reference must remain available regardless of whether new deposits are promoted in the interface.
+
+* [VAIVaultProxy administration](vai-vault-proxy.md)
+* [VAI Vault user and operator API](vai-vault.md)
+* [Deployed Funds](../../../../deployed-contracts/funds.md)

--- a/technical-reference/reference-core-pool/vaults/vai/vai-vault-proxy.md
+++ b/technical-reference/reference-core-pool/vaults/vai/vai-vault-proxy.md
@@ -1,65 +1,21 @@
-# VAI Vault Proxy
-Proxy contract for the VAI Vault
+# VAIVaultProxy
 
-# Solidity API
+`VAIVaultProxy` is a custom delegate proxy. Users and integrations call the proxy; state is stored at the proxy while the implementation supplies logic.
 
-### _setPendingImplementation
+## BNB deployment
 
-* Admin Functions **
+At block `118,364,540`:
 
-```solidity
-function _setPendingImplementation(address newPendingImplementation) public returns (uint256)
-```
+| Field | Address |
+| --- | --- |
+| Proxy | `0x0667Eed0a0aAb930af74a3dfeDD263A73994f216` |
+| `vaiVaultImplementation()` | `0xA52f2a56aBb7cbDD378bC36c6088fAfEaf9AC423` |
+| `admin()` | `0x939bD8d64c0A9583A7Dcea9933f7b21697ab6396` |
+| `pendingVAIVaultImplementation()` | Read live before an upgrade |
+| `pendingAdmin()` | Read live before an admin transfer |
 
-- - -
+The constructor initially sets `admin` to the deployer. The current admin can call `_setPendingImplementation(address)` and `_setPendingAdmin(address)`. A pending implementation or admin must accept its role through `_acceptImplementation()` or `_acceptAdmin()` respectively.
 
-### _acceptImplementation
+These methods return protocol error codes: `0` means success. Decode the return value and emitted events instead of relying only on EVM transaction success.
 
-Accepts new implementation of VAI Vault. msg.sender must be pendingImplementation
-
-```solidity
-function _acceptImplementation() public returns (uint256)
-```
-
-#### Return Values
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | uint 0=success, otherwise a failure (see ErrorReporter.sol for details) |
-
-- - -
-
-### _setPendingAdmin
-
-Begins transfer of admin rights. The newPendingAdmin must call `_acceptAdmin` to finalize the transfer.
-
-```solidity
-function _setPendingAdmin(address newPendingAdmin) public returns (uint256)
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| newPendingAdmin | address | New pending admin. |
-
-#### Return Values
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | uint 0=success, otherwise a failure (see ErrorReporter.sol for details) |
-
-- - -
-
-### _acceptAdmin
-
-Accepts transfer of admin rights. msg.sender must be pendingAdmin
-
-```solidity
-function _acceptAdmin() public returns (uint256)
-```
-
-#### Return Values
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | uint 0=success, otherwise a failure (see ErrorReporter.sol for details) |
-
-- - -
-
+Source: [VAIVaultProxy.sol in venus-protocol v10.3.0](https://github.com/VenusProtocol/venus-protocol/blob/v10.3.0/contracts/VAIVault/VAIVaultProxy.sol).

--- a/technical-reference/reference-core-pool/vaults/vai/vai-vault.md
+++ b/technical-reference/reference-core-pool/vaults/vai/vai-vault.md
@@ -1,135 +1,33 @@
-# VAI Vault
-The VAI Vault is configured for users to stake VAI And receive XVS as a reward.
+# VAI Vault API
 
-# Solidity API
+This reference applies to the BNB Chain VAI Vault proxy `0x0667Eed0a0aAb930af74a3dfeDD263A73994f216`, which used implementation `0xA52f2a56aBb7cbDD378bC36c6088fAfEaf9AC423` at block `118,364,540`.
 
-### pause
+{% hint style="warning" %}
+Call the proxy, not the implementation. Verify `vaiVaultImplementation()`, `vaultPaused()`, token addresses, reward funding, and live permissions at the block relevant to the transaction.
+{% endhint %}
 
-Pause vault
-
-```solidity
-function pause() external
-```
-
-- - -
-
-### resume
-
-Resume vault
+## User functions
 
 ```solidity
-function resume() external
-```
-
-- - -
-
-### deposit
-
-Deposit VAI to VAIVault for XVS allocation
-
-```solidity
-function deposit(uint256 _amount) external
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _amount | uint256 | The amount to deposit to vault |
-
-- - -
-
-### withdraw
-
-Withdraw VAI from VAIVault
-
-```solidity
-function withdraw(uint256 _amount) external
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _amount | uint256 | The amount to withdraw from vault |
-
-- - -
-
-### claim
-
-Claim XVS from VAIVault
-
-```solidity
+function deposit(uint256 amount) external
+function withdraw(uint256 amount) external
 function claim() external
-```
-
-- - -
-
-### claim
-
-Claim XVS from VAIVault
-
-```solidity
 function claim(address account) external
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| account | address | The account for which to claim XVS |
-
-- - -
-
-### pendingXVS
-
-View function to see pending XVS on frontend
-
-```solidity
-function pendingXVS(address _user) public view returns (uint256)
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _user | address | The user to see pending XVS |
-
-#### Return Values
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | Amount of XVS the user can claim |
-
-- - -
-
-### updatePendingRewards
-
-Function that updates pending rewards
-
-```solidity
+function pendingXVS(address user) public view returns (uint256)
 function updatePendingRewards() public
 ```
 
-- - -
+`deposit` transfers VAI from the caller and therefore requires an underlying VAI allowance. `withdraw` returns staked VAI. `claim(address)` pays the named account; it does not redirect that account's rewards to the caller.
 
-### _become
+The vault can record rewards that have not yet been distributed. Check both `pendingXVS` and current reward funding before presenting a claim as guaranteed.
 
-* Admin Functions **
+## Administration
 
-```solidity
-function _become(contract VAIVaultProxy vaiVaultProxy) external
-```
+* `pause()` and `resume()` are signature-gated through the Access Control Manager.
+* `_become(VAIVaultProxy)` can accept an implementation only when called by the proxy admin.
+* `setAccessControl(address)` is restricted to the proxy admin.
+* `setVenusInfo(address xvs, address vai)` updates the token references, in that order, and is restricted to the proxy admin.
 
-- - -
+Permission assignments and token addresses can change. Query the proxy and ACM instead of relying on a static caller label.
 
-### setAccessControl
-
-Sets the address of the access control of this contract
-
-```solidity
-function setAccessControl(address newAccessControlAddress) external
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| newAccessControlAddress | address | New address for the access control |
-
-- - -
-
+Source: [VAIVault.sol in venus-protocol v10.3.0](https://github.com/VenusProtocol/venus-protocol/blob/v10.3.0/contracts/VAIVault/VAIVault.sol).

--- a/technical-reference/reference-core-pool/vaults/xvs/README.md
+++ b/technical-reference/reference-core-pool/vaults/xvs/README.md
@@ -1,1 +1,33 @@
-# XVS Vault
+# XVS Vault Version Map
+
+The XVS Vault is a multi-chain custom delegate-proxy family. Each deployment has a separate implementation, time basis, pause state, pool configuration, XVSStore, and permission set.
+
+## Mainnet deployments
+
+State observed on 2026-08-27:
+
+| Network | Proxy | Implementation | Reward/vote clock | Paused |
+| --- | --- | --- | --- | --- |
+| BNB Chain | `0x051100480289e704d20e9DB4804837068f3f9204` | `0x74c8a97BE672db3e9a224648bE566AdA5F43B378` | block, 70,080,000/year | No |
+| Ethereum | `0xA0882C2D5DF29233A092d2887A258C2b90e9b994` | `0x437042777255A1f25BE60eD25C814Dea6E43bC28` | block, 2,628,000/year | No |
+| opBNB | `0x7dc969122450749A8B0777c0e324522d67737988` | `0x785BEF8B6dB40E86fA3749b44cD67C14945E2a71` | block, 126,144,000/year | Yes |
+| Arbitrum | `0x8b79692AAB2822Be30a6382Eb04763A74752d5B4` | `0x4C4BedC003e4E2f3A057DeC35aeF26F64Cb07384` | second, 31,536,000/year | No |
+| ZKsync | `0xbbB3C88192a5B0DB759229BeF49DcD1f168F326F` | `0x513323f8bd847Bd4C7C73DD69098B38789Ae0590` | second, 31,536,000/year | No |
+| Optimism | `0x133120607C018c949E91AE333785519F6d947e01` | `0x8B8651EEB002a7991F2287500B17a395E8cfe7d9` | second, 31,536,000/year | No |
+| Base | `0x708B54F2C3f3606ea48a8d94dab88D9Ab22D7fCd` | `0x322F1a2E03F089F8ce510855e793970D6f0EFcF9` | second, 31,536,000/year | No |
+| Unichain | `0x5ECa0FBBc5e7bf49dbFb1953a92784F8e4248eF6` | `0x2ba0F45f7368d2A56d0c9e5a29af363987BE1d02` | second, 31,536,000/year | No |
+
+Observed blocks were BNB `118,364,446`, Ethereum `25,845,840`, opBNB `178,832,524`, Arbitrum `498,882,806`, ZKsync `71,738,207`, Optimism `156,113,142`, Base `50,517,857`, and Unichain `57,076,698`.
+
+{% hint style="warning" %}
+A paused vault is not automatically deprecated. Pause status only establishes whether pause-gated actions could execute at the observed block. Check balances, pending withdrawals, claimable rewards, governance duties, and formal support before assigning a lifecycle state.
+{% endhint %}
+
+## Components
+
+* [XVSVaultProxy](xvs-vault-proxy.md) — stores state and delegates calls to the current implementation.
+* [XVS Vault](xvs-vault.md) — staking, withdrawals, rewards, governance delegation, and Prime callback logic.
+* [XVSStore](xvs-store.md) — custody contract from which the vault transfers configured rewards.
+* [XVSVaultTreasury](xvs-vault-treasury.md) — funds the store with governance-approved XVS allocations.
+
+Current proxy and store addresses are listed in [Deployed Funds](../../../../deployed-contracts/funds.md).

--- a/technical-reference/reference-core-pool/vaults/xvs/xvs-store.md
+++ b/technical-reference/reference-core-pool/vaults/xvs/xvs-store.md
@@ -1,97 +1,22 @@
-# XVS Store
-XVS Store responsible for distributing XVS rewards
+# XVSStore
 
-# Solidity API
+XVSStore holds reward tokens and transfers them on behalf of its configured owner, normally an XVS Vault. It is a non-proxy contract with separate `admin` and `owner` roles.
 
-### safeRewardTransfer
+{% hint style="warning" %}
+Every network has its own store, roles, balances, and active reward-token list. Read those values from the exact address in [Deployed Funds](../../../../deployed-contracts/funds.md).
+{% endhint %}
 
-Safely transfer rewards. Only active reward tokens can be sent using this function.
-Only callable by owner
+## Roles and API
 
-```solidity
-function safeRewardTransfer(address token, address _to, uint256 _amount) external
-```
+| Function | Caller requirement | Effect |
+| --- | --- | --- |
+| `safeRewardTransfer(address,address,uint256)` | Owner | Transfers an active reward token, capped by the store's available balance |
+| `setPendingAdmin(address)` | Admin | Starts an admin transfer |
+| `acceptAdmin()` | Pending admin | Accepts the admin role |
+| `setNewOwner(address)` | Admin | Replaces the owner that can distribute or withdraw rewards |
+| `setRewardToken(address,bool)` | Admin **or owner** | Enables or disables a reward token |
+| `emergencyRewardWithdraw(address,uint256)` | Owner | Withdraws a reward token from the store |
 
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| token | address | Reward token to transfer |
-| _to | address | Destination address of the reward |
-| _amount | uint256 | Amount to transfer |
+The owner can therefore both distribute active rewards and change which tokens are active. The admin can replace the owner. Permission reviews must account for both roles rather than treating the vault as the only privileged actor.
 
-- - -
-
-### setPendingAdmin
-
-Allows the admin to propose a new admin
-Only callable admin
-
-```solidity
-function setPendingAdmin(address _admin) external
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _admin | address | Propose an account as admin of the XVS store |
-
-- - -
-
-### acceptAdmin
-
-Allows an account that is pending as admin to accept the role
-nly calllable by the pending admin
-
-```solidity
-function acceptAdmin() external
-```
-
-- - -
-
-### setNewOwner
-
-Set the contract owner
-
-```solidity
-function setNewOwner(address _owner) external
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _owner | address | The address of the owner to set Only callable admin |
-
-- - -
-
-### setRewardToken
-
-Set or disable a reward token
-
-```solidity
-function setRewardToken(address _tokenAddress, bool status) external
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _tokenAddress | address | The address of a token to set as active or inactive |
-| status | bool | Set whether a reward token is active or not |
-
-- - -
-
-### emergencyRewardWithdraw
-
-Security function to allow the owner of the contract to withdraw from the contract
-
-```solidity
-function emergencyRewardWithdraw(address _tokenAddress, uint256 _amount) external
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _tokenAddress | address | Reward token address to withdraw |
-| _amount | uint256 | Amount of token to withdraw |
-
-- - -
-
+Source: [XVSStore.sol in venus-protocol v10.3.0](https://github.com/VenusProtocol/venus-protocol/blob/v10.3.0/contracts/XVSVault/XVSStore.sol).

--- a/technical-reference/reference-core-pool/vaults/xvs/xvs-vault-proxy.md
+++ b/technical-reference/reference-core-pool/vaults/xvs/xvs-vault-proxy.md
@@ -1,65 +1,13 @@
-# XVS Vault Proxy
-XVS Vault Proxy contract
+# XVSVaultProxy
 
-# Solidity API
+`XVSVaultProxy` is a custom delegate proxy used on every XVS Vault deployment. Users and integrations call the proxy; state is stored at the proxy while `implementation()` supplies the logic.
 
-### _setPendingImplementation
+The constructor sets the initial admin. The current admin can call `_setPendingImplementation(address)` and `_setPendingAdmin(address)`. A pending implementation or admin accepts through `_acceptImplementation()` or `_acceptAdmin()`.
 
-* Admin Functions **
+These functions return protocol error codes: `0` means success. Decode the return value and emitted events instead of relying only on EVM transaction success.
 
-```solidity
-function _setPendingImplementation(address newPendingImplementation) public returns (uint256)
-```
+{% hint style="warning" %}
+Implementation and admin are chain-specific. Resolve `implementation()`, `admin()`, pending values, pause state, and time mode on the exact proxy. See the [mainnet XVS Vault version map](README.md).
+{% endhint %}
 
-- - -
-
-### _acceptImplementation
-
-Accepts new implementation of XVS Vault. msg.sender must be pendingImplementation
-
-```solidity
-function _acceptImplementation() public returns (uint256)
-```
-
-#### Return Values
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | uint 0=success, otherwise a failure (see ErrorReporter.sol for details) |
-
-- - -
-
-### _setPendingAdmin
-
-Begins transfer of admin rights. The newPendingAdmin must call `_acceptAdmin` to finalize the transfer.
-
-```solidity
-function _setPendingAdmin(address newPendingAdmin) public returns (uint256)
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| newPendingAdmin | address | New pending admin. |
-
-#### Return Values
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | uint 0=success, otherwise a failure (see ErrorReporter.sol for details) |
-
-- - -
-
-### _acceptAdmin
-
-Accepts transfer of admin rights. msg.sender must be pendingAdmin
-
-```solidity
-function _acceptAdmin() public returns (uint256)
-```
-
-#### Return Values
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | uint 0=success, otherwise a failure (see ErrorReporter.sol for details) |
-
-- - -
-
+Source: [XVSVaultProxy.sol in venus-protocol v10.3.0](https://github.com/VenusProtocol/venus-protocol/blob/v10.3.0/contracts/XVSVault/XVSVaultProxy.sol).

--- a/technical-reference/reference-core-pool/vaults/xvs/xvs-vault-treasury.md
+++ b/technical-reference/reference-core-pool/vaults/xvs/xvs-vault-treasury.md
@@ -1,70 +1,36 @@
 # XVSVaultTreasury
 
-This contract stores `XVS` received from `XVSBuyback` and funds `XVSVault`.
+`XVSVaultTreasury` receives XVS allocated by the protocol-reserve conversion flow and funds the XVSStore used by an XVS Vault.
 
-# Solidity API
+## BNB deployment
 
-### XVS_ADDRESS
+At BNB Chain block `118,364,540`:
 
-The xvs token address
+| Field | Value |
+| --- | --- |
+| Proxy | `0x269ff7818DB317f60E386D2be0B259e1a324a40a` |
+| Implementation | `0xA95a4f34337d8fAC283c3e3D2A605b95dA916cD6` |
+| Owner | `0x939bD8d64c0A9583A7Dcea9933f7b21697ab6396` |
+| Access Control Manager | `0x4788629ABc6cFCA10F9f969efdEAa1cF70c23555` |
+| XVS Vault | `0x051100480289e704d20e9DB4804837068f3f9204` |
+| XVS | `0xcF6BB5389c92Bdda8a3747Ddb454cB7a64626C63` |
 
-```solidity
-address XVS_ADDRESS
-```
+Other network deployments can use different proxies, implementations, owners, and vaults.
 
-- - -
-
-### xvsVault
-
-The xvsvault address
-
-```solidity
-address xvsVault
-```
-
-- - -
-
-### fundXVSVault
-
-This function transfers funds to the XVS vault
+## API and permissions
 
 ```solidity
+constructor(address xvsAddress_)
+function initialize(address accessControlManager_, address xvsVault_) public
+function setXVSVault(address xvsVault_) external
 function fundXVSVault(uint256 amountMantissa) external
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| amountMantissa | uint256 | Amount to be sent to XVS vault |
-
-#### 📅 Events
-* FundsTransferredToXVSStore emits on success
-
-#### ⛔️ Access Requirements
-* Restricted by ACM
-
-#### ❌ Errors
-* InsufficientBalance is thrown when amount entered is greater than balance
-
-### sweepToken
-
-This function sweep tokens from the contract
-
-```solidity
 function sweepToken(address tokenAddress, address to, uint256 amount) external
 ```
 
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenAddress | address | Address of the asset(token) |
-| to | address | Address to which assets will be transferred |
-| amount | uint256 | Amount need to sweep from the contract |
+* `setXVSVault` is `onlyOwner`.
+* `fundXVSVault` checks `fundXVSVault(uint256)` through the Access Control Manager and sends XVS directly to the vault's current XVSStore.
+* `sweepToken` is `onlyOwner`; it is **not** gated by the Access Control Manager.
 
-#### 📅 Events
-* SweepToken emits on success
+Because this contract holds funds and can change its destination vault, resolve the live proxy implementation, owner, ACM permissions, and `xvsVault()` value before an operator transaction.
 
-#### ⛔️ Access Requirements
-* Restricted by ACM
-- - -
-
+Source: [XVSVaultTreasury.sol](https://github.com/VenusProtocol/protocol-reserve/blob/main/contracts/ProtocolReserve/XVSVaultTreasury.sol).

--- a/technical-reference/reference-core-pool/vaults/xvs/xvs-vault.md
+++ b/technical-reference/reference-core-pool/vaults/xvs/xvs-vault.md
@@ -1,432 +1,57 @@
-# XVS Vault
-The XVS Vault allows XVS holders to lock their XVS to recieve voting rights in Venus governance and are rewarded with XVS.
+# XVS Vault API
 
-# Solidity API
+The XVS Vault lets users stake configured tokens, accrue rewards, request and execute withdrawals, and delegate voting power. Deployments can be block-based or time-based; use the [mainnet version map](README.md) to select the correct units and implementation.
 
-### pause
+{% hint style="danger" %}
+Call the chain's proxy, not the implementation. Verify `implementation()`, `vaultPaused()`, `isTimeBased()`, `blocksOrSecondsPerYear()`, pool configuration, reward funding, and live permissions before constructing a transaction.
+{% endhint %}
 
-Pauses vault
-
-```solidity
-function pause() external
-```
-
-- - -
-
-### resume
-
-Resume vault
+## User staking and rewards
 
 ```solidity
-function resume() external
+function deposit(address rewardToken, uint256 pid, uint256 amount) external
+function claim(address account, address rewardToken, uint256 pid) external
+function requestWithdrawal(address rewardToken, uint256 pid, uint256 amount) external
+function executeWithdrawal(address rewardToken, uint256 pid) external
+function pendingReward(address rewardToken, uint256 pid, address user) external view returns (uint256)
+function getEligibleWithdrawalAmount(address rewardToken, uint256 pid, address user) external view returns (uint256)
+function getRequestedAmount(address rewardToken, uint256 pid, address user) external view returns (uint256)
+function getWithdrawalRequests(address rewardToken, uint256 pid, address user) external view returns (WithdrawalRequest[])
 ```
 
-- - -
+The user must approve the vault to transfer the staked token before depositing. A withdrawal has two stages: request it, wait until the pool's locking period has elapsed, then execute it. `claim(address,...)` pays the named account.
 
-### poolLength
+If the XVSStore cannot fully pay a reward, the vault transfers the available amount and records the remainder in `pendingRewardTransfers` rather than treating the entire claim as paid.
 
-Returns the number of pools with the specified reward token
+## Reward clock and configuration
+
+The canonical speed setter and getter use block-or-second terminology:
 
 ```solidity
-function poolLength(address rewardToken) external view returns (uint256)
+function setRewardAmountPerBlockOrSecond(address rewardToken, uint256 rewardAmount) external
+function rewardTokenAmountsPerBlockOrSecond(address rewardToken) external view returns (uint256)
+function isTimeBased() external view returns (bool)
+function blocksOrSecondsPerYear() external view returns (uint256)
 ```
 
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| rewardToken | address | Reward token address |
+The old `rewardTokenAmountsPerBlock(address)` compatibility getter returns the same speed mapping, but its name does not describe time-based deployments. The previously documented `setRewardAmountPerBlock(address,uint256)` selector is not part of the current implementation; operator tooling must use `setRewardAmountPerBlockOrSecond` after verifying the deployed ABI.
 
-#### Return Values
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | Number of pools that distribute the specified token as a reward |
+Pool addition, allocation updates, speed changes, withdrawal-lock changes, pause/resume, and `setBlocksPerYear` use signature-specific Access Control Manager checks. `setXvsStore`, `setPrimeToken`, `initializeTimeManager`, and `setAccessControl` are restricted to the proxy admin.
 
-- - -
-
-### add
-
-Add a new token pool
-
-```solidity
-function add(address _rewardToken, uint256 _allocPoint, contract IBEP20 _token, uint256 _rewardPerBlock, uint256 _lockPeriod) external
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _rewardToken | address | Reward token address |
-| _allocPoint | uint256 | Number of allocation points assigned to this pool |
-| _token | contract IBEP20 | Staked token |
-| _rewardPerBlock | uint256 | Initial reward per block, in terms of _rewardToken |
-| _lockPeriod | uint256 | A period between withdrawal request and a moment when it's executable |
-
-- - -
-
-### set
-
-Update the given pool's reward allocation point
-
-```solidity
-function set(address _rewardToken, uint256 _pid, uint256 _allocPoint) external
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _rewardToken | address | Reward token address |
-| _pid | uint256 | Pool index |
-| _allocPoint | uint256 | Number of allocation points assigned to this pool |
-
-- - -
-
-### setRewardAmountPerBlock
-
-Update the given reward token's amount per block
-
-```solidity
-function setRewardAmountPerBlock(address _rewardToken, uint256 _rewardAmount) external
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _rewardToken | address | Reward token address |
-| _rewardAmount | uint256 | Number of allocation points assigned to this pool |
-
-- - -
-
-### setWithdrawalLockingPeriod
-
-Update the lock period after which a requested withdrawal can be executed
-
-```solidity
-function setWithdrawalLockingPeriod(address _rewardToken, uint256 _pid, uint256 _newPeriod) external
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _rewardToken | address | Reward token address |
-| _pid | uint256 | Pool index |
-| _newPeriod | uint256 | New lock period |
-
-- - -
-
-### deposit
-
-Deposit XVSVault for XVS allocation
-
-```solidity
-function deposit(address _rewardToken, uint256 _pid, uint256 _amount) external
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _rewardToken | address | The Reward Token Address |
-| _pid | uint256 | The Pool Index |
-| _amount | uint256 | The amount to deposit to vault |
-
-- - -
-
-### claim
-
-Claim rewards for pool
-
-```solidity
-function claim(address _account, address _rewardToken, uint256 _pid) external
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _account | address | The account for which to claim rewards |
-| _rewardToken | address | The Reward Token Address |
-| _pid | uint256 | The Pool Index |
-
-- - -
-
-### executeWithdrawal
-
-Execute withdrawal to XVSVault for XVS allocation
-
-```solidity
-function executeWithdrawal(address _rewardToken, uint256 _pid) external
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _rewardToken | address | The Reward Token Address |
-| _pid | uint256 | The Pool Index |
-
-- - -
-
-### requestWithdrawal
-
-Request withdrawal to XVSVault for XVS allocation
-
-```solidity
-function requestWithdrawal(address _rewardToken, uint256 _pid, uint256 _amount) external
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _rewardToken | address | The Reward Token Address |
-| _pid | uint256 | The Pool Index |
-| _amount | uint256 | The amount to withdraw from the vault |
-
-- - -
-
-### getEligibleWithdrawalAmount
-
-Get unlocked withdrawal amount
-
-```solidity
-function getEligibleWithdrawalAmount(address _rewardToken, uint256 _pid, address _user) external view returns (uint256 withdrawalAmount)
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _rewardToken | address | The Reward Token Address |
-| _pid | uint256 | The Pool Index |
-| _user | address | The User Address |
-
-#### Return Values
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| withdrawalAmount | uint256 | Amount that the user can withdraw |
-
-- - -
-
-### getRequestedAmount
-
-Get requested amount
-
-```solidity
-function getRequestedAmount(address _rewardToken, uint256 _pid, address _user) external view returns (uint256)
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _rewardToken | address | The Reward Token Address |
-| _pid | uint256 | The Pool Index |
-| _user | address | The User Address |
-
-#### Return Values
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | Total amount of requested but not yet executed withdrawals (including both executable and locked ones) |
-
-- - -
-
-### getWithdrawalRequests
-
-Returns the array of withdrawal requests that have not been executed yet
-
-```solidity
-function getWithdrawalRequests(address _rewardToken, uint256 _pid, address _user) external view returns (struct XVSVaultStorageV1.WithdrawalRequest[])
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _rewardToken | address | The Reward Token Address |
-| _pid | uint256 | The Pool Index |
-| _user | address | The User Address |
-
-#### Return Values
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | struct XVSVaultStorageV1.WithdrawalRequest[] | An array of withdrawal requests |
-
-- - -
-
-### pendingReward
-
-View function to see pending XVSs on frontend
-
-```solidity
-function pendingReward(address _rewardToken, uint256 _pid, address _user) external view returns (uint256)
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _rewardToken | address | Reward token address |
-| _pid | uint256 | Pool index |
-| _user | address | User address |
-
-#### Return Values
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint256 | Reward the user is eligible for in this pool, in terms of _rewardToken |
-
-- - -
-
-### updatePool
-
-Update reward variables of the given pool to be up-to-date
-
-```solidity
-function updatePool(address _rewardToken, uint256 _pid) external
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _rewardToken | address | Reward token address |
-| _pid | uint256 | Pool index |
-
-- - -
-
-### getUserInfo
-
-Get user info with reward token address and pid
-
-```solidity
-function getUserInfo(address _rewardToken, uint256 _pid, address _user) external view returns (uint256 amount, uint256 rewardDebt, uint256 pendingWithdrawals)
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _rewardToken | address | Reward token address |
-| _pid | uint256 | Pool index |
-| _user | address | User address |
-
-#### Return Values
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| amount | uint256 | Deposited amount |
-| rewardDebt | uint256 | Reward debt (technical value used to track past payouts) |
-| pendingWithdrawals | uint256 | Requested but not yet executed withdrawals |
-
-- - -
-
-### pendingWithdrawalsBeforeUpgrade
-
-Gets the total pending withdrawal amount of a user before upgrade
-
-```solidity
-function pendingWithdrawalsBeforeUpgrade(address _rewardToken, uint256 _pid, address _user) public view returns (uint256 beforeUpgradeWithdrawalAmount)
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| _rewardToken | address | The Reward Token Address |
-| _pid | uint256 | The Pool Index |
-| _user | address | The address of the user |
-
-#### Return Values
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| beforeUpgradeWithdrawalAmount | uint256 | Total pending withdrawal amount in requests made before the vault upgrade |
-
-- - -
-
-### delegate
-
-Delegate votes from `msg.sender` to `delegatee`
+## Governance delegation
 
 ```solidity
 function delegate(address delegatee) external
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| delegatee | address | The address to delegate votes to |
-
-- - -
-
-### delegateBySig
-
-Delegates votes from signatory to `delegatee`
-
-```solidity
 function delegateBySig(address delegatee, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s) external
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| delegatee | address | The address to delegate votes to |
-| nonce | uint256 | The contract state required to match the signature |
-| expiry | uint256 | The time at which to expire the signature |
-| v | uint8 | The recovery byte of the signature |
-| r | bytes32 | Half of the ECDSA signature pair |
-| s | bytes32 | Half of the ECDSA signature pair |
-
-- - -
-
-### getCurrentVotes
-
-Gets the current votes balance for `account`
-
-```solidity
+function delegates(address account) external view returns (address)
 function getCurrentVotes(address account) external view returns (uint96)
+function getPriorVotes(address account, uint256 blockNumberOrSecond) external view returns (uint96)
 ```
 
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| account | address | The address to get votes balance |
+Voting checkpoints use the deployment's configured clock. On time-based chains, the historical parameter is a timestamp; on block-based chains, it is a block number. Governance proposal voting on BNB Chain uses the BNB vault snapshots.
 
-#### Return Values
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint96 | The number of current votes for `account` |
+## Prime integration
 
-- - -
+The vault can call the configured Prime token when an eligible XVS stake changes. Prime generation and support differ by network; see [Prime Contract Versions](../../prime/README.md). Do not assume the BNB PrimeV2 leaderboard callback exists on a Prime V1 deployment.
 
-### getPriorVotes
-
-Determine the xvs stake balance for an account
-
-```solidity
-function getPriorVotes(address account, uint256 blockNumber) external view returns (uint96)
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| account | address | The address of the account to check |
-| blockNumber | uint256 | The block number to get the vote balance at |
-
-#### Return Values
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [0] | uint96 | The balance that user staked |
-
-- - -
-
-### _become
-
-* Admin Functions **
-
-```solidity
-function _become(contract XVSVaultProxy xvsVaultProxy) external
-```
-
-- - -
-
-### setAccessControl
-
-Sets the address of the access control of this contract
-
-```solidity
-function setAccessControl(address newAccessControlAddress) external
-```
-
-#### Parameters
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| newAccessControlAddress | address | New address for the access control |
-
-- - -
-
+Source: [XVSVault.sol in venus-protocol v10.3.0](https://github.com/VenusProtocol/venus-protocol/blob/v10.3.0/contracts/XVSVault/XVSVault.sol).


### PR DESCRIPTION
## Summary

- document current interest-rate model selection, clock constants, and CheckpointView usage
- map Prime V1/V2, leaderboard, liquidity-provider, PSM, VAI Vault, and XVS Vault deployments and operating state
- correct stale ABI, access-control, storage-layout, constructor, and per-block/per-second details
- clearly scope legacy or unverified reference pages instead of presenting them as current deployments

## Validation

- Remark: 22 changed Markdown files, no issues
- relative Markdown links: all targets exist
- git diff --check
- deployment/version data cross-checked against current source and live contract state