### PR TITLE
docs: correct periphery version and trust boundaries

### DIFF
--- a/technical-reference/reference-periphery/README.md
+++ b/technical-reference/reference-periphery/README.md
@@ -1,23 +1,29 @@
 # Periphery Contracts
 
-Venus Protocol periphery contracts extend core protocol functionality with auxiliary features for advanced DeFi operations. These contracts integrate with the Venus Comptroller and vToken markets to provide atomic, gas-efficient operations.
+Venus Protocol periphery contracts extend the lending markets with product workflows, swap execution, price-deviation monitoring, and emergency controls. They are separate contracts with their own upgrade, ownership, signer, or Access Control Manager (ACM) trust boundaries.
+
+> **Version scope:** These references follow the stable [`venus-periphery` v1.2.0 release](https://github.com/VenusProtocol/venus-periphery/tree/v1.2.0). Most deployed components are upgradeable proxies, while `SwapHelper` and PositionAccount implementations use different deployment patterns. Use the [deployed-contract registry](../../deployed-contracts/periphery.md) to find an address, then verify its current implementation and configuration on the relevant explorer before integrating or granting approvals.
 
 ## Overview
 
-The Venus periphery consists of specialized smart contracts designed to streamline complex DeFi operations:
+The public references cover the following systems:
 
-- **[RelativePositionManager](relative-position-manager.md)** - Orchestrate the full lifecycle of Venus Trade positions, from activation and opening to proportional closing and deactivation
-- **[LeverageStrategiesManager](leverage-strategies-manager.md)** - Enter and exit leveraged positions atomically using flash loans
-- **[SwapHelper](swap-helper.md)** - Execute backend-authorized token swaps with signature verification
+- **[RelativePositionManager](relative-position-manager.md)** — orchestrates Venus Trade positions and deterministic PositionAccount clones on BNB Chain.
+- **[LeverageStrategiesManager](leverage-strategies-manager.md)** — enters and exits leveraged positions using Core Pool flash loans on BNB Chain.
+- **[SwapHelper](swap-helper.md)** — executes backend-signed batches of approvals, arbitrary calls, and token sweeps for BNB trading flows.
+- **[SwapRouter](swap-router.md)** — swaps an input token and supplies or repays through BNB Core Pool markets.
+- **[DeviationSentinel](deviation-sentinel.md)** — compares configured oracle and DEX prices and routes qualifying incidents to EBrake on the networks listed in the registry.
+- **[EBrake](ebrake.md)** — exposes selected tighten-only Comptroller actions to explicitly authorized incident-response callers.
 
 ## Key Features
 
-- Flash loan-based atomic execution
-- EIP-712 signature verification for authorized operations
-- EIP-1153 transient storage for efficient callback state management
-- Comprehensive account safety validation
-- Slippage protection on all swap operations
+- Flash-loan-based atomic leverage execution
+- EIP-712 authorization for SwapHelper call batches
+- EIP-1153 transient callback state in LeverageStrategiesManager
+- Post-operation account-liquidity validation
+- Caller-selected output floors for quoted swap paths; full-repayment SwapRouter paths instead bound token input with `maxAmountIn` or `msg.value`
+- On-chain deviation checks and restricted emergency parameter tightening
 
 ## Deployment
 
-Periphery contracts are currently deployed on BNB Chain Mainnet. See [Deployed Contracts](../../deployed-contracts/periphery.md) for addresses and deployment information.
+The trading contracts are deployed on BNB Chain. DeviationSentinel and EBrake also have deployments on selected additional networks. See [Deployed Contracts](../../deployed-contracts/periphery.md) for the current published network and address list; a contract's presence in source does not establish that it is deployed on every Venus network.

--- a/technical-reference/reference-periphery/deviation-sentinel.md
+++ b/technical-reference/reference-periphery/deviation-sentinel.md
@@ -2,11 +2,13 @@
 
 The DeviationSentinel is a Venus periphery contract that monitors price deviations between the ResilientOracle and a DEX-based SentinelOracle. When deviations exceed configured thresholds, it routes emergency actions through the [EBrake](ebrake.md) contract to pause market actions and zero collateral factors, protecting the protocol from price manipulation or oracle failures.
 
+> **Version scope:** This API reference follows [`venus-periphery` v1.2.0](https://github.com/VenusProtocol/venus-periphery/tree/v1.2.0/contracts/DeviationSentinel). DeviationSentinel, EBrake, SentinelOracle, and the DEX oracle contracts are upgradeable. Resolve the current proxy implementation, configured backend, pools, direct-price overrides, keepers, token thresholds, and ACM grants before treating this page as live configuration.
+
 ## Overview
 
 Price oracle reliability is critical for lending protocols. A compromised or malfunctioning oracle can lead to undercollateralized borrows or improper liquidations. The DeviationSentinel mitigates this risk by continuously comparing prices from two independent sources and taking protective action when they diverge beyond acceptable limits.
 
-The system consists of seven contracts:
+The system consists of seven contract types:
 
 | Contract                    | Description                                                                     |
 | --------------------------- | ------------------------------------------------------------------------------- |
@@ -40,7 +42,7 @@ The deviation response logic is designed to counter specific attack vectors that
 
 **Action:** Set collateral factor to 0 and pause supply for the affected asset.
 
-Pauses trigger only for large price deviations (e.g., 15%-50%), not for minor discrepancies (1%-10%), to avoid unnecessary interruptions from normal pool volatility. Small deviations are not economically viable for attackers.
+Thresholds are configured per token to balance incident sensitivity against normal pool volatility. Whether a particular deviation is economically exploitable depends on the configured threshold, available liquidity, pool depth, execution costs, and the rest of the transaction path; the contract does not prove that a smaller deviation is harmless.
 
 ### Deviation Response Logic
 
@@ -55,15 +57,15 @@ DeviationSentinel can only tighten restrictions. Recovery (unpausing, restoring 
 
 ### Off-Chain Monitoring
 
-An off-chain monitoring service continuously compares the ResilientOracle price with the on-chain price reported by the SentinelOracle for each monitored token (sourced from the configured DEX backend — Uniswap V3, PancakeSwap V3, Curve StableSwap-NG, or Aerodrome Slipstream). When the deviation exceeds a configured threshold, the monitor calls `handleDeviation` via a trusted keeper address, which routes the emergency action through EBrake to pause the affected market.
+An off-chain monitoring service continuously compares the ResilientOracle price with the on-chain price reported by the SentinelOracle for each monitored token (sourced from its configured DEX backend). When the deviation exceeds a configured threshold, the monitor calls `handleDeviation` via a trusted keeper address, which routes the emergency action through EBrake to pause the affected market.
 
-`handleDeviation` re-runs the deviation check against live on-chain prices before acting, so a compromised or faulty off-chain monitor cannot trigger a pause that the on-chain prices don't justify. Once the incident is resolved, a governance VIP restores all parameters on the Comptroller and calls the EBrake snapshot reset functions to prepare for future incidents.
+`handleDeviation` re-runs the configured check against current on-chain inputs before acting. This prevents a keeper from substituting an arbitrary off-chain price, but it does not make the result independent of the selected DEX pool, spot-price manipulation, token configuration, or a governance-set direct-price override. Once the incident is resolved, a governance VIP restores all parameters on the Comptroller and calls the EBrake snapshot reset functions to prepare for future incidents.
 
 ## Architecture
 
 <figure><img src="../../.gitbook/assets/emergency_brake.png" alt="DeviationSentinel Architecture"><figcaption></figcaption></figure>
 
-Any of the four DEX-oracle backends (`UniswapOracle`, `PancakeSwapOracle`, `CurveOracle`, `AerodromeSlipstreamOracle`) can sit behind `SentinelOracle` per token, with the right backend chosen at deploy time per chain.
+One of four DEX-oracle backends (`UniswapOracle`, `PancakeSwapOracle`, `CurveOracle`, or `AerodromeSlipstreamOracle`) can sit behind `SentinelOracle` for a token. The live choice is mutable configuration and can differ by token and network.
 
 ## Inheritance
 
@@ -789,13 +791,13 @@ Pause and collateral factor events are now emitted by EBrake (`ActionPaused`, `C
 
 - **Governance Functions**: All configuration functions (`setTokenConfig`, `setTrustedKeeper`, `setTokenMonitoringEnabled`) are restricted via `AccessControlManager`
 - **Keeper Functions**: `handleDeviation` is restricted to trusted keepers via the `onlyKeeper` modifier
-- **Direct Price Overrides**: The `setDirectPrice` function on `SentinelOracle` is governance-controlled to prevent price manipulation
+- **Direct Price Overrides**: `setDirectPrice` on `SentinelOracle` is governance-controlled. A nonzero override replaces the configured DEX-backend value, so its live value is part of the system's trust and configuration surface.
 
 ### Separation of Detection and Execution
 
 DeviationSentinel contains only detection logic. All Comptroller interactions (pausing, CF changes) are executed by EBrake. This means:
 
-- A compromised keeper can only trigger EBrake actions, not call the Comptroller directly
+- A keeper cannot supply an arbitrary off-chain price; it can trigger only the EBrake action produced by the configured on-chain comparison. Those on-chain inputs and configurations must still be trusted and monitored.
 - EBrake enforces its own "tighten only" invariant independently — the sentinel cannot unpause or restore CF even if its logic were modified
 - Pre-incident state snapshots (original CF, borrow caps, supply caps) are tracked by EBrake, not DeviationSentinel
 
@@ -824,4 +826,4 @@ See [Deployed Contracts](../../deployed-contracts/periphery.md) for current addr
 
 ## Audits
 
-DeviationSentinel undergoes security audits before mainnet deployment. Audit reports are available in the [venus-periphery repository](https://github.com/VenusProtocol/venus-periphery/tree/main/audits).
+Published DeviationSentinel and EBrake audit reports are indexed in the [`venus-periphery` v1.2.0 release](https://github.com/VenusProtocol/venus-periphery/tree/v1.2.0/audits). Check each report's scope and reviewed commit against every current proxy implementation and configured oracle backend.

--- a/technical-reference/reference-periphery/ebrake.md
+++ b/technical-reference/reference-periphery/ebrake.md
@@ -2,9 +2,11 @@
 
 EBrake (Emergency Brake) is a Venus periphery contract that acts as an emergency action router for the protocol. It exposes a curated set of Comptroller emergency functions behind Access Control Manager (ACM) permissions, allowing the multisig, automated monitoring contracts, and trusted third-party services to rapidly tighten protocol parameters during an incident — without waiting for a governance VIP.
 
+> **Version scope:** This API reference follows [`venus-periphery` v1.2.0](https://github.com/VenusProtocol/venus-periphery/tree/v1.2.0/contracts/EmergencyBrake). EBrake is deployed behind upgradeable proxies. Its effective behavior depends on the current implementation, immutable Comptroller/type pair, ACM grants, and the Comptroller version on each network; verify those values from the [deployment registry](../../deployed-contracts/periphery.md) and explorer before incident use.
+
 ## Overview
 
-During a security incident, every block of delay increases potential losses. EBrake provides a fast-path for protective actions that are safe to take without governance: pausing market actions, reducing collateral factors, and lowering supply/borrow caps. It enforces a strict **"tighten only, never loosen"** invariant — the worst outcome from a compromised EBrake caller is a temporary freeze, never fund loss.
+During a security incident, every block of delay can increase potential losses. EBrake provides a fast path for selected protective actions without waiting for a governance proposal: pausing market actions, reducing collateral factors, and lowering supply/borrow caps. The contract restricts these mutators to tightening configured parameters, but a mistaken or compromised caller can still block user actions, reduce borrowing capacity, or prolong an incident. The contract does not guarantee that downstream economic loss is impossible.
 
 Recovery from any EBrake action always goes through a governance VIP, which also calls the snapshot reset functions to prepare EBrake for future incidents.
 
@@ -33,14 +35,14 @@ EBrake can only tighten restrictions, never loosen them. This means it intention
 - **Target individual users** — prevents griefing specific addresses
 - **Change the oracle or liquidation incentive** — would cause mass mispricing or alter liquidation economics for all users
 
-**Worst-case if EBrake is compromised:**
+**Actions available to a compromised authorized caller include:**
 
-- Pauses minting, borrowing, redeeming, or transfers (inconvenient, no fund loss)
-- Zeros supply/borrow caps (blocks new positions; existing positions are unaffected)
-- Decreases collateral factor (blocks new borrows against an asset; does **not** liquidate existing positions since LT is unchanged)
-- Pauses flash loans (blocks flash loan attack vector, no user impact)
+- Pausing minting, borrowing, redeeming, or transfers, which can delay entry and exit operations
+- Zeroing supply/borrow caps, which blocks additional exposure and can affect later account actions
+- Decreasing collateral factor, which does not directly change liquidation eligibility while liquidation threshold is preserved, but can restrict later borrows or redemptions
+- Pausing flash loans, which can block integrations that depend on that facility
 
-Recovery is a governance VIP that restores all parameters — a temporary freeze, not a catastrophic loss.
+Recovery requires a governance VIP that restores the affected parameters and clears the corresponding snapshots. Operational and economic consequences depend on the affected markets and recovery time.
 
 ### Pre-Incident Snapshots
 
@@ -48,7 +50,7 @@ Whenever EBrake tightens a parameter for the first time, it snapshots the origin
 
 ### BSC vs Non-BSC Differences
 
-EBrake is deployed on all Venus chains, but its behavior differs based on the underlying comptroller:
+EBrake supports two Comptroller families. The currently published registry lists deployments on only a subset of Venus networks, and behavior differs by the configured Comptroller:
 
 | Feature                              | BSC — Diamond Comptroller (`IS_ISOLATED_POOL=false`) | Non-BSC — IL Comptroller (`IS_ISOLATED_POOL=true`) |
 | ------------------------------------ | ---------------------------------------------------- | -------------------------------------------------- |
@@ -63,7 +65,7 @@ All other functions (`pauseActions`, `pauseSupply`, `pauseBorrow`, `pauseRedeem`
 
 ## Inheritance
 
-- `AccessControlledV8` — All functions are gated via the Venus Access Control Manager
+- `AccessControlledV8` — privileged state-changing functions are gated through the Venus Access Control Manager; initialization and public views are not ACM actions
 
 ## State Variables
 
@@ -109,6 +111,18 @@ Holds the pre-incident state captured by EBrake before any tightening action. Ne
 # Solidity API
 
 ## EBrake
+
+### initialize
+
+Initializes the proxy with its Access Control Manager. The implementation constructor fixes `COMPTROLLER` and `IS_ISOLATED_POOL` and disables direct initialization of the implementation.
+
+```solidity
+function initialize(address accessControlManager_) external initializer
+```
+
+This is a one-time proxy initialization function; it is not an ACM-gated incident action.
+
+---
 
 ### pauseActions
 
@@ -404,7 +418,7 @@ Targets a single pool. No-ops (returns without event) if `newCF == currentCF`. U
 
 ### setMarketBorrowCaps
 
-Decrease borrow caps on one or more markets. Setting to 0 blocks all new borrows. Existing borrows are never affected by caps.
+Decrease borrow caps on one or more markets. Setting a cap to 0 blocks additional borrowing; it does not change debt already recorded, although the account remains subject to normal interest and liquidation rules.
 
 ```solidity
 function setMarketBorrowCaps(address[] calldata markets, uint256[] calldata newBorrowCaps) external
@@ -439,7 +453,7 @@ Iterates the markets array. Elements equal to the current cap are silently skipp
 
 ### setMarketSupplyCaps
 
-Decrease supply caps on one or more markets. Setting to 0 blocks all new deposits. Existing deposits are never affected by caps.
+Decrease supply caps on one or more markets. Setting a cap to 0 blocks additional deposits; it does not change an existing supplied balance, although a separate redeem pause can still block withdrawals.
 
 ```solidity
 function setMarketSupplyCaps(address[] calldata markets, uint256[] calldata newSupplyCaps) external
@@ -614,7 +628,7 @@ function getMarketCFSnapshot(address market, uint96 poolId) external view return
 
 ### Access Control
 
-All functions are gated via the Venus ACM. No function can be called without an explicit ACM permission grant. The set of permissions granted at deployment differs between BSC and non-BSC chains — Diamond-only functions (`pauseFlashLoan`, `disablePoolBorrow`, `revokeFlashLoanAccess`, `decreaseCF(address,uint96,uint256)`) are not granted on IL chains.
+Privileged EBrake mutators require an explicit Venus ACM grant for their exact signature. Public view functions such as `getMarketCFSnapshot` are ungated, and `initialize` is protected by one-time initialization rather than ACM. The set of mutator grants differs between BSC and non-BSC chains — Diamond-only functions (`pauseFlashLoan`, `disablePoolBorrow`, `revokeFlashLoanAccess`, `decreaseCF(address,uint96,uint256)`) are not intended for IL chains.
 
 ### Snapshot Integrity
 
@@ -628,7 +642,7 @@ EBrake uses first-write-wins snapshots to capture the pre-incident state:
 
 EBrake decreases CF but always preserves LT when calling `setCollateralFactor`. This is intentional:
 
-- Decreasing CF prevents **new** borrows against the asset but does not affect existing positions.
+- Decreasing CF does not directly lower LT or make an account liquidatable by itself, but it can reduce available liquidity and restrict later borrow or redeem operations for existing accounts.
 - Decreasing LT would instantly make previously healthy positions liquidatable, harming innocent users.
 
 Recovery VIPs may restore both CF and LT to their original values, which is why both are included in the snapshot.
@@ -644,7 +658,7 @@ Both flags must allow borrowing for borrows to actually proceed. A recovery VIP 
 
 ## Deployment
 
-EBrake is deployed behind a `TransparentUpgradeableProxy`. The `IS_ISOLATED_POOL` flag is set in the constructor and cannot be changed. On BSC, `IS_ISOLATED_POOL = false`; on all other chains, `IS_ISOLATED_POOL = true`.
+EBrake is deployed behind a `TransparentUpgradeableProxy`. The implementation constructor fixes `COMPTROLLER` and `IS_ISOLATED_POOL`, so every proxy-to-implementation mapping must use an implementation built for that network and Comptroller family. On the documented BSC deployment `IS_ISOLATED_POOL = false`; the documented IL Comptroller deployments use `true`.
 
 ### BNB Chain Mainnet
 
@@ -662,4 +676,4 @@ EBrake is deployed behind a `TransparentUpgradeableProxy`. The `IS_ISOLATED_POOL
 
 ## Audits
 
-EBrake undergoes security audits before mainnet deployment. Audit reports are available in the [venus-periphery repository](https://github.com/VenusProtocol/venus-periphery/tree/main/audits).
+Published EBrake and DeviationSentinel audit reports are indexed in the [`venus-periphery` v1.2.0 release](https://github.com/VenusProtocol/venus-periphery/tree/v1.2.0/audits). A report's scope and reviewed commit should be checked against the current proxy implementation.

--- a/technical-reference/reference-periphery/leverage-strategies-manager.md
+++ b/technical-reference/reference-periphery/leverage-strategies-manager.md
@@ -2,6 +2,8 @@
 
 The LeverageStrategiesManager is a Venus periphery contract that enables users to enter and exit leveraged positions atomically using flash loans. It integrates with the Venus Comptroller's flash loan functionality and the SwapHelper contract to execute complex leverage operations in a single transaction.
 
+> **Version scope:** This API reference follows [`venus-periphery` v1.2.0](https://github.com/VenusProtocol/venus-periphery/tree/v1.2.0/contracts/LeverageManager). The deployed manager is an upgradeable proxy whose implementation fixes the Comptroller, SwapHelper, and unsupported vBNB address. Verify the current proxy implementation and dependencies before approving tokens or delegation.
+
 ## Overview
 
 Leverage operations in DeFi typically require multiple transactions: borrowing, swapping, and supplying assets. The LeverageStrategiesManager consolidates these into atomic operations using flash loans, eliminating intermediate exposure and reducing gas costs.
@@ -18,7 +20,7 @@ The contract supports five distinct leverage strategies:
 
 ## Prerequisites
 
-Before using the LeverageStrategiesManager, users must delegate borrowing rights to the contract:
+Before using the LeverageStrategiesManager, users must delegate account actions to the exact manager **proxy** for their network:
 
 ```solidity
 // On the Venus Comptroller
@@ -31,6 +33,8 @@ This delegation allows the contract to:
 - Mint vTokens on behalf of the user
 - Redeem vTokens on behalf of the user
 - Repay borrows on behalf of the user
+
+Obtain `leverageStrategiesManagerAddress` from [Deployed Contracts](../../deployed-contracts/periphery.md), not from an implementation address or the SwapHelper address. The delegation remains enabled until the user revokes it with `updateDelegate(leverageStrategiesManagerAddress, false)`.
 
 ## Inheritance
 
@@ -65,6 +69,18 @@ The contract uses EIP-1153 transient storage to pass state between entry functio
 | `minAmountOutAfterSwap` | `uint256`       | Slippage protection threshold               |
 
 # Solidity API
+
+### initialize
+
+Initializes two-step ownership and reentrancy protection on the manager proxy.
+
+```solidity
+function initialize() external initializer
+```
+
+The implementation constructor fixes the Comptroller, SwapHelper, and vBNB addresses and disables initialization on the implementation. Verify that the deployed proxy has already been initialized.
+
+---
 
 ### enterSingleAssetLeverage
 
@@ -380,6 +396,24 @@ function executeOperation(
 - `FlashLoanAssetOrAmountMismatch` if arrays length is not 1
 - `InvalidExecuteOperation` if operation type is unknown
 
+---
+
+### sweepToken
+
+Transfers the manager's full balance of an ERC-20 token to its current owner. This is a recovery function, not a user refund path.
+
+```solidity
+function sweepToken(address token) external onlyOwner nonReentrant
+```
+
+#### Access Requirements
+
+- Current contract owner only
+
+#### Security Considerations
+
+- The call transfers the entire token balance and has no protected-token list or lifecycle condition. Integrations should avoid leaving balances on the manager and should verify the live proxy owner before relying on recovery.
+
 ## Events
 
 | Event                        | Parameters                                                                                         | Description                                               |
@@ -390,6 +424,7 @@ function executeOperation(
 | `LeverageExited`             | user, collateralMarket, collateralAmountToRedeemForSwap, borrowedMarket, borrowedAmountToFlashLoan | Cross-asset leverage position closed                      |
 | `SingleAssetLeverageExited`  | user, collateralMarket, collateralAmountToFlashLoan                                                | Single-asset leverage position closed                     |
 | `DustTransferred`            | recipient, token, amount                                                                           | Residual tokens transferred after operation               |
+| `TokensSwept`                | token, recipient, amount                                                                            | Owner recovered the manager's full token balance           |
 
 ## Security Considerations
 
@@ -412,7 +447,7 @@ All swap operations accept a `minAmountOutAfterSwap` parameter. The transaction 
 
 - Enter operations perform pre-checks to ensure the user is not already at liquidation risk
 - All operations perform post-checks to verify the final position is healthy
-- Exit operations skip pre-checks since reducing debt can only improve health
+- Exit operations skip the initial liquidity pre-check because they begin by reducing debt, but they also redeem collateral to settle the flash loan. The contract therefore still performs a final account-liquidity check; an exit is not assumed safe solely because debt decreased.
 
 ### Dust Handling
 
@@ -429,9 +464,10 @@ See [Deployed Contracts](../../deployed-contracts/periphery.md) for current addr
 
 ### For Users
 
-1. **Enable Delegation**: Call `Comptroller.updateDelegate(leverageStrategiesManagerAddress, true)` to authorize the contract
+1. **Enable Delegation**: Resolve the network's manager proxy from [Deployed Contracts](../../deployed-contracts/periphery.md), then call `Comptroller.updateDelegate(leverageStrategiesManagerAddress, true)`
 2. **Approve Tokens**: Grant token spending approval to LeverageStrategiesManager for collateral tokens
 3. **Execute Operations**: Call the appropriate entry function with parameters
+4. **Revoke When Finished**: Call `Comptroller.updateDelegate(leverageStrategiesManagerAddress, false)` when the manager no longer needs to act for the account
 
 ### For Developers
 
@@ -480,4 +516,4 @@ Cross-asset operations (enterLeverage, enterLeverageFromBorrow, exitLeverage) re
 
 ## Audits
 
-LeverageStrategiesManager undergoes security audits before mainnet deployment. Audit reports are available in the [venus-periphery repository](https://github.com/VenusProtocol/venus-periphery/tree/main/audits).
+Published LeverageStrategiesManager audit reports are indexed in the [`venus-periphery` v1.2.0 release](https://github.com/VenusProtocol/venus-periphery/tree/v1.2.0/audits). Check each report's scope and reviewed commit against the current proxy implementation.

--- a/technical-reference/reference-periphery/relative-position-manager.md
+++ b/technical-reference/reference-periphery/relative-position-manager.md
@@ -4,6 +4,12 @@
 
 For architecture details and implementation walkthrough, see the [Trade Technical Article](../reference-technical-articles/trade.md).
 
+> **Version scope:** This API reference follows [`venus-periphery` v1.2.0](https://github.com/VenusProtocol/venus-periphery/tree/v1.2.0/contracts/RelativePositionManager). RelativePositionManager is an upgradeable proxy; PositionAccounts are deterministic EIP-1167 clones of the one-time configured implementation. Verify the current proxy implementation, locked PositionAccount implementation, ACM grants, DSA configuration, pause state, and manager dependencies before integrating.
+
+{% hint style="warning" %}
+PositionAccount is an accounting boundary, not an exclusive-custody guarantee. Standard Venus liquidations can seize vTokens held by a PositionAccount. In addition, an account granted the RelativePositionManager ACM permission for `executePositionAccountCall(address,address[],bytes[])` can cause arbitrary external calls from a PositionAccount through `genericCalls`; this emergency/administrative path does not require a contemporaneous transaction from the position owner.
+{% endhint %}
+
 # Solidity API
 
 ### COMPTROLLER
@@ -158,6 +164,10 @@ while allowing defensive operations (close, supply principal).
 function partialPause() external
 ```
 
+#### Access Requirements
+
+- ACM permission required: `partialPause()`
+
 ---
 
 ### partialUnpause
@@ -167,6 +177,10 @@ Removes partial pause, re-enabling risk operations (unless completely paused).
 ```solidity
 function partialUnpause() external
 ```
+
+#### Access Requirements
+
+- ACM permission required: `partialUnpause()`
 
 ---
 
@@ -178,6 +192,10 @@ Completely pauses all state-changing user operations on the manager
 function completePause() external
 ```
 
+#### Access Requirements
+
+- ACM permission required: `completePause()`
+
 ---
 
 ### completeUnpause
@@ -187,6 +205,10 @@ Removes complete pause, re-enabling all operations (unless partially paused).
 ```solidity
 function completeUnpause() external
 ```
+
+#### Access Requirements
+
+- ACM permission required: `completeUnpause()`
 
 ---
 
@@ -203,6 +225,11 @@ function setPositionAccountImplementation(address positionAccountImpl) external
 | Name                | Type    | Description                                                 |
 | ------------------- | ------- | ----------------------------------------------------------- |
 | positionAccountImpl | address | Implementation contract for PositionAccount EIP-1167 clones |
+
+#### Access Requirements
+
+- ACM permission required: `setPositionAccountImplementation(address)`
+- The implementation can be set only once; existing and future clones then use that locked address
 
 #### 📅 Events
 
@@ -229,13 +256,17 @@ function setProportionalCloseTolerance(uint256 newTolerance) external
 | ------------ | ------- | ----------------------------------- |
 | newTolerance | uint256 | New tolerance value in basis points |
 
+#### Access Requirements
+
+- ACM permission required: `setProportionalCloseTolerance(uint256)`
+
 #### 📅 Events
 
 - Emits ProportionalCloseToleranceUpdated event.
 
 #### ❌ Errors
 
-- Throw InvalidProportionalCloseTolerance if tolerance is outside [1, 10000].
+- Throw InvalidProportionalCloseTolerance if tolerance is outside `[1, 10000]`.
 - Throw SameProportionalCloseTolerance if tolerance is unchanged.
 
 ---
@@ -253,6 +284,10 @@ function addDSAVToken(address dsaVToken) external
 | Name      | Type    | Description                                         |
 | --------- | ------- | --------------------------------------------------- |
 | dsaVToken | address | The vToken market address to add as a supported DSA |
+
+#### Access Requirements
+
+- ACM permission required: `addDSAVToken(address)`
 
 #### 📅 Events
 
@@ -281,6 +316,10 @@ function setDSAVTokenActive(uint8 dsaIndex, bool active) external
 | dsaIndex | uint8 | Index of the DSA vToken in the internal mapping                      |
 | active   | bool  | New active flag (true to allow new activations, false to block them) |
 
+#### Access Requirements
+
+- ACM permission required: `setDSAVTokenActive(uint8,bool)`
+
 #### 📅 Events
 
 - Emits DSAVTokenActiveUpdated when the active flag is changed.
@@ -294,7 +333,7 @@ function setDSAVTokenActive(uint8 dsaIndex, bool active) external
 
 ### executePositionAccountCall
 
-Executes multiple generic calls on behalf of a position account
+Executes multiple generic calls from a position account for emergency or administrative actions.
 
 ```solidity
 function executePositionAccountCall(address positionAccount, address[] targets, bytes[] data) external
@@ -307,6 +346,11 @@ function executePositionAccountCall(address positionAccount, address[] targets, 
 | positionAccount | address   | Address of the position account     |
 | targets         | address[] | Array of target contract addresses  |
 | data            | bytes[]   | Array of encoded function call data |
+
+#### Access Requirements
+
+- ACM permission required: `executePositionAccountCall(address,address[],bytes[])`
+- The granted caller selects every target and calldata item. RelativePositionManager forwards them to the PositionAccount's `genericCalls` function without restricting the called contracts or selectors.
 
 ---
 
@@ -471,7 +515,7 @@ of the position account to cover the fee.
 
 **Implementation notes:**
 - **First exit (long → short):** long/short amounts are derived from BPS; the user passes shortAmountToRepayForFirstSwap,
-  which is validated to be within [0, expectedShort] and minAmountOutFirst must be >= shortAmountToRepayForFirstSwap.
+  which is validated to be within `[0, expectedShort]` and minAmountOutFirst must be >= shortAmountToRepayForFirstSwap.
   For 100% close with one leg, shortAmountToRepayForFirstSwap should be slightly higher to cover the internal tolerance bump.
 - **Second exit (DSA → short):** the second repay amount is calculated as expectedShort - shortAmountToRepayForFirstSwap
   (and bumped for 100% close when > 0). minAmountOutSecond must be >= the calculated second repay (slippage protection;
@@ -503,7 +547,7 @@ function closeWithLoss(contract IVToken longVToken, contract IVToken shortVToken
 #### 📅 Events
 
 - Emits PositionClosed event. When DSA == Long, PositionClosed.longDustRedeemed is reclassified
--               back as principal vTokens rather than transferred.
+  back as principal vTokens rather than transferred.
 
 #### ❌ Errors
 
@@ -1023,7 +1067,7 @@ function transferDustToOwner(address token) external
 
 ### genericCalls
 
-Executes multiple generic calls to external contracts
+Executes multiple generic calls to external contracts. Direct callers are restricted to RelativePositionManager, but the manager exposes the ACM-gated `executePositionAccountCall` administrative path described above.
 
 ```solidity
 function genericCalls(address[] targets, bytes[] data) external
@@ -1035,6 +1079,10 @@ function genericCalls(address[] targets, bytes[] data) external
 | ------- | --------- | ----------------------------------- |
 | targets | address[] | Array of target contract addresses  |
 | data    | bytes[]   | Array of encoded function call data |
+
+#### Trust Boundary
+
+Each target call executes from the PositionAccount and can therefore act on its token balances, approvals, and protocol permissions. Review the live ACM grantee for `executePositionAccountCall(address,address[],bytes[])`; `onlyRelativePositionManager` does not make this path owner-only.
 
 #### ❌ Errors
 

--- a/technical-reference/reference-periphery/swap-helper.md
+++ b/technical-reference/reference-periphery/swap-helper.md
@@ -1,6 +1,8 @@
 # SwapHelper
 
-The SwapHelper is a Venus periphery contract that enables secure, backend-authorized token swaps. It provides an atomic multicall interface with EIP-712 signature verification, allowing the Venus backend to authorize specific swap operations while preventing arbitrary execution.
+The SwapHelper is a Venus periphery contract for backend-authorized token operations. It provides an atomic multicall interface with EIP-712 signature verification, allowing the configured backend signer to authorize a specific batch of approvals, arbitrary external calls, and token sweeps.
+
+> **Version scope:** This API reference follows the standalone [`SwapHelper` in `venus-periphery` v1.2.0](https://github.com/VenusProtocol/venus-periphery/blob/v1.2.0/contracts/SwapHelper/SwapHelper.sol). It is not a proxy. Its current owner, pending owner, backend signer, EIP-712 domain/address, and consuming manager/router versions are live trust inputs that must be checked before use.
 
 ## Overview
 
@@ -50,7 +52,7 @@ The contract is designed to be called by the LeverageStrategiesManager during fl
 ## Inheritance
 
 - `EIP712` - EIP-712 typed data hashing for signature verification
-- `Ownable` - Access control for admin functions
+- `Ownable2Step` - Two-step ownership transfer and owner access for admin functions
 - `ReentrancyGuard` - Reentrancy protection
 
 ## State Variables
@@ -274,12 +276,14 @@ All multicall operations require a valid EIP-712 signature from the `backendSign
 - The deadline timestamp
 - A unique salt
 
-This prevents:
+Assuming the backend signer and owner remain trusted, these checks prevent:
 
 - Unauthorized swap execution
 - Cross-address signature replay attacks
 - Replay attacks (via salt tracking)
 - Stale quote execution (via deadline)
+
+They do not constrain what a valid signed batch may call. The signer can authorize `approveMax`, `genericCall`, and `sweep`, and the owner can call those functions directly. Integrations must validate the complete encoded call list and output conditions, not only the signature and deadline.
 
 ### Access Control
 
@@ -287,6 +291,8 @@ Functions that interact with external contracts (`genericCall`, `sweep`, `approv
 
 - Direct calls require owner privileges
 - Calls within `multicall` are authorized via backend signature
+
+`approveMax` grants an unlimited allowance and `sweep` transfers the helper's full balance of the selected token. End users should not approve SwapHelper or leave tokens in it; callers such as LeverageStrategiesManager should transfer only the amount needed for an atomic operation and validate the returned output.
 
 ### Reentrancy Protection
 
@@ -303,9 +309,7 @@ This domain separation ensures signatures are specific to this contract and vers
 
 ## Deployment
 
-SwapHelper is currently deployed on BNB Chain Mainnet. See [Deployed Contracts](../deployed-contracts/periphery.md) for current addresses.
-
-Deployments on additional networks are planned. The contract is designed to be deployed on any EVM-compatible network where Venus Protocol operates.
+SwapHelper is currently published for BNB Chain Mainnet and testnet. See [Deployed Contracts](../../deployed-contracts/periphery.md) for current addresses. Source portability does not establish a deployment on another network.
 
 ## Integration
 
@@ -376,4 +380,4 @@ The API returns encoded `multicall` parameters with the backend signature that i
 
 ## Audits
 
-SwapHelper undergoes security audits before mainnet deployment. Audit reports are available in the [venus-periphery repository](https://github.com/VenusProtocol/venus-periphery/tree/main/audits).
+Published SwapHelper audit reports are indexed in the [`venus-periphery` v1.2.0 release](https://github.com/VenusProtocol/venus-periphery/tree/v1.2.0/audits). Check each report's scope and reviewed commit against the deployed standalone bytecode.


### PR DESCRIPTION
## Summary

- pin the Periphery API references to the stable venus-periphery v1.2.0 release and distinguish stable source behavior from live proxy configuration
- expand the Periphery index with the deployed Trade, SwapRouter, DeviationSentinel, and EBrake systems and correct network and slippage boundaries
- document the exact RelativePositionManager ACM selectors, PositionAccount arbitrary-call authority, LeverageStrategiesManager delegation/revocation and owner sweep, and SwapHelper owner/signer trust
- qualify EBrake and DeviationSentinel safety claims, deployment scope, initializer behavior, and current-implementation verification
- intentionally exclude develop-only Periphery additions and the in-development Liquidity Hub pages

## Validation

- targeted Remark: 6 files, no warnings
- relative Markdown links: all resolve
- stable GitHub source/audit links: HTTP 200
- stable v1.2.0 direct public/external API coverage reviewed
- BNB mainnet and testnet EBrake implementation slots match the documented addresses
- git diff --check
- no file overlap with PRs #386-#407