### PR TITLE
docs: version governance and XVS bridge contracts

### DIFF
--- a/guides/xvs-bridge.md
+++ b/guides/xvs-bridge.md
@@ -1,53 +1,30 @@
 # XVS Bridge
 
-### Introduction
+The Venus interface can bridge XVS among BNB Chain, Ethereum, Arbitrum, opBNB, Optimism, Base, zkSync Era, and Unichain. Available paths and limits are mutable; use the networks and live checks shown by the interface rather than a saved limits table.
 
-This guide provides step-by-step instructions on how to bridge XVS tokens from the BNB Chain to the Ethereum network.
+## Before you start
 
-### Steps for Bridging XVS from BNB Chain to Ethereum
+* Open the official [XVS Bridge](https://app.venus.io/#/bridge) and confirm the domain before connecting a wallet.
+* Keep native gas tokens on the source network.
+* Confirm the source and destination networks, connected account, XVS amount, quoted LayerZero fee, bridge address, and wallet spending limit.
+* The current interface sends destination XVS to the connected account. Do not use this workflow when you need a different recipient.
+* Bridging is asynchronous and depends on both networks, Venus bridge configuration, its oracle and limits, destination mint capacity, and LayerZero V1 messaging.
 
-#### Step 1: Access the Venus Bridge
+## Submit a transfer
 
-* Navigate to the Venus Protocol and select the "Bridge" option from the sidebar menu. [XVS Bridge](https://app.venus.io/#/bridge)
+1. Connect the wallet that holds XVS and select the source network.
+2. Choose a different destination network. Switching the source network in the form also requests a wallet network switch.
+3. Enter the XVS amount. The interface checks the local balance, single and rolling 24-hour bridge limits, destination mint capacity, and estimated native-token fee.
+4. If the interface requests an approval, inspect the exact token, spender, amount, and network before signing. BNB Chain outbound transfers lock native XVS with `transferFrom`; destination-chain transfers burn omnichain XVS through the authorized local bridge.
+5. Review the final quote and submit the bridge transaction. The fee can change before inclusion, so reject a wallet request whose value or contract differs from the reviewed transaction.
+6. Track the source transaction and the corresponding LayerZero message. The destination balance is final only after the destination transaction succeeds.
 
-#### Step 2: Connect Your Wallet
+## If a transfer is delayed or fails
 
-* Click on the "Connect wallet" button in the top right corner of the Venus Bridge interface to connect your wallet.
+Do not immediately repeat the transfer: a delayed message can still execute and a duplicate transfer would send another amount. Record the source transaction hash and inspect its LayerZero message and destination status.
 
-<figure><img src="../.gitbook/assets/Screenshot 2024-01-22 at 1.15.11 PM.png" alt=""><figcaption></figcaption></figure>
+Common causes include a paused bridge or token, stale or rejected oracle price, path limits, insufficient destination gas, an untrusted route, blacklisting, or exhausted destination mint capacity. `retryMessage` is an administrative recovery path for a stored failed payload, not a normal user action. Report the transaction hash and both networks through an official Venus support channel if the interface does not recover normally.
 
-#### Step 3: Configure the Bridge Transaction
+## Approval hygiene
 
-* **From**: Ensure "BNB mainnet" is selected in the "From" dropdown menu.
-* **To**: Select "Ethereum" in the "To" dropdown menu to set the destination network.
-
-<figure><img src="../.gitbook/assets/Screenshot 2024-01-22 at 1.25.29 PM.png" alt=""><figcaption></figcaption></figure>
-
-#### Step 4: Enter the Amount to Bridge
-
-* Enter the amount of XVS you wish to transfer in the "Amount" field. You can also use the "MAX" button to transfer the total available balance.
-* Check your "Wallet balance" to confirm you have sufficient XVS and BNB for gas fees.
-
-#### Step 5: Approve XVS Token
-
-* Before initiating the transfer, you must give the bridge contract permission to access your XVS tokens. Click on the "Approve XVS" button to do this.
-* A wallet pop-up will request your confirmation for the approval. Confirm to proceed.
-
-<figure><img src="../.gitbook/assets/Screenshot 2024-01-22 at 1.31.35 PM.png" alt=""><figcaption></figcaption></figure>
-
-#### Step 6: Initiate the Transfer
-
-* After approving XVS token usage, the interface will update to reflect the next step. Click the "Transfer" button (which replaces the "Approve XVS" button after approval) to initiate the bridging process.
-* A confirmation pop-up will appear in your wallet for you to approve the transaction.
-
-#### Step 7: Confirm and Wait
-
-* Confirm the transaction in your wallet. The Venus Bridge interface will show the transaction as pending, indicating that it is being processed. This may take a few minutes.
-
-#### Step 8: Transaction Completion
-
-* Once the transaction is complete, the XVS tokens will be available in your Ethereum wallet.
-
-### Conclusion
-
-Bridging XVS tokens from BNB Chain to Ethereum is made simple with the Venus Protocol. Remember to approve your tokens for use by the bridge and to check transaction details carefully before confirming to ensure a smooth bridging experience.
+An ERC-20 approval remains after a transfer unless it is consumed or revoked. Prefer the amount needed for the intended transaction. After bridging, review the remaining XVS allowance to the source bridge and revoke it if you do not plan to bridge again.

--- a/technical-reference/reference-governance/README.md
+++ b/technical-reference/reference-governance/README.md
@@ -1,1 +1,16 @@
-# Governance
+# Governance contract families
+
+These references cover several deployed generations. They are not one interchangeable ABI. The source baseline for this section is the stable [`governance-contracts` v2.15.0 tag](https://github.com/VenusProtocol/governance-contracts/tree/v2.15.0).
+
+| Family | Production role | Version boundary |
+| --- | --- | --- |
+| Governor Bravo | Proposes, votes, queues, and executes BNB Chain VIPs through three route-specific timelocks | Upgradeable Solidity 0.5 governor. Its V1 scalar `votingDelay`, `votingPeriod`, and `proposalThreshold` slots are deprecated; current rules are stored per proposal type in `proposalConfigs` |
+| Omnichain governance | Sends approved BNB Chain commands to executors and TimelockV8 contracts on destination networks | LayerZero V1-style messaging with `uint16` endpoint IDs (called chain IDs in the ABI). Do not substitute EVM chain IDs or LayerZero V2 EIDs/OApp APIs |
+| Risk Steward V2 | Publishes and validates bounded risk-parameter updates | Current stable source, but rollout is not uniform: v2.15.0 artifacts contain the BNB mainnet origin stack and destination receivers/stewards on testnets, not on every destination mainnet |
+| Access control | Resolves exact-contract and wildcard function-signature permissions | The BNB mainnet AccessControlManager has the older ABI without `hasPermission`; the seven destination-mainnet artifacts include it |
+
+`AccessControlledV5` remains relevant to live legacy contracts. `AccessControlledV8` is the current Solidity 0.8 base, but inherited owner, proxy, and access-control selectors depend on the exact deployed implementation.
+
+LayerZero labels V1 deprecated for new integrations in its [V1 deployment reference](https://docs.layerzero.network/v1/deployments/deployed-contracts). That upstream lifecycle label does not mean the active Venus Omnichain Governance contracts have been retired; it means new code must not silently substitute V2 APIs for this legacy transport.
+
+Addresses and lifecycle labels belong in the [deployed governance registry](../../deployed-contracts/governance.md). Use this section for ABI and version selection, and identify a proxy's implementation before encoding administrative calls.

--- a/technical-reference/reference-governance/access-control-manager.md
+++ b/technical-reference/reference-governance/access-control-manager.md
@@ -1,18 +1,20 @@
 # AccessControlManager
 
+This page follows [`AccessControlManager.sol` at governance-contracts v2.15.0](https://github.com/VenusProtocol/governance-contracts/blob/v2.15.0/contracts/Governance/AccessControlManager.sol). The BNB mainnet instance uses an older deployed ABI without `hasPermission`; the destination-mainnet v2.15.0 artifacts include that selector. `isAllowedToCall` remains the permission hook on both generations.
+
 Access control plays a crucial role in the Venus governance model. It is used to restrict functions so that they can only be called from one
 account or list of accounts (EOA or Contract Accounts).
 
-The implementation of `AccessControlManager`(https://github.com/VenusProtocol/governance-contracts/blob/main/contracts/Governance/AccessControlManager.sol)
+The [`AccessControlManager` implementation](https://github.com/VenusProtocol/governance-contracts/blob/v2.15.0/contracts/Governance/AccessControlManager.sol)
 inherits the [Open Zeppelin AccessControl](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/AccessControl.sol)
 contract as a base for role management logic. There are two role types: admin and granular permissions.
 
 ## Granular Roles
 
 Granular roles are built by hashing the contract address and its function signature. For example, given contract `Foo` with function `Foo.bar()` which
-is guarded by ACM, calling `giveRolePermission` for account B do the following:
+is guarded by ACM, calling `giveCallPermission` for account B does the following:
 
-1. Compute `keccak256(contractFooAddress,functionSignatureBar)`
+1. Compute `keccak256(abi.encodePacked(contractFooAddress, functionSignatureBar))`
 2. Add the computed role to the roles of account B
 3. Account B now can call `ContractFoo.bar()`
 
@@ -114,6 +116,8 @@ function isAllowedToCall(address account, string functionSig) public view return
 ### hasPermission
 
 Verifies if the given account can call a contract's guarded function
+
+This convenience view exists in the current source and destination-mainnet deployments. It is not present in the BNB mainnet AccessControlManager ABI; offchain tools querying that instance must compute the role and use `hasRole`, or call the guarded contract's normal permission path.
 
 ```solidity
 function hasPermission(address account, address contractAddress, string functionSig) public view returns (bool)

--- a/technical-reference/reference-governance/access-controlled-v5.md
+++ b/technical-reference/reference-governance/access-controlled-v5.md
@@ -1,7 +1,8 @@
 # AccessControlledV5
 
-This contract is helper between access control manager and actual contract. This contract further inherited by other contract (using solidity 0.5.16)
-to integrate access controlled mechanism. It provides initialise methods and verifying access methods.
+[`AccessControlledV5`](https://github.com/VenusProtocol/governance-contracts/blob/v2.15.0/contracts/Governance/AccessControlledV5.sol) is the Solidity 0.5.16 adapter retained for legacy contracts such as Governor Bravo and older protocol components. Its compiler generation is old, but the base is not globally deprecated while those deployments remain active.
+
+It exposes the configured AccessControlManager and provides internal initialization and permission-check helpers. It has no public ACM setter; the inheriting contract determines when `_setAccessControlManager` can run.
 
 # Solidity API
 

--- a/technical-reference/reference-governance/access-controlled-v8.md
+++ b/technical-reference/reference-governance/access-controlled-v8.md
@@ -1,7 +1,8 @@
 # AccessControlledV8
 
-This contract is helper between access control manager and actual contract. This contract further inherited by other contract (using solidity 0.8.13)
-to integrate access controlled mechanism. It provides initialise methods and verifying access methods.
+[`AccessControlledV8`](https://github.com/VenusProtocol/governance-contracts/blob/v2.15.0/contracts/Governance/AccessControlledV8.sol) is the current Solidity 0.8.25 upgradeable adapter between an inheriting contract and AccessControlManager. The previous statement that this stable source uses Solidity 0.8.13 is stale.
+
+The base inherits OpenZeppelin `Ownable2StepUpgradeable`: `setAccessControlManager` is owner-only, while ownership transfer requires the pending owner to accept. Older inheriting deployments can expose a different inherited surface, so select the ABI by implementation rather than by this base page alone.
 
 # Solidity API
 

--- a/technical-reference/reference-governance/base-omnichain-controller-dest.md
+++ b/technical-reference/reference-governance/base-omnichain-controller-dest.md
@@ -1,10 +1,12 @@
 # BaseOmnichainControllerDest
 
+[`BaseOmnichainControllerDest` at v2.15.0](https://github.com/VenusProtocol/governance-contracts/blob/v2.15.0/contracts/Cross-chain/BaseOmnichainControllerDest.sol) is the abstract destination-side base for OmnichainGovernanceExecutor. It uses the LayerZero V1 `NonblockingLzApp` API, applies one 24-hour receive-command limit to the BNB source, and disables ownership renunciation. It is not a standalone deployment.
+
 # Solidity API
 
 ### maxDailyReceiveLimit
 
-Maximum daily limit for receiving commands from Binance chain
+Maximum daily limit for receiving commands from BNB Chain
 
 ```solidity
 uint256 maxDailyReceiveLimit

--- a/technical-reference/reference-governance/base-omnichain-controller-src.md
+++ b/technical-reference/reference-governance/base-omnichain-controller-src.md
@@ -1,5 +1,7 @@
 # BaseOmnichainControllerSrc
 
+[`BaseOmnichainControllerSrc` at v2.15.0](https://github.com/VenusProtocol/governance-contracts/blob/v2.15.0/contracts/Cross-chain/BaseOmnichainControllerSrc.sol) is the abstract BNB-side base for the current OmnichainProposalSender. It uses LayerZero V1 `uint16` endpoint IDs, named chain IDs in the ABI, applies per-destination 24-hour command limits, and disables ownership renunciation. It is not a standalone deployment.
+
 # Solidity API
 
 ### accessControlManager

--- a/technical-reference/reference-governance/base-risk-steward.md
+++ b/technical-reference/reference-governance/base-risk-steward.md
@@ -1,6 +1,8 @@
 # BaseRiskSteward
 Abstract base contract for Risk Steward contracts providing common functionality
 
+[`BaseRiskSteward` at governance-contracts v2.15.0](https://github.com/VenusProtocol/governance-contracts/blob/v2.15.0/contracts/RiskSteward/BaseRiskSteward.sol) is not deployed directly. It provides the shared `safeDeltaBps` threshold and owner-only update used by the concrete market-cap, collateral-factor, and interest-rate-model stewards.
+
 # Solidity API
 
 ### safeDeltaBps
@@ -26,4 +28,3 @@ function renounceOwnership() public pure
 * Throws RenounceOwnershipNotAllowed
 
 - - -
-

--- a/technical-reference/reference-governance/collateral-factors-risk-steward.md
+++ b/technical-reference/reference-governance/collateral-factors-risk-steward.md
@@ -1,6 +1,8 @@
 # CollateralFactorsRiskSteward
 Contract that can update collateral factors and liquidation thresholds received from `RiskStewardReceiver`.
 
+This page follows [`CollateralFactorsRiskSteward.sol` at v2.15.0](https://github.com/VenusProtocol/governance-contracts/blob/v2.15.0/contracts/RiskSteward/CollateralFactorsRiskSteward.sol). On BNB mainnet at block `118369568`, proxy `0x1414ADf007E324ec1D0A77b9F1A8759Ad33d2879` used implementation `0x92352572478965A0377F57a4A2bebb4B369c22d4`, matching the tagged artifact. Destination-mainnet deployment must be verified separately; the stable tag contains destination instances on testnets.
+
 # Solidity API
 
 ### COLLATERAL_FACTORS
@@ -118,7 +120,7 @@ function isSafeForDirectExecution(struct RiskParameterUpdate update) external vi
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | bool | True if update is safe for direct execution, false if timelock is required |
+| \[0] | bool | True if update is safe for direct execution, false if timelock is required |
 
 #### ❌ Errors
 * Throws UnsupportedUpdateType if the update type is not supported
@@ -151,4 +153,3 @@ function applyUpdate(struct RiskParameterUpdate update) external
 * Throws UnsupportedUpdateType if the update type is not supported
 
 - - -
-

--- a/technical-reference/reference-governance/destination-steward-receiver.md
+++ b/technical-reference/reference-governance/destination-steward-receiver.md
@@ -2,6 +2,10 @@
 Destination‑chain contract that receives bridged updates from `RiskStewardReceiver` via LayerZero,
         enforces a fixed remote delay, and then executes the updates on the configured `IRiskSteward` contracts.
 
+This page follows [`DestinationStewardReceiver.sol` at v2.15.0](https://github.com/VenusProtocol/governance-contracts/blob/v2.15.0/contracts/RiskSteward/DestinationStewardReceiver.sol). The stable tag contains destination receiver artifacts on Sepolia-family testnets, but not on the seven destination mainnets. Treat this as the stable staged-rollout API, not evidence that every production network already has this component.
+
+The receiver uses LayerZero V2 OApp endpoint IDs (`uint32`) and peers, not the LayerZero V1 `uint16` trusted-remote model used by Omnichain Governance.
+
 # Solidity API
 
 ### REMOTE_UPDATE_EXPIRATION_TIME
@@ -311,7 +315,7 @@ function getRiskParameterConfig(string updateType) external view returns (struct
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | struct IDestinationStewardReceiver.RiskParamConfig | The risk parameter configuration |
+| \[0] | struct IDestinationStewardReceiver.RiskParamConfig | The risk parameter configuration |
 
 - - -
 
@@ -332,7 +336,7 @@ function getRegisteredUpdate(string updateType, address market) external view re
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | struct IDestinationStewardReceiver.DestinationUpdate | The registered update |
+| \[0] | struct IDestinationStewardReceiver.DestinationUpdate | The registered update |
 
 - - -
 
@@ -353,7 +357,17 @@ function getLastExecutedAt(string updateType, address market) external view retu
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | uint256 | The last executed timestamp |
+| \[0] | uint256 | The last executed timestamp |
+
+- - -
+
+### transferOwnership
+
+Starts the two-step ownership transfer used jointly by AccessControlledV8 and the LayerZero OApp base. The pending owner must call `acceptOwnership`.
+
+```solidity
+function transferOwnership(address newOwner) public
+```
 
 - - -
 
@@ -369,4 +383,3 @@ function renounceOwnership() public pure
 * Throws RenounceOwnershipNotAllowed
 
 - - -
-

--- a/technical-reference/reference-governance/governor-bravo-delegate.md
+++ b/technical-reference/reference-governance/governor-bravo-delegate.md
@@ -1,6 +1,8 @@
 # GovernorBravoDelegate
 
-Venus Governance latest on chain governance includes several new features including variable proposal routes and fine grained pause control.
+The BNB mainnet Governor is the `GovernorBravoDelegator` proxy at `0x2d56dC077072B53571b8252008C60e945108c75a`. At block `118369123`, its `implementation()` was `0x9975d7064e40D16E1B76B90e56F606D72B385701`, matching the stable [`GovernorBravoDelegate` v2.15.0 API](https://github.com/VenusProtocol/governance-contracts/blob/v2.15.0/contracts/Governance/GovernorBravoDelegate.sol).
+
+Venus Governance includes variable proposal routes and fine-grained pause control.
 Variable routes for proposals allows for governance paramaters such as voting threshold and timelocks to be customized based on the risk level and
 impact of the proposal. Added granularity to the pause control mechanism allows governance to pause individual actions on specific markets,
 which reduces impact on the protocol as a whole. This is particularly useful when applied to isolated pools.
@@ -24,11 +26,12 @@ Governance has **3 main contracts**: **GovernanceBravoDelegate, XVSVault, XVS** 
 * Cancel a proposal
 * Queue a proposal for execution with a timelock executor contract.
 
-`GovernanceBravoDelegate` uses the XVSVault to get restrict certain actions based on a user's voting power. The governance rules it inforces are:
+`GovernorBravoDelegate` uses the XVSVault to restrict certain actions based on a user's voting power. The governance rules it enforces are:
 
-* A user's voting power must be greater than the `proposalThreshold` to submit a proposal
-* If a user's voting power drops below certain amount, anyone can cancel the the proposal. The governance guardian and proposal creator can also
-  cancel a proposal at anytime before it is queued for execution.
+* A user's prior voting power must be greater than or equal to the selected route's `proposalConfigs[proposalType].proposalThreshold` to submit a proposal.
+* Before queueing, the proposer or guardian can cancel. Other callers can cancel if the proposer's prior votes have dropped below that route's threshold.
+
+The public V1 scalar getters `proposalThreshold`, `votingDelay`, and `votingPeriod` are deprecated storage retained for compatibility. They are not the authoritative current route configuration.
 
 ## Venus Improvement Proposal
 
@@ -40,7 +43,7 @@ that can prevent a larger risk to the protocol and are not urgent. There are thr
 * `FASTTRACK`
 * `CRITICAL`
 
-When initializing the `GovernorBravo` contract, the parameters for the three routes are set. The parameters are:
+Each route stores a configuration that can be initialized or updated with `setProposalConfigs`, subject to `validationParams` and the contract's threshold constants:
 
 * `votingDelay`: The delay in blocks between submitting a proposal and when voting begins
 * `votingPeriod`: The number of blocks where voting will be open
@@ -51,8 +54,7 @@ flow of each type of VIP.
 
 ## Voting
 
-After a VIP is proposed, voting is opened after the `votingDelay` has passed. For example, if `votingDelay = 0`, then voting will begin in the next block
-after the proposal has been submitted. After the delay, the proposal state is `ACTIVE` and users can cast their vote `for`, `against`, or `abstain`,
+After a VIP is proposed, voting opens after the selected route's configured `votingDelay`. Current validation requires a nonzero minimum delay and bounds every route's delay and period. Once the start block is reached, the proposal state is `ACTIVE` and users can cast their vote `for`, `against`, or `abstain`,
 weighted by their total voting power (tokens + delegated voting power). Abstaining from a voting allows for a vote to be cast and optionally include a
 comment, without the incrementing for or against vote count. The total voting power for the user is obtained by calling XVSVault's `getPriorVotes`.
 
@@ -75,17 +77,38 @@ vote delegation by calling the same function with a value of `0`.
 Used to initialize the contract during delegator contructor
 
 ```solidity
-function initialize(address xvsVault_, struct GovernorBravoDelegateStorageV2.ProposalConfig[] proposalConfigs_, contract TimelockInterface[] timelocks, address guardian_) public
+function initialize(address xvsVault_, struct GovernorBravoDelegateStorageV3.ValidationParams validationParams_, struct GovernorBravoDelegateStorageV2.ProposalConfig[] proposalConfigs_, contract TimelockInterface[] timelocks, address guardian_) public
 ```
 
 #### Parameters
 
-| Name              | Type                                                   | Description                                  |
-| ----------------- | ------------------------------------------------------ | -------------------------------------------- |
-| xvsVault\_        | address                                                | The address of the XvsVault                  |
+| Name | Type | Description |
+| --- | --- | --- |
+| xvsVault\_ | address | The address of the XvsVault |
+| validationParams\_ | struct GovernorBravoDelegateStorageV3.ValidationParams | Minimum and maximum voting delay and voting period accepted for route configuration |
 | proposalConfigs\_ | struct GovernorBravoDelegateStorageV2.ProposalConfig\[] | Governance configs for each governance route |
-| timelocks         | contract TimelockInterface\[]                           | Timelock addresses for each governance route |
-| guardian\_        | address                                                |                                              |
+| timelocks | contract TimelockInterface\[] | Timelock addresses for each governance route |
+| guardian\_ | address | Governance guardian |
+
+---
+
+### setValidationParams
+
+Sets the allowed minimum and maximum voting delay and voting period. The proxy admin is the only authorized caller.
+
+```solidity
+function setValidationParams(struct GovernorBravoDelegateStorageV3.ValidationParams newValidationParams) public
+```
+
+---
+
+### setProposalConfigs
+
+Sets all three route configurations after checking their delay, period, and threshold against the validation bounds and the contract's threshold constants. The proxy admin is the only authorized caller.
+
+```solidity
+function setProposalConfigs(struct GovernorBravoDelegateStorageV2.ProposalConfig[] proposalConfigs_) public
+```
 
 ---
 
@@ -151,7 +174,7 @@ function execute(uint256 proposalId) external
 
 ### cancel
 
-Cancels a proposal only if sender is the proposer, or proposer delegates dropped below proposal threshold
+Cancels an unexecuted proposal when called by its proposer or the guardian, or when the proposer's prior votes have dropped below the selected route's proposal threshold.
 
 ```solidity
 function cancel(uint256 proposalId) external

--- a/technical-reference/reference-governance/governor-bravo-delegator.md
+++ b/technical-reference/reference-governance/governor-bravo-delegator.md
@@ -1,6 +1,8 @@
 # GovernorBravoDelegator
 
-The `GovernorBravoDelegator` contract.
+[`GovernorBravoDelegator`](https://github.com/VenusProtocol/governance-contracts/blob/v2.15.0/contracts/Governance/GovernorBravoDelegator.sol) is the BNB mainnet governor proxy at `0x2d56dC077072B53571b8252008C60e945108c75a`. At block `118369123`, its public `implementation()` getter returned `0x9975d7064e40D16E1B76B90e56F606D72B385701`.
+
+This page documents the delegator-only upgrade entry point. Calls not implemented by the delegator are delegated to the active [GovernorBravoDelegate](governor-bravo-delegate.md), so the user-facing proxy ABI is the union of both surfaces. Only the delegator admin can change the implementation.
 
 # Solidity API
 

--- a/technical-reference/reference-governance/governor-bravo-interfaces.md
+++ b/technical-reference/reference-governance/governor-bravo-interfaces.md
@@ -1,6 +1,8 @@
 # GovernorBravoEvents
 
-Set of events emitted by the GovernorBravo contracts.
+Storage structures and events used by the stable [`GovernorBravoInterfaces.sol` v2.15.0 source](https://github.com/VenusProtocol/governance-contracts/blob/v2.15.0/contracts/Governance/GovernorBravoInterfaces.sol).
+
+The V1 scalar `votingDelay`, `votingPeriod`, `proposalThreshold`, and `timelock` storage slots are explicitly deprecated in the source but retained for upgrade-safe layout. Current logic uses the V2 `proposalConfigs` and `proposalTimelocks` mappings, plus the V3 `validationParams` structure.
 
 # Solidity API
 
@@ -59,6 +61,15 @@ struct ProposalConfig {
   uint256 votingDelay;
   uint256 votingPeriod;
   uint256 proposalThreshold;
+}
+```
+
+```solidity
+struct ValidationParams {
+  uint256 minVotingPeriod;
+  uint256 maxVotingPeriod;
+  uint256 minVotingDelay;
+  uint256 maxVotingDelay;
 }
 ```
 

--- a/technical-reference/reference-governance/irm-risk-steward.md
+++ b/technical-reference/reference-governance/irm-risk-steward.md
@@ -1,6 +1,8 @@
 # IRMRiskSteward
 Contract that can update interest rate models updates received from RiskStewardReceiver.
 
+This page follows [`IRMRiskSteward.sol` at v2.15.0](https://github.com/VenusProtocol/governance-contracts/blob/v2.15.0/contracts/RiskSteward/IRMRiskSteward.sol). On BNB mainnet at block `118369568`, proxy `0x8acaBc42Bb98E2e2b091902a7E23f60CcB730aaa` used implementation `0x0548A031574221e432f21a96bd7D24C0463c9eA5`, matching the tagged artifact. Destination-mainnet deployment must be verified separately; the stable tag contains destination instances on testnets.
+
 # Solidity API
 
 ### INTEREST_RATE_MODEL
@@ -119,11 +121,10 @@ function isSafeForDirectExecution(struct RiskParameterUpdate update) external vi
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | bool | True if update is safe for direct execution, false if timelock is required |
+| \[0] | bool | True if update is safe for direct execution, false if timelock is required |
 
 #### ❌ Errors
 * Throws UnsupportedUpdateType if the update type is not supported
 * Throws RedundantValue if the new IRM address is equal to the current IRM address
 
 - - -
-

--- a/technical-reference/reference-governance/market-caps-risk-steward.md
+++ b/technical-reference/reference-governance/market-caps-risk-steward.md
@@ -1,6 +1,8 @@
 # MarketCapsRiskSteward
 Contract that can update supply and borrow caps updates received from RiskStewardReceiver.
 
+This page follows [`MarketCapsRiskSteward.sol` at v2.15.0](https://github.com/VenusProtocol/governance-contracts/blob/v2.15.0/contracts/RiskSteward/MarketCapsRiskSteward.sol). On BNB mainnet at block `118369568`, proxy `0x816FfD00A274EDE0091421F77817ca260Db3a3E3` used implementation `0x6c4538b7e85b073099BFf08B43F7273E4792Bb43`, matching the tagged artifact. Destination-mainnet deployment must be verified separately; the stable tag contains destination instances on testnets.
+
 # Solidity API
 
 ### SUPPLY_CAP
@@ -127,7 +129,7 @@ function isSafeForDirectExecution(struct RiskParameterUpdate update) external vi
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | bool | True if update is safe for direct execution, false if timelock is required |
+| \[0] | bool | True if update is safe for direct execution, false if timelock is required |
 
 #### ❌ Errors
 * Throws UnsupportedUpdateType if the update type is not supported
@@ -160,4 +162,3 @@ function applyUpdate(struct RiskParameterUpdate update) external
 * Throws UnsupportedUpdateType if the update type is not supported
 
 - - -
-

--- a/technical-reference/reference-governance/omnichain-executor-owner.md
+++ b/technical-reference/reference-governance/omnichain-executor-owner.md
@@ -1,8 +1,8 @@
 # OmnichainExecutorOwner
 
-OmnichainProposalSender contract acts as a governance and access control mechanism,
-allowing owner to upsert signature of OmnichainGovernanceExecutor contract,
-also contains function to transfer the ownership of contract as well.
+[`OmnichainExecutorOwner` at v2.15.0](https://github.com/VenusProtocol/governance-contracts/blob/v2.15.0/contracts/Cross-chain/OmnichainExecutorOwner.sol) is the upgradeable access-controlled owner of a destination OmnichainGovernanceExecutor. The previous description incorrectly called this contract `OmnichainProposalSender`.
+
+Known selectors are registered by their full function-signature strings. The fallback resolves `msg.sig`, checks the corresponding AccessControlManager permission, and forwards the original calldata to the executor. `upsertSignature` is owner-only; `setTrustedRemoteAddress` and `transferBridgeOwnership` use exact ACM signatures. Ownership renunciation is disabled.
 
 # Solidity API
 
@@ -85,7 +85,7 @@ fallback(bytes data_) external returns (bytes)
 
 | Name | Type  | Description             |
 | ---- | ----- | ----------------------- |
-| [0]  | bytes | Result of function call |
+| \[0]  | bytes | Result of function call |
 
 #### ⛔️ Access Requirements
 

--- a/technical-reference/reference-governance/omnichain-governance-executor.md
+++ b/technical-reference/reference-governance/omnichain-governance-executor.md
@@ -1,6 +1,8 @@
 # OmnichainGovernanceExecutor
 
-Executes the proposal transactions sent from the main chain
+[`OmnichainGovernanceExecutor` at v2.15.0](https://github.com/VenusProtocol/governance-contracts/blob/v2.15.0/contracts/Cross-chain/OmnichainGovernanceExecutor.sol) receives LayerZero V1 messages from the trusted BNB sender, queues each route through its destination TimelockV8, and permits permissionless execution after the timelock ETA. Only the configured guardian can cancel a queued remote proposal.
+
+The deployed surface also inherits LayerZero configuration, trusted-remote, failed-message, pause, ownership, and receive-limit selectors from `NonblockingLzApp` and [BaseOmnichainControllerDest](base-omnichain-controller-dest.md). Administrative calls normally pass through OmnichainExecutorOwner; do not infer direct caller authority from public ABI presence.
 
 # Solidity API
 
@@ -276,6 +278,6 @@ function state(uint256 proposalId_) public view returns (enum OmnichainGovernanc
 
 | Name | Type                                           | Description    |
 | ---- | ---------------------------------------------- | -------------- |
-| [0]  | enum OmnichainGovernanceExecutor.ProposalState | Proposal state |
+| \[0]  | enum OmnichainGovernanceExecutor.ProposalState | Proposal state |
 
 ---

--- a/technical-reference/reference-governance/omnichain-proposal-sender.md
+++ b/technical-reference/reference-governance/omnichain-proposal-sender.md
@@ -1,8 +1,8 @@
 # OmnichainProposalSender
 
-OmnichainProposalSender contract builds upon the functionality of its parent contract, BaseOmnichainControllerSrc
-It sends a proposal's data to remote chains for execution after the proposal passes on the main chain
-when used with GovernorBravo, the owner of this contract must be set to the Timelock contract
+[`OmnichainProposalSender` at v2.15.0](https://github.com/VenusProtocol/governance-contracts/blob/v2.15.0/contracts/Cross-chain/OmnichainProposalSender.sol) is the BNB-side LayerZero V1 sender. It sends proposal data to configured destination executors after the BNB proposal passes. In the production governance flow its owner is the Normal Timelock, while the exact caller permissions for `execute` and administrative functions are resolved by AccessControlManager.
+
+The current API includes inherited `setMaxDailyLimit`, `pause`, `unpause`, `setAccessControlManager`, `owner`, and `transferOwnership` selectors. Ownership renunciation is deliberately disabled. `retryExecute` is for sends that failed before LayerZero accepted them; `fallbackWithdraw` clears a matching stored execution and recovers its original native-token value.
 
 # Solidity API
 
@@ -67,8 +67,8 @@ function estimateFees(uint16 remoteChainId_, bytes payload_, bool useZro_, bytes
 
 | Name | Type    | Description                                                    |
 | ---- | ------- | -------------------------------------------------------------- |
-| [0]  | uint256 | nativeFee The amount of fee in the native gas token (e.g. ETH) |
-| [1]  | uint256 | zroFee The amount of fee in ZRO token                          |
+| \[0]  | uint256 | nativeFee The amount of fee in the native gas token (e.g. ETH) |
+| \[1]  | uint256 | zroFee The amount of fee in ZRO token                          |
 
 ---
 

--- a/technical-reference/reference-governance/risk-oracle.md
+++ b/technical-reference/reference-governance/risk-oracle.md
@@ -1,6 +1,10 @@
 # Risk Oracle
 Contract for managing and publishing risk parameter updates for Risk-Steward Updates
 
+This API is pinned to [`RiskOracle.sol` at v2.15.0](https://github.com/VenusProtocol/governance-contracts/blob/v2.15.0/contracts/RiskSteward/RiskOracle.sol). On BNB mainnet at block `118369568`, proxy `0x0E3E51958b0Daa8C57c949675975CBEDd7b5a1a1` used implementation `0x34045517284cB1Ac2806Fe3298a39886DA29De48`, matching the tagged artifact.
+
+The proxy surface also includes inherited two-step ownership, AccessControlManager, and upgrade selectors. Publishing authorization is determined by `authorizedSenders` and active update types; ABI presence alone does not authorize a caller.
+
 # Solidity API
 
 ### updateCounter
@@ -271,7 +275,7 @@ function getLatestUpdateByTypeAndMarket(string updateType, address market) exter
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | struct RiskParameterUpdate | The most recent RiskParameterUpdate for the specified parameter and market |
+| \[0] | struct RiskParameterUpdate | The most recent RiskParameterUpdate for the specified parameter and market |
 
 #### ❌ Errors
 * Throws NoUpdateFound if no update exists for the specified parameter and market
@@ -294,7 +298,7 @@ function getUpdateById(uint256 updateId) external view returns (struct RiskParam
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | struct RiskParameterUpdate | The RiskParameterUpdate for the specified id |
+| \[0] | struct RiskParameterUpdate | The RiskParameterUpdate for the specified id |
 
 #### ❌ Errors
 * Throws InvalidUpdateId if updateId is 0 or greater than updateCounter
@@ -312,7 +316,7 @@ function allUpdateTypesLength() external view returns (uint256)
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | uint256 | The length of the allUpdateTypes array |
+| \[0] | uint256 | The length of the allUpdateTypes array |
 
 - - -
 
@@ -333,7 +337,7 @@ function getLatestUpdateIdByTypeAndMarket(string updateType, address market) ext
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | uint256 | The latest update ID for the given market and update type, or 0 if none exists |
+| \[0] | uint256 | The latest update ID for the given market and update type, or 0 if none exists |
 
 - - -
 
@@ -353,7 +357,7 @@ function getActiveUpdateTypes(string updateType) external view returns (bool)
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | bool | True if the update type is active, false otherwise |
+| \[0] | bool | True if the update type is active, false otherwise |
 
 - - -
 
@@ -368,7 +372,7 @@ function getAllUpdateTypes() external view returns (string[])
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | string[] | An array of all update type strings |
+| \[0] | string[] | An array of all update type strings |
 
 - - -
 
@@ -384,4 +388,3 @@ function renounceOwnership() public pure
 * Throws RenounceOwnershipNotAllowed
 
 - - -
-

--- a/technical-reference/reference-governance/risk-steward-receiver.md
+++ b/technical-reference/reference-governance/risk-steward-receiver.md
@@ -2,6 +2,10 @@
 Contract that reads updates from a Risk Oracle, validates them with timelock and debounce,
         and either executes them locally via the configured RiskSteward or forwards them cross‑chain.
 
+This page follows [`RiskStewardReceiver.sol` at v2.15.0](https://github.com/VenusProtocol/governance-contracts/blob/v2.15.0/contracts/RiskSteward/RiskStewardReceiver.sol). On BNB mainnet at block `118369568`, proxy `0x47856bFa74B71d24a5545c7506862B8FddE52baB` used implementation `0xC00Ec4149eCfB60378152e05C5B896c08EA49e6E`, matching the tagged artifact.
+
+This is the origin receiver. It uses LayerZero V2 OApp endpoint IDs (`uint32`), unlike the older `uint16` LayerZero V1 endpoint IDs in Omnichain Governance and the XVS bridge. Do not interchange their peer, fee, or retry APIs.
+
 # Solidity API
 
 ### UPDATE_EXPIRATION_TIME
@@ -397,7 +401,7 @@ function isUpdateExecutable(uint256 updateId) external view returns (bool)
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | bool | True if the update is pending, not expired, active, and past its timelock |
+| \[0] | bool | True if the update is pending, not expired, active, and past its timelock |
 
 - - -
 
@@ -417,7 +421,7 @@ function getRiskParameterConfig(string updateType) external view returns (struct
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | struct IRiskStewardReceiver.RiskParamConfig | The risk parameter configuration |
+| \[0] | struct IRiskStewardReceiver.RiskParamConfig | The risk parameter configuration |
 
 - - -
 
@@ -438,7 +442,7 @@ function getLastProcessedUpdate(string updateType, address market) external view
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | uint256 | The last processed update ID |
+| \[0] | uint256 | The last processed update ID |
 
 - - -
 
@@ -459,7 +463,7 @@ function getLastRegisteredUpdate(string updateType, address market) external vie
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | uint256 | The last registered update ID |
+| \[0] | uint256 | The last registered update ID |
 
 - - -
 
@@ -507,6 +511,16 @@ function lzSend(uint32 dstEid, struct RiskParameterUpdate update, bytes options,
 
 - - -
 
+### transferOwnership
+
+Starts the two-step ownership transfer used jointly by AccessControlledV8 and the LayerZero OApp base. The pending owner must call `acceptOwnership`.
+
+```solidity
+function transferOwnership(address newOwner) public
+```
+
+- - -
+
 ### renounceOwnership
 
 Disables renounceOwnership function
@@ -519,4 +533,3 @@ function renounceOwnership() public pure
 * Throws RenounceOwnershipNotAllowed
 
 - - -
-

--- a/technical-reference/reference-governance/timelock.md
+++ b/technical-reference/reference-governance/timelock.md
@@ -1,5 +1,8 @@
 # Timelock
-The Timelock contract.
+
+Venus has two active Timelock source families with the same transaction tuple but different administration semantics. BNB mainnet's three Governor Bravo routes use the legacy Solidity 0.5 [`Timelock`](https://github.com/VenusProtocol/governance-contracts/blob/v2.15.0/contracts/Governance/Timelock.sol). Destination-mainnet governance artifacts use Solidity 0.8.25 [`TimelockV8`](https://github.com/VenusProtocol/governance-contracts/blob/v2.15.0/contracts/Governance/TimelockV8.sol).
+
+`TimelockV8` allows `setPendingAdmin` from the current admin as well as from the timelock itself, rejects duplicate queue/cancel state transitions, validates nonzero admins, and exposes `GRACE_PERIOD`, `MINIMUM_DELAY`, and `MAXIMUM_DELAY` as virtual view functions. The legacy contract permits `setPendingAdmin` only through the timelock itself. Select the contract family by network and bytecode before relying on those differences.
 
 # Solidity API
 
@@ -56,14 +59,14 @@ function queueTransaction(address target, uint256 value, string signature, bytes
 | ---- | ---- | ----------- |
 | target | address | Address of the contract with the method to be called |
 | value | uint256 | Native token amount sent with the transaction |
-| signature | string | Ssignature of the function to be called |
+| signature | string | Signature of the function to be called |
 | data | bytes | Arguments to be passed to the function when called |
 | eta | uint256 | Timestamp after which the transaction can be executed |
 
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | bytes32 | Hash of the queued transaction |
+| \[0] | bytes32 | Hash of the queued transaction |
 
 - - -
 
@@ -80,7 +83,7 @@ function cancelTransaction(address target, uint256 value, string signature, byte
 | ---- | ---- | ----------- |
 | target | address | Address of the contract with the method to be called |
 | value | uint256 | Native token amount sent with the transaction |
-| signature | string | Ssignature of the function to be called |
+| signature | string | Signature of the function to be called |
 | data | bytes | Arguments to be passed to the function when called |
 | eta | uint256 | Timestamp after which the transaction can be executed |
 
@@ -99,9 +102,8 @@ function executeTransaction(address target, uint256 value, string signature, byt
 | ---- | ---- | ----------- |
 | target | address | Address of the contract with the method to be called |
 | value | uint256 | Native token amount sent with the transaction |
-| signature | string | Ssignature of the function to be called |
+| signature | string | Signature of the function to be called |
 | data | bytes | Arguments to be passed to the function when called |
 | eta | uint256 | Timestamp after which the transaction can be executed |
 
 - - -
-

--- a/technical-reference/reference-technical-articles/omnichain-governance.md
+++ b/technical-reference/reference-technical-articles/omnichain-governance.md
@@ -1,5 +1,7 @@
 # Omnichain Governance
 
+The contract descriptions are pinned to stable [`governance-contracts` v2.15.0](https://github.com/VenusProtocol/governance-contracts/tree/v2.15.0). This governance transport uses LayerZero V1 `uint16` endpoint IDs (named chain IDs in the ABI) and trusted-remote APIs. It is separate from the Risk Steward V2 OApp transport, which uses `uint32` EIDs and peers.
+
 ## System Overview
 
 Omnichain Governance is designed to facilitate the execution of VIP across multiple blockchain networks, integrating with the Access Control Manager (ACM) and LayerZero communication protocol. It extends the [governance model proposed by LayerZero](https://github.com/LayerZero-Labs/omnichain-governance-executor/tree/main).
@@ -52,11 +54,11 @@ Omnichain Governance is designed to facilitate the execution of VIP across multi
 1. Proposing a remote VIP on BNB Chain
 
 * A proposer submits a VIP through the existing governance mechanism on the BNB Chain.
-* The must VIP include a command invoking the `OmnichainProposalSender::execute` function which will send the remote VIP payload.
+* The VIP must include a command invoking `OmnichainProposalSender::execute`, which sends the remote VIP payload.
 * The `execute` function takes four arguments:
-  * `chainID`: Identifies the destination network for the remote execution (`endpointId` according to [LayerZero](https://layerzero.gitbook.io/docs/technical-reference/mainnet/supported-chain-ids)).
+  * `chainID`: The destination's [LayerZero V1 endpoint ID](https://docs.layerzero.network/v1/deployments/deployed-contracts), not its EVM chain ID or LayerZero V2 EID.
   * `payload`: Encoded data (off-chain) containing the specific commands to be executed on the target network.
-  * `adapterParams`: The params used to specify the custom amount of gas required for the execution on the destination encoded as (ethers.utils.solidityPack(['uint16','uint256'],[1, gasValue])).
+  * `adapterParams`: Parameters specifying destination execution gas, encoded with `ethers.utils.solidityPack(["uint16", "uint256"], [1, gasValue])` for a version-1 adapter payload.
   * `zroPaymentAddress_`: The address of the ZRO token holder who would pay for the transaction.
 
 2. Eligibility checks and limits
@@ -228,7 +230,7 @@ This contract executes proposal transactions sent from the main chain. It contro
 
 #### State variables
 
-* **`GUARDIAN (address)`**: A privileged role that can cancel any proposal.
+* **`guardian (address)`**: A privileged role that can cancel a queued remote proposal.
 * **`srcChainId (uint16)`**: Stores the layerzero endpoint ID.
 * **`lastProposalReceived (uint256)`**: Last proposal count received.
 * **`proposals (mapping)`**: Official record of all proposals ever proposed.

--- a/technical-reference/reference-technical-articles/xvs-bridge.md
+++ b/technical-reference/reference-technical-articles/xvs-bridge.md
@@ -1,19 +1,23 @@
 # XVS Cross-Chain Bridge Documentation
 
-This documentation provides detailed instructions and explanations for using the XVS Cross-Chain Bridge. The bridge allows users to transfer tokens between different blockchain networks, including the [BNB chain](https://www.bnbchain.org) and multiple destination chains. The supported networks are as follows:
+This article describes the stable [`token-bridge` v2.7.0 architecture](https://github.com/VenusProtocol/token-bridge/tree/v2.7.0). It uses LayerZero OFT V2 contracts on the LayerZero V1 messaging stack (`uint16` endpoint IDs, named chain IDs in the ABI); it is not the LayerZero V2 OApp API.
+
+The current Venus interface includes these mainnets:
+
 * [Arbitrum](https://arbitrum.io)
 * [Base](https://www.base.org/)
-* [BNB](https://www.bnbchain.org)
+* [BNB Chain](https://www.bnbchain.org)
 * [Ethereum](https://ethereum.org)
 * [opBNB](https://opbnb.bnbchain.org)
 * [Optimism](https://app.optimism.io)
+* [Unichain](https://www.unichain.org/)
 * [ZKsync](https://zksync.io/)
 
 ## Supported Transfer Paths
 
-The bridge supports transfers between all network pairs, providing users with enhanced flexibility and interoperability across blockchain ecosystems.
+The interface can construct transfers between its supported networks, but a path is usable only while both bridge contracts, their trusted remotes, limits, oracle, LayerZero configuration, and destination mint capacity permit it. Recheck the selected path immediately before signing.
 
-The system consists of multiple contracts, including [XVSBridgeAdmin](https://github.com/VenusProtocol/token-bridge/blob/develop/contracts/Bridge/XVSBridgeAdmin.sol), [XVSProxySrc](https://github.com/VenusProtocol/token-bridge/blob/develop/contracts/Bridge/XVSProxyOFTSrc.sol), [XVSProxyDest](https://github.com/VenusProtocol/token-bridge/blob/develop/contracts/Bridge/XVSProxyOFTDest.sol), and [XVS](https://github.com/VenusProtocol/token-bridge/blob/develop/contracts/Bridge/token/XVS.sol) token contracts.
+The system consists of [XVSBridgeAdmin](https://github.com/VenusProtocol/token-bridge/blob/v2.7.0/contracts/Bridge/XVSBridgeAdmin.sol), [XVSProxyOFTSrc](https://github.com/VenusProtocol/token-bridge/blob/v2.7.0/contracts/Bridge/XVSProxyOFTSrc.sol), [XVSProxyOFTDest](https://github.com/VenusProtocol/token-bridge/blob/v2.7.0/contracts/Bridge/XVSProxyOFTDest.sol), and the destination-chain [XVS](https://github.com/VenusProtocol/token-bridge/blob/v2.7.0/contracts/Bridge/token/XVS.sol) token.
 
 **_The functionality of the bridge relies on [LayerZero](https://layerzero.network) for the seamless transfer of XVS tokens across different networks. Consequently, the security and integrity of the token on each network are subject to potential vulnerabilities inherent in the bridging mechanism. It is essential to note that these risks are a general characteristic of integrating with network bridges and do not stem from any particular weaknesses within the token implementation._**
 
@@ -31,13 +35,13 @@ Before transferring XVS tokens, you need to approve the `Bridge` contract on the
 
 ### 1.2. Estimating Transaction Fees
 
-To estimate the transaction fees required to send XVS tokens to the destination chain, call the `estimateSend` function of the `Bridge` contract with the following parameters:
+To estimate the transaction fees required to send XVS tokens to the destination chain, call `estimateSendFee` on the local bridge with the following parameters:
 
-- `_dstChainId`: Destination chain ID, [defined by LayerZero](https://layerzero.gitbook.io/docs/technical-reference/mainnet/supported-chain-ids) (e.g., Ethereum virtual chain ID (101))
+- `_dstChainId`: Destination [LayerZero V1 endpoint ID](https://docs.layerzero.network/v1/deployments/deployed-contracts), not the EVM chain ID (for example, Ethereum V1 endpoint ID `101`)
 - `_toAddress`: Receiver address on the destination chain
 - `_amount`: Amount of XVS tokens you want to send, defined with 18 decimals
 - `_useZro`: `false` (indicating that you are not paying in LayerZero ZRO tokens)
-- `_adapterParams`: `0x000100000000000000000000000000000000000000000000000000000000000493E0` (ethers.utils.solidityPack(['uint16','uint256'],[1, gasValue]) the gas value should be greater then minDestGas which is set to 300k).
+- `_adapterParams`: Versioned LayerZero V1 adapter parameters with destination gas at or above the bridge's current `minDstGasLookup` requirement. Do not copy a historical fixed gas value.
 
 ## 2. Transferring Tokens
 
@@ -47,19 +51,19 @@ The actual token transfer is performed using the `sendFrom` function of the `Bri
 
 <figure><img src="../../.gitbook/assets/XVS_bridge_BNB_to_dest.svg" alt="Assets bridging from src chain to dest chain"><figcaption></figcaption></figure>
 
-1. Call the `sendFrom` function of the `Bridge` contract with the following parameters::
-   - `_from`: Your address on the BNB chain
-   - `_dstChainId`: Destination chain ID [defined by LayerZero](https://layerzero.gitbook.io/docs/technical-reference/mainnet/supported-chain-ids) (e.g., Ethereum virtual chain ID (101))
+1. Call the `sendFrom` function of the local bridge with the following parameters:
+   - `_from`: Your address on the source network
+   - `_dstChainId`: Destination LayerZero V1 endpoint ID (for example, Ethereum `101`)
    - `_toAddress`: The address on the destination chain where you want to receive the XVS tokens
    - `_amount`: Amount of XVS tokens you want to send, defined with 18 decimals
-   - `_callParams`: ["RefundGasAddress", "ZROaddress", "adapterParams"]
+   - `_callParams`: `[refundAddress, zroPaymentAddress, adapterParams]`
      - `RefundGasAddress`: Address where you want to receive a refund for excessive gas sent. It can be the sender's address.
      - `ZROaddress`: `0x0000000000000000000000000000000000000000` (indicating that you are not paying in ZRO tokens)
-     - `adapterParams`: `0x000100000000000000000000000000000000000000000000000000000000000493E0` (ethers.utils.solidityPack(['uint16','uint256'],[1, gasValue]) the gas value should be greater then minDestGas which is set to 300k).
+     - `adapterParams`: The same current LayerZero V1 adapter parameters used for the fee estimate.
 
 ## 3. Receiving Tokens on the Destination Chain
 
-When you send XVS tokens to the destination chain using the bridge, the tokens will be minted by the `Bridge` contract to the receiver's address on the destination chain.
+When BNB-chain XVS leaves BNB Chain it is locked by XVSProxyOFTSrc; XVSProxyOFTDest mints destination-chain XVS to the receiver. For destination-to-destination transfers, the source destination token is burned and the target destination token is minted.
 
 ## 4. Transferring Tokens Back to the BNB chain
 
@@ -82,7 +86,7 @@ After initiating a token transfer, you should wait for the transaction to confir
 - Use the `transferOwnership` method in the `XVSBridgeAdmin` contract to transfer ownership of the admin contract.
 - Use the `transferBridgeOwnership` method to transfer ownership of the `Bridge` contract from one contract to another.
 - Ownership control is crucial in case of emergencies or security issues.
-- The owner of the `XVSBridgeAdmin` contract will be initially the `Guardian`, but it will be transferred to Governance as soon as the `MultichainGovernance` module is deployed.
+- The initial-Guardian rollout statement is obsolete. On August 27, 2026, each mainnet XVSBridgeAdmin was owned by that network's Normal Timelock, and each local bridge was owned by its XVSBridgeAdmin. Verify both `owner()` values before preparing an administrative action.
 
 ### 6.2. Pause and Resume
 
@@ -94,48 +98,31 @@ After initiating a token transfer, you should wait for the transaction to confir
 
 - Example: Limit the maximum XVS transfer to USD 1,000 in one transaction and USD 100,000 in one day. These limits can be adjusted using VIPs.
 
-### 6.4. Transfer Delays
+### 6.4. Message Finality
 
-- Configurable delay after XVS transfers to the target network by specifying a minimum number of blocks in the LayerZero endpoint configuration.
+- The bridge contract does not expose a user-set transfer delay. Delivery time and confirmation requirements come from the selected LayerZero V1 path, both networks, adapter gas, and current messaging-library configuration.
 
 ### 6.5. Token Controller Contract
 
-- [Token Controller](https://github.com/VenusProtocol/token-bridge/blob/develop/contracts/Bridge/token/TokenController.sol) contract within the XVS token deployed on the target network to blacklist addresses, preventing them from transferring or receiving XVS. Integrated with the ACM.
+- The [TokenController](https://github.com/VenusProtocol/token-bridge/blob/v2.7.0/contracts/Bridge/token/TokenController.sol) within destination-chain XVS can blacklist addresses, preventing them from transferring or receiving XVS. Its protected functions use the local AccessControlManager.
 
 ### 6.6. Cap on Token Minting
 
-- Cap on the amount of tokens that can be minted in the destination target network. This feature can be integrated in Token Controller.
+- Destination-chain XVS already enforces `minterToCap` and `minterToMintedAmount` for each authorized bridge minter. This is a live second bound in addition to bridge send/receive limits.
 
 ### 6.7. Mitigation Plans for Mint Cap Reached
 
-- If XVS become stuck between bridges due to exceeding the mint cap, the system will extend the mint cap via VIP. The failed message will be retried.
+- A mint-cap failure creates an operational incident; it does not guarantee that governance will raise the cap. Any cap change and message retry require an independently reviewed authorized action.
 
 ### 6.8. Bridge Model
 
-- The `XVSProxyOFTDest` contract serves as the `Bridge` model. It will be authorized to mint and burn XVS in the destination chain. Limits on these actions will be set by Governance or the Guardian.
-- While the initial deployment involves one `Bridge` contract per network, the system is designed to support several bridges simultaneously, providing users with flexibility.
-- The system's architecture allows for the deployment of multiple bridges within the same network, offering users the option to choose different bridges for their transactions. This flexibility ensures efficient and diverse token bridging capabilities.
-
-   **Example of Bridging in Case of Multiple Active Bridges:**
-
-      1. Initial Setup:
-         - Bridge Contract A (BridgeA) has a minterToMintedAmount of 100 XVS.
-         - User A holds all 100 XVS minted by BridgeA.
-
-      2. Separate Bridge Contract B Setup:
-         - Bridge Contract B (BridgeB) has a separate minterToMintedAmount of 50 XVS.
-         - User B holds all 50 XVS minted by BridgeB.
-
-      3. User B Bridges Off Tokens Using Bridge A:
-         - User B decides to use BridgeA to bridge off his 50 XVS.
-         - After the successful bridging process, BridgeA's minterToMintedAmount is now 50, reflecting the XVS burned by User B through this BridgeA.
-
-      4. User A Bridges Off Tokens Using Both Bridges:
-         - Now, User A intends to bridge off his 100 XVS, splitting them between BridgeA and BridgeB.
-         - User A uses BridgeA for 50 XVS and BridgeB for the remaining 50 XVS.
+- XVSProxyOFTDest is authorized through the destination XVS token's AccessControlManager to mint and burn. Its bridge owner is XVSBridgeAdmin; current administrative caller permissions must be read from the local ACM.
+- The stable mainnet artifacts contain one bridge per network. TokenController supports migrating minter accounting if governance replaces a destination bridge, but that recovery capability is not evidence of multiple simultaneously supported user routes on one network.
 
 ### 6.9. Bridge Replacement Scenario
-In the event that a `Bridge` contract needs replacement, such as due to a security risk, the following steps will be taken:
+
+A bridge replacement is a governance and incident-response procedure, not one atomic contract call. A reviewed plan can include:
+
 1. **Pause the Bridge:**
    - Temporarily pause the `Bridge` contract to prevent further transactions.
 
@@ -143,15 +130,16 @@ In the event that a `Bridge` contract needs replacement, such as due to a securi
    - Evaluate whether pausing the XVS token is necessary during the replacement process.
 
 3. **Migrate MinterToMintedAmount:**
-   - Move the `minterToMintedAmount` value to a different `Bridge` contract address using the `migrateMintedTokens` function.
+   - Move the recorded `minterToMintedAmount` value to a replacement bridge with `migrateMinterTokens`. This updates accounting only; it does not transfer users' ERC-20 balances.
 
-4. **Reduce MintCap:**
-   - Reduce the `mintCap` to zero for the `Bridge` contract address with security issues.
+4. **Reduce the old minter cap:**
+   - Set the affected bridge's `minterToCap` to its remaining accounted minted amount or complete a valid migration before reducing it further; `setMintCap` rejects a cap below `minterToMintedAmount`.
 
-These steps ensure a secure and systematic replacement of a `Bridge` contract, maintaining the integrity of the token. Simultaneously, on the BNB chain, the locked XVS will be transferred and locked in the other `Bridge` contract, ensuring a fix total supply of XVS.
+BNB-side custody must be reconciled separately with the source bridge's `fallbackWithdraw` and `fallbackDeposit` accounting and the exact failed-message state. None of these steps automatically proves global XVS supply conservation; the complete cross-chain supply and in-flight messages must be reconciled before enabling the replacement path.
 
-### 6.10. Default Downtime
-- Currently, the `Bridge` relies on a single relayer, the [default](https://layerzero.gitbook.io/docs/technical-reference/mainnet/default-config) by LayerZero, to generate proofs and submit them to target chains. While this configuration is functional, it's important to be aware of the potential implications. If the relayer goes offline or encounters problems, there's no immediate backup to maintain bridge functionality, potentially delaying or preventing transactions. In the event of unforeseen downtime affecting the default LayerZero relayer, a wallet can be authorized to temporarily generate proofs and submit them on the target network on behalf of the relayer. This authorization is granted only in exceptional circumstances via VIP.
+### 6.10. Messaging Dependency
+
+- Delivery depends on each path's current LayerZero V1 endpoint, messaging library, oracle/relayer configuration, trusted remote, and destination execution gas. The old blanket statement that every route uses one fixed default relayer is not a durable configuration guarantee. Inspect the live endpoint configuration for the exact route when diagnosing downtime.
 
 
 ## 7. Contract Details
@@ -160,20 +148,20 @@ Here, we provide more details about the key contracts used in the XVS Cross-chai
 
 ### 7.1. XVSBridgeAdmin
 
-- [XVSBridgeAdmin](https://github.com/VenusProtocol/token-bridge/blob/develop/contracts/Bridge/XVSBridgeAdmin.sol) is the admin contract for the bridge, ensuring proper setup.
+- [XVSBridgeAdmin](https://github.com/VenusProtocol/token-bridge/blob/v2.7.0/contracts/Bridge/XVSBridgeAdmin.sol) is the admin contract for the bridge, ensuring proper setup.
 - It contains a `functionRegistry` mapping for function signatures, allowing the contract to call corresponding methods in destination contracts after ensuring access control permissions.
 - Ownership transfers for `XVSBridgeAdmin` and `Bridge` can be executed via the `transferOwnership` and `transferBridgeOwnership` methods respectively.
 
 ### 7.2. XVSProxySrc
 
-- [XVSProxySrc](https://github.com/VenusProtocol/token-bridge/blob/develop/contracts/Bridge/XVSProxyOFTSrc.sol) extends the [BaseOFTV2](https://github.com/LayerZero-Labs/solidity-examples/blob/main/contracts/token/oft/v2/BaseOFTV2.sol) contract and includes custom logic for token transfers.
+- [XVSProxyOFTSrc](https://github.com/VenusProtocol/token-bridge/blob/v2.7.0/contracts/Bridge/XVSProxyOFTSrc.sol) extends the LayerZero `BaseOFTV2` contract and includes custom logic for token transfers.
 - It overrides the `_debitFrom` and `_creditTo` functions, checking transaction limits and user eligibility.
 - It enforces transaction limits, tracks 24-hour window limits, and allows whitelisting of users.
 - `XVSProxySrc` can be paused and resumed in emergencies.
 
 ### 7.3. XVSProxyDest
 
-- [XVSProxyDest](https://github.com/VenusProtocol/token-bridge/blob/develop/contracts/Bridge/XVSProxyOFTDest.sol) is similar to `XVSProxySrc` but with specific differences.
+- [XVSProxyOFTDest](https://github.com/VenusProtocol/token-bridge/blob/v2.7.0/contracts/Bridge/XVSProxyOFTDest.sol) shares the base bridge controls but uses burn/mint token accounting.
 - Transaction limits are enforced primarily for outbound amounts only in the source chain.
 - It overrides the `debitFrom` function to include custom logic for checking transaction limits in USD and performs an external call to the XVS token contract to burn tokens from the sender.
 - It overrides the `creditTo` function to trigger an external call to the XVS token contract to mint tokens for the receiver.
@@ -182,13 +170,13 @@ Here, we provide more details about the key contracts used in the XVS Cross-chai
 
 ### 7.4. XVS Token
 
-- The [XVS](https://github.com/VenusProtocol/token-bridge/blob/develop/contracts/Bridge/token/XVS.sol) token contract is deployed on destination chains, and it is used within the `XVSProxyDest` contract.
-- The XVS token follows the ERC20 standard and extends the [TokenController](https://github.com/VenusProtocol/token-bridge/blob/develop/contracts/Bridge/token/TokenController.sol) ownable contract, which contains all controlling mechanisms of the XVS.
+- The [XVS](https://github.com/VenusProtocol/token-bridge/blob/v2.7.0/contracts/Bridge/token/XVS.sol) token contract is deployed on destination chains and is used by XVSProxyOFTDest.
+- The XVS token follows the ERC-20 standard and extends the [TokenController](https://github.com/VenusProtocol/token-bridge/blob/v2.7.0/contracts/Bridge/token/TokenController.sol) ownable contract.
 - It is responsible for setting minting limits for the minter (in this case, the remote `Bridge` contract).
 - When receiving transactions and tokens from the source chain's `Bridge` contract, an external call is made to mint tokens for the receiver.
 - When sending tokens to the source chain's `Bridge` contract, an external call is made from the `Bridge` contract to burn tokens from the sender.
 - Offers a blacklisting feature to prevent certain users from receiving, transferring and bridging XVS tokens.
-- [ACM](https://github.com/VenusProtocol/governance-contracts/blob/develop/contracts/Governance/AccessControlManager.sol) integration is used for setting minting caps and blacklisting, and these settings can be configured via VIPs or Guardian.
+- [AccessControlManager v2.15.0](https://github.com/VenusProtocol/governance-contracts/blob/v2.15.0/contracts/Governance/AccessControlManager.sol) integration is used for mint caps, blacklisting, pause controls, and bridge administration. The authorized caller must be checked from current permissions; it is not implied by the labels “VIP” or “Guardian.”
 
 ## 8. Additional Features
 
@@ -204,39 +192,8 @@ In addition to the core functionality, the XVS Cross-chain Bridge includes addit
 
 ### 8.3. Transaction Limits
 
-- The contract introduces transaction limits for both sending and receiving transactions, based on a daily and single transaction basis. The limits are defined using `chainIdToMaxSingleTransactionLimit`, `chainIdToMaxDailyLimit`, `chainIdToMaxSingleReceiveTransactionLimit`, and `chainIdToMaxDailyReceiveLimit`.
-
-- Single Send Limit (source network in the first column, destination network in the first row)
-
-   |          |   BNB     |   opBNB   |   Arbitrum   |   Ethereum   |   ZKsync  | Optimism  |    Base   |
-   |----------|-----------|-----------|--------------|--------------|-----------|-----------|-----------|
-   | BNB      |     -     | $10,000   | $20,000      | $100,000     | $20,000   | $20,000   | $20,000   |
-   | opBNB    | $10,000   |    -      | $20,000      | $10,000      | $20,000   | $20,000   | $20,000   |
-   | Arbitrum | $20,000   | $20,000   |     -        | $20,000      | $20,000   | $20,000   | $20,000   |
-   | Ethereum | $100,000  | $10,000   | $20,000      |      -       | $20,000   | $20,000   | $20,000   |  
-   | ZKsync   | $20,000   | $20,000   | $20,000      | $20,000      |     -     | $20,000   | $20,000   |
-   | Optimism | $20,000   | $20,000   | $20,000      | $20,000      | $20,000   |    -      | $20,000   |
-   | Base     | $20,000   | $20,000   | $20,000      | $20,000      | $20,000   | $20,000   |    -      |
-
-   
-- Daily Send Limit (source network in the first column, destination network in the first row)
-
-   |          |    BNB     |   opBNB   |   Arbitrum   |   Ethereum   |   ZKsync  | Optimism  |    Base   |
-   |----------|------------|-----------|--------------|--------------|-----------|-----------|-----------|
-   | BNB      |     -      | $50,000   | $100,000     | $1,000,000   | $100,000  | $100,000  | $100,000  |
-   | opBNB    | $50,000    |    -      | $100,000     | $50,000      | $100,000  | $100,000  | $100,000  |
-   | Arbitrum | $100,000   | $100,000  |     -        | $100,000     | $100,000  | $100,000  | $100,000  |
-   | Ethereum | $1,000,000 | $50,000   | $100,000     |      -       | $100,000  | $100,000  | $100,000  |
-   | ZKsync   | $100,000   | $100,000  | $100,000     | $100,000     |     -     | $100,000  | $100,000  |
-   | Optimism | $100,000   | $100,000  | $100,000     | $100,000     | $100,000  |     -     | $100,000  |
-   | Base     | $100,000   | $100,000  | $100,000     | $100,000     | $100,000  | $100,000  |     -     |
-
-
-- Single Receive Limit = Single Send Limit + 2%
-
-- Daily Receive Limit = Daily Send Limit + 2%
-
-**Note**: The additional 2% provides a margin to account for potential price fluctuations during the processing of bridging transactions.
+- The bridge enforces mutable single-send, daily-send, single-receive, and daily-receive USD limits per LayerZero path. Read `chainIdToMaxSingleTransactionLimit`, `chainIdToMaxDailyLimit`, `chainIdToMaxSingleReceiveTransactionLimit`, and `chainIdToMaxDailyReceiveLimit` on the source contract selected by the interface.
+- The historical static matrices have been removed: they omitted Unichain and could become unsafe after a governance update. Also read the current rolling-window counters and the destination XVS mint capacity before signing.
 
 ### 8.4. Pause and Unpause Mechanism
 
@@ -261,13 +218,13 @@ In addition to the core functionality, the XVS Cross-chain Bridge includes addit
 
 ### Retry Mechanism for Failed Transactions
 
-In the event of a failed transaction, follow the below step-by-step process using block explorers and the [`retryMessage`](https://github.com/VenusProtocol/token-bridge/blob/main/contracts/Bridge/BaseXVSProxyOFT.sol#L368) function to retry transactions on the respective blockchain. Here's a detailed guide:
+In the event of a failed transaction, inspect the destination event and the stable [`retryMessage` implementation](https://github.com/VenusProtocol/token-bridge/blob/v2.7.0/contracts/Bridge/BaseXVSProxyOFT.sol). Retrying is a state-changing action: confirm that the stored payload hash still exists, the trusted path is unchanged, and the underlying failure has been resolved.
 
 1. **Identify the Failed Transaction:**
    - Use [LayerZero scan](https://layerzeroscan.com) to identify the failed transaction within the target network by providing the transaction hash from the source network where the transaction was initiated.
 
 2. **Examine the MessageFailed Log:**
-   - Access the emitted events of the failed transaction and specifically examine the [`MessageFailed`](https://github.com/LayerZero-Labs/solidity-examples/blob/main/contracts/lzApp/NonblockingLzApp.sol#L20) log. This log contains essential function parameters needed for the retry.
+   - Examine the emitted `MessageFailed` event. Its source chain ID, source path, nonce, payload, and reason identify the stored message and retry parameters.
 
 3. **Extract Function Parameters:**
    - From the `MessageFailed` log, extract the following essential function parameters:

--- a/technical-reference/reference-xvs-bridge/BaseXVSProxyOFT.md
+++ b/technical-reference/reference-xvs-bridge/BaseXVSProxyOFT.md
@@ -1,9 +1,13 @@
 # BaseXVSProxyOFT
+
+[`BaseXVSProxyOFT` at token-bridge v2.7.0](https://github.com/VenusProtocol/token-bridge/blob/v2.7.0/contracts/Bridge/BaseXVSProxyOFT.sol) is the shared abstract LayerZero OFT V2 base. It is not an upgradeable proxy or a standalone deployment. The concrete source and destination contracts fix the token, shared decimals, LayerZero V1 endpoint, and ResilientOracle in their constructors.
+
+In addition to the Venus-specific functions below, the concrete ABI inherits OFT/LzApp functions such as `sendFrom`, `estimateSendFee`, `retryMessage`, trusted-remote and messaging-library configuration, ownership, and packet state. Those inherited functions use LayerZero V1 `uint16` endpoint IDs, named chain IDs in the ABI. Administrative calls should normally be routed through XVSBridgeAdmin and checked against its function registry and AccessControlManager permissions.
 The `BaseXVSProxyOFT` contract is tailored for facilitating cross-chain transactions with an ERC20 token.
 It manages transaction limits of a single and daily transactions.
 This contract inherits key functionalities from other contracts, including pausing capabilities and error handling.
 It holds state variables for the inner token and maps for tracking transaction limits and statistics across various chains and addresses.
-The contract allows the owner to configure limits, set whitelists, and control pausing.
+The contract owner can configure bridge state directly at the Solidity level, but production ownership is assigned to XVSBridgeAdmin, which applies its own registry and AccessControlManager checks.
 Internal functions conduct eligibility check of transactions, making the contract a fundamental component for cross-chain token management.
 
 # Solidity API
@@ -376,6 +380,16 @@ function sendAndCall(address from_, uint16 dstChainId_, bytes32 toAddress_, uint
 
 - - -
 
+### retryMessage
+
+Retries a stored failed LayerZero V1 message after requiring the supplied source path to equal the contract's current nonempty trusted remote. Anyone can submit the retry transaction, but the payload must match the stored failed-message hash.
+
+```solidity
+function retryMessage(uint16 srcChainId_, bytes srcAddress_, uint64 nonce_, bytes payload_) public payable
+```
+
+- - -
+
 ### renounceOwnership
 
 Empty implementation of renounce ownership to avoid any mishappening.
@@ -397,7 +411,6 @@ function token() public view returns (address)
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | address | Address of the inner token of this bridge. |
+| \[0] | address | Address of the inner token of this bridge. |
 
 - - -
-

--- a/technical-reference/reference-xvs-bridge/README.md
+++ b/technical-reference/reference-xvs-bridge/README.md
@@ -1,1 +1,16 @@
-# XVS Bridge
+# XVS Bridge contract families
+
+The XVS bridge remains an active LayerZero OFT V2 deployment. This section is pinned to the stable [`token-bridge` v2.7.0 tag](https://github.com/VenusProtocol/token-bridge/tree/v2.7.0), rather than the moving `develop` branch.
+
+The contract names use `ProxyOFT` in the LayerZero token-model sense. `XVSProxyOFTSrc` and `XVSProxyOFTDest` are not EIP-1967 upgradeable proxies in the tagged mainnet artifacts. `XVSBridgeAdmin` is the transparent proxy.
+
+| Network role | Contracts | Token behavior |
+| --- | --- | --- |
+| BNB Chain source | Native XVS, `XVSProxyOFTSrc`, `XVSBridgeAdmin` | XVS is locked on outbound transfers and released on inbound transfers |
+| Ethereum, Arbitrum, opBNB, Optimism, Base, zkSync Era, and Unichain destinations | Omnichain `XVS`, `XVSProxyOFTDest`, `XVSBridgeAdmin` | XVS is burned on outbound transfers and minted on inbound transfers, subject to the TokenController mint cap |
+
+`BaseXVSProxyOFT` is abstract and is not a deployment address. `TokenController` is inherited by the destination-chain XVS token. The bridge uses LayerZero V1 `uint16` endpoint IDs (named chain IDs in the ABI) and OFT V2 APIs; these must not be replaced with EVM chain IDs, LayerZero V2 EIDs, or OApp selectors.
+
+LayerZero marks V1 deprecated for new integrations in its [V1 deployment reference](https://docs.layerzero.network/v1/deployments/deployed-contracts). The existing Venus bridge is nevertheless active. “Deprecated upstream transport” and “retired Venus product” are different lifecycle claims.
+
+A deployment on two networks does not by itself prove that their trusted-remote path is enabled. For user transactions, use the networks exposed by the current Venus interface and verify the selected route, limits, mint capacity, and native-gas fee immediately before signing. See the [XVS omnichain registry](../../deployed-contracts/xvs-omnichain.md) for addresses.

--- a/technical-reference/reference-xvs-bridge/TokenController.md
+++ b/technical-reference/reference-xvs-bridge/TokenController.md
@@ -1,4 +1,6 @@
 # TokenController
+[`TokenController` at token-bridge v2.7.0](https://github.com/VenusProtocol/token-bridge/blob/v2.7.0/contracts/Bridge/token/TokenController.sol) is inherited by the destination-chain XVS token; it is not deployed separately. Its mint accounting is per authorized minter. `minterToMintedAmount` increases when that minter mints and decreases when it burns.
+
 TokenController contract acts as a governance and access control mechanism,
 allowing the owner to manage minting restrictions and blacklist certain addresses to maintain control and security within the token ecosystem.
 It provides a flexible framework for token-related operations.
@@ -129,6 +131,27 @@ function setAccessControlManager(address newAccessControlAddress_) external
 
 - - -
 
+### migrateMinterTokens
+
+Moves the full recorded minted amount from one minter's accounting bucket to another. The destination minter must already have enough cap, the addresses must differ, and the operation does not move ERC-20 balances.
+
+```solidity
+function migrateMinterTokens(address source_, address destination_) external
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| source\_ | address | Minter whose recorded minted amount is cleared |
+| destination\_ | address | Minter that receives the recorded minted amount |
+
+#### Access requirements
+
+* Controlled by AccessControlManager using `migrateMinterTokens(address,address)`.
+
+- - -
+
 ### isBlackListed
 
 Returns the blacklist status of the address.
@@ -145,7 +168,6 @@ function isBlackListed(address user_) external view returns (bool)
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | bool | bool status of blacklist. |
+| \[0] | bool | bool status of blacklist. |
 
 - - -
-

--- a/technical-reference/reference-xvs-bridge/XVS.md
+++ b/technical-reference/reference-xvs-bridge/XVS.md
@@ -1,6 +1,10 @@
 # XVS
+[`XVS` at token-bridge v2.7.0](https://github.com/VenusProtocol/token-bridge/blob/v2.7.0/contracts/Bridge/token/XVS.sol) is the destination-chain XVS implementation. BNB Chain uses the native XVS contract instead. The destination token inherits the standard ERC-20 ABI and the complete [TokenController](TokenController.md) surface in addition to the `mint` and `burn` functions below.
+
+Both `mint` and `burn` check the exact AccessControlManager signature. Production bridge permissions and `minterToCap` must be configured for the local XVSProxyOFTDest; deployment alone does not authorize it.
+
 XVS contract serves as a customized ERC-20 token with additional minting and burning functionality.
- It also incorporates access control features provided by the "TokenController" contract to ensure proper governance and restrictions on minting and burning operations.
+It also incorporates access control features provided by the `TokenController` contract to ensure proper governance and restrictions on minting and burning operations.
 
 # Solidity API
 
@@ -52,4 +56,3 @@ function burn(address account_, uint256 amount_) external
 * Controlled by AccessControlManager.
 
 - - -
-

--- a/technical-reference/reference-xvs-bridge/XVSBridgeAdmin.md
+++ b/technical-reference/reference-xvs-bridge/XVSBridgeAdmin.md
@@ -1,9 +1,45 @@
 # XVSBridgeAdmin
+
+[`XVSBridgeAdmin` at token-bridge v2.7.0](https://github.com/VenusProtocol/token-bridge/blob/v2.7.0/contracts/Bridge/XVSBridgeAdmin.sol) is the transparent proxy that owns and administers the local source or destination bridge. Its implementation constructor fixes an immutable `XVSBridge`, so each network has a different implementation address even though all eight implementations match the same tagged source.
+
+| Network | Read block | Proxy | Implementation |
+| --- | ---: | --- | --- |
+| BNB Chain | `118369693` | `0x70d644877b7b73800E9073BCFCE981eAaB6Dbc21` | `0xb085926fa310b4af85B499162B96e30E5c0E6fAC` |
+| Ethereum | `25846037` | `0x9C6C95632A8FB3A74f2fB4B7FfC50B003c992b96` | `0x83aBB808bb291FED8593e953c6489d29aFa0c5Ca` |
+| Arbitrum | `498892235` | `0xf5d81C6F7DAA3F97A6265C8441f92eFda22Ad784` | `0xC57f35500f4F5B2B31c5250bF8BCcf8058835a9B` |
+| opBNB | `178841988` | `0x52fcE05aDbf6103d71ed2BA8Be7A317282731831` | `0x0f0be7BAf4B9E394F91e5B8a17Fc9579f5d3c072` |
+| Optimism | `156114325` | `0x3c307DF1Bf3198a2417d9CA86806B307D147Ddf7` | `0xc8A17E5394aeB0A0E227E0f27F922dc60300e80B` |
+| Base | `50519042` | `0x6303FEcee7161bF959d65df4Afb9e1ba5701f78e` | `0x358691eB7CC06ac512d9068a71Ea3bc2893F50Ed` |
+| Unichain | `57079073` | `0x2EAaa880f97C9B63d37b39b0b316022d93d43604` | `0xc6d8bBC659d0B3Beaca513a20218b1727Ef3DCE4` |
+| zkSync Era | `71738687` | `0x2471043F05Cc41A6051dd6714DC967C7BfC8F902` | `0x21f8b24f48a3af53B9B597DbA1D7737e4D7aBa3B` |
+
+The implementation inherits two-step ownership and AccessControlManager selectors. The transparent proxy adds proxy-admin upgrade selectors; those do not imply that a normal caller can upgrade it.
+
 The XVSBridgeAdmin contract extends a parent contract AccessControlledV8 for access control, and it manages an external contract called XVSProxyOFT.
 It maintains a registry of function signatures and names,
 allowing for dynamic function handling i.e checking of access control of interaction with only owner functions.
 
 # Solidity API
+
+### XVSBridge
+
+Returns the immutable bridge controlled by this implementation.
+
+```solidity
+function XVSBridge() external view returns (contract IXVSProxyOFT)
+```
+
+---
+
+### initialize
+
+Initializes proxy ownership and the AccessControlManager. The implementation disables initializers in its constructor.
+
+```solidity
+function initialize(address accessControlManager_) external
+```
+
+---
 
 ### functionRegistry
 
@@ -13,7 +49,7 @@ A mapping keeps track of function signature associated with function name string
 mapping(bytes4 => string) functionRegistry
 ```
 
-- - -
+---
 
 ### fallback
 
@@ -26,12 +62,12 @@ fallback(bytes data) external returns (bytes)
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | bytes | Response of low level call. |
+| \[0] | bytes | Response of low level call. |
 
 #### ⛔️ Access Requirements
 * Controlled by AccessControlManager.
 
-- - -
+---
 
 ### setTrustedRemoteAddress
 
@@ -53,7 +89,7 @@ function setTrustedRemoteAddress(uint16 remoteChainId_, bytes remoteAddress_) ex
 #### ❌ Errors
 * ZeroAddressNotAllowed is thrown when remoteAddress_ contract address is zero.
 
-- - -
+---
 
 ### upsertSignature
 
@@ -75,7 +111,7 @@ function upsertSignature(string[] signatures_, bool[] active_) external
 #### ⛔️ Access Requirements
 * Only owner.
 
-- - -
+---
 
 ### transferBridgeOwnership
 
@@ -93,7 +129,7 @@ function transferBridgeOwnership(address newOwner_) external
 #### ⛔️ Access Requirements
 * Controlled by AccessControlManager.
 
-- - -
+---
 
 ### isTrustedRemote
 
@@ -112,12 +148,12 @@ function isTrustedRemote(uint16 remoteChainId_, bytes remoteAddress_) external r
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | bool | Bool indicating whether the remote chain is trusted or not. |
+| \[0] | bool | Bool indicating whether the remote chain is trusted or not. |
 
 #### ❌ Errors
 * ZeroAddressNotAllowed is thrown when remoteAddress_ contract address is zero.
 
-- - -
+---
 
 ### renounceOwnership
 
@@ -127,5 +163,4 @@ Empty implementation of renounce ownership to avoid any mishappening.
 function renounceOwnership() public
 ```
 
-- - -
-
+---

--- a/technical-reference/reference-xvs-bridge/XVSProxyOFTDest.md
+++ b/technical-reference/reference-xvs-bridge/XVSProxyOFTDest.md
@@ -1,4 +1,6 @@
 # XVSProxyOFTDest
+[`XVSProxyOFTDest` at token-bridge v2.7.0](https://github.com/VenusProtocol/token-bridge/blob/v2.7.0/contracts/Bridge/XVSProxyOFTDest.sol) is the non-upgradeable bridge used on destination networks. It burns the destination-chain XVS token on outbound transfers and mints it on inbound transfers. Minting is additionally bounded by the token's per-minter cap; this contract does not use the BNB source bridge's locked-supply accounting.
+
 XVSProxyOFTDest contract builds upon the functionality of its parent contract, BaseXVSProxyOFT,
 and focuses on managing token transfers to the destination chain.
 It provides functions to check eligibility and perform the actual token transfers while maintaining strict access controls and pausing mechanisms.
@@ -39,7 +41,6 @@ function circulatingSupply() public view returns (uint256)
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | uint256 | total circulating supply of the token on the destination chain. |
+| \[0] | uint256 | total circulating supply of the token on the destination chain. |
 
 - - -
-

--- a/technical-reference/reference-xvs-bridge/XVSProxyOFTSrc.md
+++ b/technical-reference/reference-xvs-bridge/XVSProxyOFTSrc.md
@@ -1,4 +1,6 @@
 # XVSProxyOFTSrc
+[`XVSProxyOFTSrc` at token-bridge v2.7.0](https://github.com/VenusProtocol/token-bridge/blob/v2.7.0/contracts/Bridge/XVSProxyOFTSrc.sol) is the non-upgradeable BNB Chain source bridge. It locks native BNB-chain XVS on outbound transfers and releases that same token on inbound transfers. `outboundAmount` tracks the locked supply attributed to remote chains.
+
 XVSProxyOFTSrc contract serves as a crucial component for cross-chain token transactions,
 focusing on the source side of these transactions.
 It monitors the total amount transferred to other chains, ensuring it complies with defined limits,
@@ -39,6 +41,27 @@ function fallbackWithdraw(address to_, uint256 amount_) external
 
 - - -
 
+### fallbackDeposit
+
+Reconciles an owner-approved amount into bridge custody, increases `outboundAmount`, and transfers the dust-adjusted XVS amount from the depositor. This is an operational recovery function, not a user bridge entry point.
+
+```solidity
+function fallbackDeposit(address depositor_, uint256 amount_) external
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| depositor\_ | address | Address supplying XVS to bridge custody |
+| amount\_ | uint256 | Requested amount before shared-decimal dust removal |
+
+#### Access requirements
+
+* Only the bridge owner.
+
+- - -
+
 ### dropFailedMessage
 
 Clear failed messages from the storage.
@@ -73,7 +96,6 @@ function circulatingSupply() public view returns (uint256)
 #### Return Values
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [0] | uint256 | Returns difference in total supply and the outbound amount. |
+| \[0] | uint256 | Returns difference in total supply and the outbound amount. |
 
 - - -
-


### PR DESCRIPTION
## Summary

- separate the active Solidity 0.5 Governor/BNB timelock family, Solidity 0.8 destination governance, and staged Risk Steward V2 surface
- correct the live Governor implementation ABI: add `ValidationParams`, `setValidationParams`, and `setProposalConfigs`, and label the V1 scalar route slots deprecated
- pin Governance and XVS Bridge references to stable `governance-contracts@v2.15.0` and `token-bridge@v2.7.0` sources
- distinguish active Venus deployments from LayerZero V1 being deprecated for new integrations, and distinguish V1 `uint16` endpoint IDs from V2 OApp EIDs
- map all eight live XVSBridgeAdmin proxy implementations and current Normal-Timelock/bridge ownership shape
- add omitted `fallbackDeposit`, `migrateMinterTokens`, receiver ownership, and bridge retry APIs
- replace the obsolete bridge limits matrices and Ethereum-only screenshot guide with live-verification guidance for the eight interface-supported mainnets

The 30-file batch is independent from #402: it changes no product-governance or tokenomics files and is based directly on the fixed documentation baseline.

## Evidence

- BNB Governor implementation and five Risk Steward proxy implementations read onchain on August 27, 2026
- XVSBridgeAdmin implementation, admin owner, configured bridge, and bridge owner read across BNB Chain, Ethereum, Arbitrum, opBNB, Optimism, Base, Unichain, and zkSync Era
- deployment families and ABIs checked against the two stable tagged artifact sets

## Validation

- Remark: all 30 changed Markdown files pass with no warnings
- relative-link check: all 30 changed Markdown files pass
- 28 pinned Venus source links return HTTP 200; the replacement official LayerZero V1 reference also returns HTTP 200
- all direct public/external functions across 24 contract reference pages are covered
- `git diff --check` and fixed-baseline checks pass