### PR TITLE
docs: clarify fund and oracle registry lifecycle

### DIFF
--- a/deployed-contracts/funds.md
+++ b/deployed-contracts/funds.md
@@ -1,29 +1,41 @@
 # Funds - Deployed Contracts
 
-### BNB Chain Mainnet
+This page is an address registry, not a guarantee that a fund path, reward program, transfer, auction, or claim is currently enabled. Proxy implementations, owners, permissions, balances, pause flags, and recipients can change through governance. Verify live state before interacting.
+
+Stable implementation and deployment baselines are available in [`venus-protocol` v10.3.0](https://github.com/VenusProtocol/venus-protocol/tree/v10.3.0) for Prime and the BNB vault family, and [`protocol-reserve` v3.5.0](https://github.com/VenusProtocol/protocol-reserve/tree/v3.5.0) for reserve and XVSVaultTreasury families. The on-chain proxy implementation and configuration remain authoritative.
+
+{% hint style="warning" %}
+**Lifecycle legend:** **Active** means the address has a current role or remaining custody duty, not that every action is unpaused. **Paused** is reversible governance state, not proof that a contract can be discarded. **Legacy / recovery-only** means a superseded path is retained for existing balances or recovery. Every testnet section is **Test-only**.
+
+The Prime Liquidity Provider suffixes below are recorded-block observations from August 27, 2026. BNB (`118373320`) and Ethereum (`25846173`) were unpaused and block-based. Arbitrum (`498898734`), ZKsync (`71738875`), Optimism (`156115139`), Base (`50519855`), and Unichain (`57080698`) were paused and time-based. Re-read `paused()`, `isTimeBased()`, and `prime()` for current operations.
+{% endhint %}
+
+## BNB Chain Mainnet
 
 * Venus Treasury: [`0xf322942f644a996a617bd29c16bd7d231d9f35e9`](https://bscscan.com/address/0xf322942f644a996a617bd29c16bd7d231d9f35e9)
 * XVS Vault Proxy: [`0x051100480289e704d20e9DB4804837068f3f9204`](https://bscscan.com/address/0x051100480289e704d20e9DB4804837068f3f9204)
 * XVS Store: [`0x1e25CF968f12850003Db17E0Dba32108509C4359`](https://bscscan.com/address/0x1e25CF968f12850003Db17E0Dba32108509C4359)
+* XVS Vault Treasury: [`0x269ff7818DB317f60E386D2be0B259e1a324a40a`](https://bscscan.com/address/0x269ff7818DB317f60E386D2be0B259e1a324a40a) (active custody/funding path; points to the XVS Vault above at the checkpoint)
 * Prime: [`0xBbCD063efE506c3D42a0Fa2dB5C08430288C71FC`](https://bscscan.com/address/0xBbCD063efE506c3D42a0Fa2dB5C08430288C71FC) (legacy V1, paused on BNB Chain — superseded by PrimeV2)
-* Prime Liquidity Provider: [`0x23c4F844ffDdC6161174eB32c770D4D8C07833F2`](https://bscscan.com/address/0x23c4F844ffDdC6161174eB32c770D4D8C07833F2)
+* Prime Liquidity Provider: [`0x23c4F844ffDdC6161174eB32c770D4D8C07833F2`](https://bscscan.com/address/0x23c4F844ffDdC6161174eB32c770D4D8C07833F2) (PrimeV2; unpaused, block-based at the checkpoint)
 * PrimeV2: [`0x059EabA8676b03e4e8f009eFb7F587C28450F50f`](https://bscscan.com/address/0x059EabA8676b03e4e8f009eFb7F587C28450F50f) (active Prime program on BNB Chain)
 * PrimeLeaderboard: [`0x55e2ccF68B7A276dc28AfA107997b8B1Be932c0b`](https://bscscan.com/address/0x55e2ccF68B7A276dc28AfA107997b8B1Be932c0b) (live)
 * PrimeLens: [`0x2f8c5e4562E22DB7908C56Bf99961C053436473c`](https://bscscan.com/address/0x2f8c5e4562E22DB7908C56Bf99961C053436473c) (read-only APR lens for PrimeV2)
 * Liquidator: [`0x0870793286aaDA55D39CE7f82fb2766e8004cF43`](https://bscscan.com/address/0x0870793286aaDA55D39CE7f82fb2766e8004cF43)
 * Peg Stability Module: [`0xC138aa4E424D1A8539e8F38Af5a754a2B7c3Cc36`](https://bscscan.com/address/0xC138aa4E424D1A8539e8F38Af5a754a2B7c3Cc36)
 * ProtocolShareReserve: [`0xCa01D5A9A248a830E9D93231e791B1afFed7c446`](https://bscscan.com/address/0xCa01D5A9A248a830E9D93231e791B1afFed7c446)
-* RiskFund: [`0xdF31a28D68A2AB381D42b380649Ead7ae2A76E42`](https://bscscan.com/address/0xdF31a28D68A2AB381D42b380649Ead7ae2A76E42)
-* Shortfall: [`0xf37530A8a810Fcb501AA0Ecd0B0699388F0F2209`](https://bscscan.com/address/0xf37530A8a810Fcb501AA0Ecd0B0699388F0F2209)
+* RiskFundV2: [`0xdF31a28D68A2AB381D42b380649Ead7ae2A76E42`](https://bscscan.com/address/0xdF31a28D68A2AB381D42b380649Ead7ae2A76E42) (active raw-balance custody/buyback destination; legacy per-pool accounting was removed)
+* Shortfall: [`0xf37530A8a810Fcb501AA0Ecd0B0699388F0F2209`](https://bscscan.com/address/0xf37530A8a810Fcb501AA0Ecd0B0699388F0F2209) (legacy / recovery-only; auctions paused at BNB block `118373320`)
 * VAI Unitroller: [`0x004065D34C6b18cE4370ced1CeBDE94865DbFAFE`](https://bscscan.com/address/0x004065D34C6b18cE4370ced1CeBDE94865DbFAFE)
 * VAI Vault Proxy: [`0x0667Eed0a0aAb930af74a3dfeDD263A73994f216`](https://bscscan.com/address/0x0667Eed0a0aAb930af74a3dfeDD263A73994f216)
 * vBNB Admin: [`0x9A7890534d9d91d473F28cB97962d176e2B65f1d`](https://bscscan.com/address/0x9A7890534d9d91d473F28cB97962d176e2B65f1d)
 
-### BNB Chain Testnet
+## BNB Chain Testnet (Test-only)
 
 * Venus Treasury: [`0x8b293600c50d6fbdc6ed4251cc75ece29880276f`](https://testnet.bscscan.com/address/0x8b293600c50d6fbdc6ed4251cc75ece29880276f)
 * XVS Vault Proxy: [`0x9aB56bAD2D7631B2A857ccf36d998232A8b82280`](https://testnet.bscscan.com/address/0x9aB56bAD2D7631B2A857ccf36d998232A8b82280)
 * XVS Store: [`0xDd8C124A63bFC2F7b06247879B3808FBC225880c`](https://testnet.bscscan.com/address/0xDd8C124A63bFC2F7b06247879B3808FBC225880c)
+* XVS Vault Treasury: [`0x317c6C4c9AA7F87170754DB08b4804dD689B68bF`](https://testnet.bscscan.com/address/0x317c6C4c9AA7F87170754DB08b4804dD689B68bF)
 * PrimeV2: [`0xeC22366d2572e52BCB29B50C905b945BA421B9b2`](https://testnet.bscscan.com/address/0xeC22366d2572e52BCB29B50C905b945BA421B9b2)
 * PrimeLeaderboard: [`0x1a4408613eec291f2d338F7A88E9D550fa9cD8dC`](https://testnet.bscscan.com/address/0x1a4408613eec291f2d338F7A88E9D550fa9cD8dC)
 * PrimeLens: [`0x13b3C3442e5fD642bc31D34db43d547E8C4322f7`](https://testnet.bscscan.com/address/0x13b3C3442e5fD642bc31D34db43d547E8C4322f7)
@@ -42,16 +54,18 @@
 * Venus Treasury: [`0xFD9B071168bC27DBE16406eC3Aba050Ce8Eb22FA`](https://etherscan.io/address/0xFD9B071168bC27DBE16406eC3Aba050Ce8Eb22FA)
 * XVS Vault Proxy: [`0xA0882C2D5DF29233A092d2887A258C2b90e9b994`](https://etherscan.io/address/0xA0882C2D5DF29233A092d2887A258C2b90e9b994)
 * XVS Store: [`0x1Db646E1Ab05571AF99e47e8F909801e5C99d37B`](https://etherscan.io/address/0x1Db646E1Ab05571AF99e47e8F909801e5C99d37B)
-* Prime: [`0x14C4525f47A7f7C984474979c57a2Dccb8EACB39`](https://etherscan.io/address/0x14C4525f47A7f7C984474979c57a2Dccb8EACB39)
-* Prime Liquidity Provider: [`0x8ba6aFfd0e7Bcd0028D1639225C84DdCf53D8872`](https://etherscan.io/address/0x8ba6aFfd0e7Bcd0028D1639225C84DdCf53D8872)
+* XVS Vault Treasury: [`0xaE39C38AF957338b3cEE2b3E5d825ea88df02EfE`](https://etherscan.io/address/0xaE39C38AF957338b3cEE2b3E5d825ea88df02EfE) (active custody/funding path; points to the XVS Vault above at the checkpoint)
+* Prime (V1): [`0x14C4525f47A7f7C984474979c57a2Dccb8EACB39`](https://etherscan.io/address/0x14C4525f47A7f7C984474979c57a2Dccb8EACB39)
+* Prime Liquidity Provider (V1; unpaused, block-based at the checkpoint): [`0x8ba6aFfd0e7Bcd0028D1639225C84DdCf53D8872`](https://etherscan.io/address/0x8ba6aFfd0e7Bcd0028D1639225C84DdCf53D8872)
 * ProtocolShareReserve: [`0x8c8c8530464f7D95552A11eC31Adbd4dC4AC4d3E`](https://etherscan.io/address/0x8c8c8530464f7D95552A11eC31Adbd4dC4AC4d3E)
 
-## Sepolia (Ethereum testnet)
+## Sepolia (Ethereum testnet; Test-only)
 
 * Venus Treasury: [`0x4116CA92960dF77756aAAc3aFd91361dB657fbF8`](https://sepolia.etherscan.io/address/0x4116CA92960dF77756aAAc3aFd91361dB657fbF8)
 * XVS Vault Proxy: [`0x1129f882eAa912aE6D4f6D445b2E2b1eCbA99fd5`](https://sepolia.etherscan.io/address/0x1129f882eAa912aE6D4f6D445b2E2b1eCbA99fd5)
 * XVS Store: [`0x03B868C7858F50900fecE4eBc851199e957b5d3D`](https://sepolia.etherscan.io/address/0x03B868C7858F50900fecE4eBc851199e957b5d3D)
-* Prime: [`0x2Ec432F123FEbb114e6fbf9f4F14baF0B1F14AbC`](https://sepolia.etherscan.io/address/0x2Ec432F123FEbb114e6fbf9f4F14baF0B1F14AbC)
+* XVS Vault Treasury: [`0xCCB08e5107b406E67Ad8356023dd489CEbc79B40`](https://sepolia.etherscan.io/address/0xCCB08e5107b406E67Ad8356023dd489CEbc79B40)
+* Prime (V1): [`0x2Ec432F123FEbb114e6fbf9f4F14baF0B1F14AbC`](https://sepolia.etherscan.io/address/0x2Ec432F123FEbb114e6fbf9f4F14baF0B1F14AbC)
 * Prime Liquidity Provider: [`0x15242a55Ad1842A1aEa09c59cf8366bD2f3CE9B4`](https://sepolia.etherscan.io/address/0x15242a55Ad1842A1aEa09c59cf8366bD2f3CE9B4)
 * ProtocolShareReserve: [`0xbea70755cc3555708ca11219adB0db4C80F6721B`](https://sepolia.etherscan.io/address/0xbea70755cc3555708ca11219adB0db4C80F6721B)
 
@@ -62,7 +76,7 @@
 * XVS Store: [`0xc3279442a5aCaCF0A2EcB015d1cDDBb3E0f3F775`](https://opbnbscan.com/address/0xc3279442a5aCaCF0A2EcB015d1cDDBb3E0f3F775)
 * ProtocolShareReserve: [`0xA2EDD515B75aBD009161B15909C19959484B0C1e`](https://opbnbscan.com/address/0xA2EDD515B75aBD009161B15909C19959484B0C1e)
 
-## opBNB Chain Testnet
+## opBNB Chain Testnet (Test-only)
 
 * Venus Treasury: [`0x3370915301E8a6A6baAe6f461af703e2498409F3`](https://testnet.opbnbscan.com/address/0x3370915301E8a6A6baAe6f461af703e2498409F3)
 * XVS Vault Proxy: [`0xB14A0e72C5C202139F78963C9e89252c1ad16f01`](https://testnet.opbnbscan.com/address/0xB14A0e72C5C202139F78963C9e89252c1ad16f01)
@@ -74,16 +88,18 @@
 * Venus Treasury: [`0x8a662ceAC418daeF956Bc0e6B2dd417c80CDA631`](https://arbiscan.io/address/0x8a662ceac418daef956bc0e6b2dd417c80cda631)
 * XVS Vault Proxy: [`0x8b79692AAB2822Be30a6382Eb04763A74752d5B4`](https://arbiscan.io/address/0x8b79692AAB2822Be30a6382Eb04763A74752d5B4)
 * XVS Store: [`0x507D9923c954AAD8eC530ed8Dedb75bFc893Ec5e`](https://arbiscan.io/address/0x507D9923c954AAD8eC530ed8Dedb75bFc893Ec5e)
-* Prime: [`0xFE69720424C954A2da05648a0FAC84f9bf11Ef49`](https://arbiscan.io/address/0xFE69720424C954A2da05648a0FAC84f9bf11Ef49)
-* Prime Liquidity Provider: [`0x86bf21dB200f29F21253080942Be8af61046Ec29`](https://arbiscan.io/address/0x86bf21dB200f29F21253080942Be8af61046Ec29)
+* XVS Vault Treasury: [`0xb076D4f15c08D7A7B89466327Ba71bc7e1311b58`](https://arbiscan.io/address/0xb076D4f15c08D7A7B89466327Ba71bc7e1311b58) (active custody/funding path; points to the XVS Vault above at the checkpoint)
+* Prime (V1): [`0xFE69720424C954A2da05648a0FAC84f9bf11Ef49`](https://arbiscan.io/address/0xFE69720424C954A2da05648a0FAC84f9bf11Ef49)
+* Prime Liquidity Provider (V1; paused, time-based at the checkpoint): [`0x86bf21dB200f29F21253080942Be8af61046Ec29`](https://arbiscan.io/address/0x86bf21dB200f29F21253080942Be8af61046Ec29)
 * ProtocolShareReserve: [`0xF9263eaF7eB50815194f26aCcAB6765820B13D41`](https://arbiscan.io/address/0xF9263eaF7eB50815194f26aCcAB6765820B13D41)
 
-## Arbitrum Sepolia
+## Arbitrum Sepolia (Test-only)
 
 * Venus Treasury: [`0x4e7ab1fD841E1387Df4c91813Ae03819C33D5bdB`](https://sepolia.arbiscan.io/address/0x4e7ab1fD841E1387Df4c91813Ae03819C33D5bdB)
 * XVS Vault Proxy: [`0x407507DC2809D3aa31D54EcA3BEde5C5c4C8A17F`](https://sepolia.arbiscan.io/address/0x407507dc2809d3aa31d54eca3bede5c5c4c8a17f)
 * XVS Store: [`0x4e909DA6693215dC630104715c035B159dDb67Dd`](https://sepolia.arbiscan.io/address/0x4e909DA6693215dC630104715c035B159dDb67Dd)
-* Prime: [`0xadb04ac4942683bc41e27d18234c8dc884786e89`](https://sepolia.arbiscan.io/address/0xadb04ac4942683bc41e27d18234c8dc884786e89)
+* XVS Vault Treasury: [`0x309b71a417dA9CfA8aC47e6038000B1739d9A3A6`](https://sepolia.arbiscan.io/address/0x309b71a417dA9CfA8aC47e6038000B1739d9A3A6)
+* Prime (V1): [`0xadb04ac4942683bc41e27d18234c8dc884786e89`](https://sepolia.arbiscan.io/address/0xadb04ac4942683bc41e27d18234c8dc884786e89)
 * Prime Liquidity Provider: [`0xe82c2c10f55d3268126c29ec813dc6f086904694`](https://sepolia.arbiscan.io/address/0xe82c2c10f55d3268126c29ec813dc6f086904694)
 * ProtocolShareReserve: [`0x09267d30798B59c581ce54E861A084C6FC298666`](https://sepolia.arbiscan.io/address/0x09267d30798B59c581ce54E861A084C6FC298666)
 
@@ -92,16 +108,16 @@
 * Venus Treasury: [`0xB2e9174e23382f7744CebF7e0Be54cA001D95599`](https://explorer.zksync.io/address/0xB2e9174e23382f7744CebF7e0Be54cA001D95599)
 * XVS Vault Proxy: [`0xbbB3C88192a5B0DB759229BeF49DcD1f168F326F`](https://explorer.zksync.io/address/0xbbB3C88192a5B0DB759229BeF49DcD1f168F326F)
 * XVS Store: [`0x84266F552756cBed893b1FFA85248cD99501e3ce`](https://explorer.zksync.io/address/0x84266F552756cBed893b1FFA85248cD99501e3ce)
-* Prime: [`0xdFe62Dcba3Ce0A827439390d7d45Af8baE599978`](https://explorer.zksync.io/address/0xdFe62Dcba3Ce0A827439390d7d45Af8baE599978)
-* Prime Liquidity Provider: [`0x0EDE6d7fB474614C5D3d5a16581628bb96CB5dff`](https://explorer.zksync.io/address/0x0EDE6d7fB474614C5D3d5a16581628bb96CB5dff)
+* Prime (V1): [`0xdFe62Dcba3Ce0A827439390d7d45Af8baE599978`](https://explorer.zksync.io/address/0xdFe62Dcba3Ce0A827439390d7d45Af8baE599978)
+* Prime Liquidity Provider (V1; paused, time-based at the checkpoint): [`0x0EDE6d7fB474614C5D3d5a16581628bb96CB5dff`](https://explorer.zksync.io/address/0x0EDE6d7fB474614C5D3d5a16581628bb96CB5dff)
 * ProtocolShareReserve: [`0xA1193e941BDf34E858f7F276221B4886EfdD040b`](https://explorer.zksync.io/address/0xA1193e941BDf34E858f7F276221B4886EfdD040b)
 
-## ZKsync Sepolia
+## ZKsync Sepolia (Test-only)
 
 * Venus Treasury: [`0x943eBE4460a12F551D60A68f510Ea10CD8d564BA`](https://sepolia.explorer.zksync.io/address/0x943eBE4460a12F551D60A68f510Ea10CD8d564BA)
 * XVS Vault Proxy: [`0x825f9EE3b2b1C159a5444A111A70607f3918564e`](https://sepolia.explorer.zksync.io/address/0x825f9EE3b2b1C159a5444A111A70607f3918564e)
 * XVS Store: [`0xf0DaEFE5f5df4170426F88757EcdF45430332d88`](https://sepolia.explorer.zksync.io/address/0xf0DaEFE5f5df4170426F88757EcdF45430332d88)
-* Prime: [`0x72b85930F7f8D00ACe5EAD10a315C17b8954FBcF`](https://sepolia.explorer.zksync.io/address/0x72b85930F7f8D00ACe5EAD10a315C17b8954FBcF)
+* Prime (V1): [`0x72b85930F7f8D00ACe5EAD10a315C17b8954FBcF`](https://sepolia.explorer.zksync.io/address/0x72b85930F7f8D00ACe5EAD10a315C17b8954FBcF)
 * Prime Liquidity Provider: [`0x3407c349F80E4E9544c73ca1E9334CeEA7266517`](https://sepolia.explorer.zksync.io/address/0x3407c349F80E4E9544c73ca1E9334CeEA7266517)
 * ProtocolShareReserve: [`0x5722B43BD91fAaDC4E7f384F4d6Fb32456Ec5ffB`](https://sepolia.explorer.zksync.io/address/0x5722B43BD91fAaDC4E7f384F4d6Fb32456Ec5ffB)
 
@@ -110,16 +126,16 @@
 * Venus Treasury: [`0x104c01EB7b4664551BE6A9bdB26a8C5c6Be7d3da`](https://optimistic.etherscan.io/address/0x104c01EB7b4664551BE6A9bdB26a8C5c6Be7d3da)
 * XVS Vault Proxy: [`0x133120607C018c949E91AE333785519F6d947e01`](https://optimistic.etherscan.io/address/0x133120607C018c949E91AE333785519F6d947e01)
 * XVS Store: [`0xFE548630954129923f63113923eF5373E10589d3`](https://optimistic.etherscan.io/address/0xFE548630954129923f63113923eF5373E10589d3)
-* Prime: [`0xE76d2173546Be97Fa6E18358027BdE9742a649f7`](https://optimistic.etherscan.io/address/0xE76d2173546Be97Fa6E18358027BdE9742a649f7)
-* Prime Liquidity Provider: [`0x6412f6cd58D0182aE150b90B5A99e285b91C1a12`](https://optimistic.etherscan.io/address/0x6412f6cd58D0182aE150b90B5A99e285b91C1a12)
+* Prime (V1): [`0xE76d2173546Be97Fa6E18358027BdE9742a649f7`](https://optimistic.etherscan.io/address/0xE76d2173546Be97Fa6E18358027BdE9742a649f7)
+* Prime Liquidity Provider (V1; paused, time-based at the checkpoint): [`0x6412f6cd58D0182aE150b90B5A99e285b91C1a12`](https://optimistic.etherscan.io/address/0x6412f6cd58D0182aE150b90B5A99e285b91C1a12)
 * ProtocolShareReserve: [`0x735ed037cB0dAcf90B133370C33C08764f88140a`](https://optimistic.etherscan.io/address/0x735ed037cB0dAcf90B133370C33C08764f88140a)
 
-## Optimism Sepolia
+## Optimism Sepolia (Test-only)
 
 * Venus Treasury: [`0x5A1a12F47FA7007C9e23cf5e025F3f5d3aC7d755`](https://sepolia-optimism.etherscan.io/address/0x5A1a12F47FA7007C9e23cf5e025F3f5d3aC7d755)
 * XVS Vault Proxy: [`0x4d344e48F02234E82D7D1dB84d0A4A18Aa43Dacc`](https://sepolia-optimism.etherscan.io/address/0x4d344e48F02234E82D7D1dB84d0A4A18Aa43Dacc)
 * XVS Store: [`0xE888FA54b32BfaD3cE0e3C7D566EFe809a6A0143`](https://sepolia-optimism.etherscan.io/address/0xE888FA54b32BfaD3cE0e3C7D566EFe809a6A0143)
-* Prime: [`0x54dEb59698c628be5EEd5AD41Fd825Eb3Be89704`](https://sepolia-optimism.etherscan.io/address/0x54dEb59698c628be5EEd5AD41Fd825Eb3Be89704)
+* Prime (V1): [`0x54dEb59698c628be5EEd5AD41Fd825Eb3Be89704`](https://sepolia-optimism.etherscan.io/address/0x54dEb59698c628be5EEd5AD41Fd825Eb3Be89704)
 * Prime Liquidity Provider: [`0xE3EC955b94D197a8e4081844F3f25F81047A9AF5`](https://sepolia-optimism.etherscan.io/address/0xE3EC955b94D197a8e4081844F3f25F81047A9AF5)
 * ProtocolShareReserve: [`0x0F021c29283c47DF8237741dD5a0aA22952aFc88`](https://sepolia-optimism.etherscan.io/address/0x0F021c29283c47DF8237741dD5a0aA22952aFc88)
 
@@ -128,16 +144,16 @@
 * Venus Treasury: [`0xbefD8d06f403222dd5E8e37D2ba93320A97939D1`](https://basescan.org/address/0xbefD8d06f403222dd5E8e37D2ba93320A97939D1)
 * XVS Vault Proxy: [`0x708B54F2C3f3606ea48a8d94dab88D9Ab22D7fCd`](https://basescan.org/address/0x708B54F2C3f3606ea48a8d94dab88D9Ab22D7fCd)
 * XVS Store: [`0x11b084Cfa559a82AAC0CcD159dBea27899c7955A`](https://basescan.org/address/0x11b084Cfa559a82AAC0CcD159dBea27899c7955A)
-* Prime: [`0xD2e84244f1e9Fca03Ff024af35b8f9612D5d7a30`](https://basescan.org/address/0xD2e84244f1e9Fca03Ff024af35b8f9612D5d7a30)
-* Prime Liquidity Provider: [`0xcB293EB385dEFF2CdeDa4E7060974BB90ee0B208`](https://basescan.org/address/0xcB293EB385dEFF2CdeDa4E7060974BB90ee0B208)
+* Prime (V1): [`0xD2e84244f1e9Fca03Ff024af35b8f9612D5d7a30`](https://basescan.org/address/0xD2e84244f1e9Fca03Ff024af35b8f9612D5d7a30)
+* Prime Liquidity Provider (V1; paused, time-based at the checkpoint): [`0xcB293EB385dEFF2CdeDa4E7060974BB90ee0B208`](https://basescan.org/address/0xcB293EB385dEFF2CdeDa4E7060974BB90ee0B208)
 * ProtocolShareReserve: [`0x3565001d57c91062367C3792B74458e3c6eD910a`](https://basescan.org/address/0x3565001d57c91062367C3792B74458e3c6eD910a)
 
-## Base Sepolia
+## Base Sepolia (Test-only)
 
 * Venus Treasury: [`0x07e880DaA6572829cE8ABaaf0f5323A4eFC417A6`](https://sepolia.basescan.org/address/0x07e880DaA6572829cE8ABaaf0f5323A4eFC417A6)
 * XVS Vault Proxy: [`0x9b5D0aDfCEcC8ed422d714EcbcE2FFA436e269B8`](https://sepolia.basescan.org/address/0x9b5D0aDfCEcC8ed422d714EcbcE2FFA436e269B8)
 * XVS Store: [`0x059f1eA3973738C649d63bF4dA18221ecA418cDC`](https://sepolia.basescan.org/address/0x059f1eA3973738C649d63bF4dA18221ecA418cDC)
-* Prime: [`0x15A1AC7fA14C5900Ba93853375d66b6bB6A83B50`](https://sepolia.basescan.org/address/0x15A1AC7fA14C5900Ba93853375d66b6bB6A83B50)
+* Prime (V1): [`0x15A1AC7fA14C5900Ba93853375d66b6bB6A83B50`](https://sepolia.basescan.org/address/0x15A1AC7fA14C5900Ba93853375d66b6bB6A83B50)
 * Prime Liquidity Provider: [`0xb5BA66311C5f9A5C9d3CeE0183F5426DD694dE37`](https://sepolia.basescan.org/address/0xb5BA66311C5f9A5C9d3CeE0183F5426DD694dE37)
 * ProtocolShareReserve: [`0x4Ae3D77Ece08Ec3E5f5842B195f746bd3bCb8d73`](https://sepolia.basescan.org/address/0x4Ae3D77Ece08Ec3E5f5842B195f746bd3bCb8d73)
 
@@ -146,15 +162,15 @@
 * Venus Treasury: [`0x958F4C84d3ad523Fa9936Dc465A123C7AD43D69B`](https://uniscan.xyz/address/0x958F4C84d3ad523Fa9936Dc465A123C7AD43D69B)
 * XVS Vault Proxy: [`0x5ECa0FBBc5e7bf49dbFb1953a92784F8e4248eF6`](https://uniscan.xyz/address/0x5ECa0FBBc5e7bf49dbFb1953a92784F8e4248eF6)
 * XVS Store: [`0x0ee4b35c2cEAb19856Bf35505F81608d12B2a7Bb`](https://uniscan.xyz/address/0x0ee4b35c2cEAb19856Bf35505F81608d12B2a7Bb)
-* Prime: [`0x600aFf613d40D87C8Fe90Cb2e78e8e6667c0C872`](https://uniscan.xyz/address/0x600aFf613d40D87C8Fe90Cb2e78e8e6667c0C872)
-* Prime Liquidity Provider: [`0x045a45603E1b073F444fe3Be7d5C7e0a5035afB7`](https://uniscan.xyz/address/0x045a45603E1b073F444fe3Be7d5C7e0a5035afB7)
+* Prime (V1): [`0x600aFf613d40D87C8Fe90Cb2e78e8e6667c0C872`](https://uniscan.xyz/address/0x600aFf613d40D87C8Fe90Cb2e78e8e6667c0C872)
+* Prime Liquidity Provider (V1; paused, time-based at the checkpoint): [`0x045a45603E1b073F444fe3Be7d5C7e0a5035afB7`](https://uniscan.xyz/address/0x045a45603E1b073F444fe3Be7d5C7e0a5035afB7)
 * ProtocolShareReserve: [`0x0A93fBcd7B53CE6D335cAB6784927082AD75B242`](https://uniscan.xyz/address/0x0A93fBcd7B53CE6D335cAB6784927082AD75B242)
 
-## Unichain Sepolia
+## Unichain Sepolia (Test-only)
 
 * Venus Treasury: [`0x0C7CB62F2194cD701bcE8FD8067b43A3Bb76428e`](https://sepolia.uniscan.xyz/address/0x0C7CB62F2194cD701bcE8FD8067b43A3Bb76428e)
 * XVS Vault Proxy: [`0x3a33d235E23B6B54004E25FF8E622228df16717a`](https://sepolia.uniscan.xyz/address/0x3a33d235E23B6B54004E25FF8E622228df16717a)
 * XVS Store: [`0xeE012BeFEa825a21b6346EF0f78249740ca2569b`](https://sepolia.uniscan.xyz/address/0xeE012BeFEa825a21b6346EF0f78249740ca2569b)
-* Prime: [`0x59b95BF96D6D5FA1adf1Bfd20848A9b25814317A`](https://sepolia.uniscan.xyz/address/0x59b95BF96D6D5FA1adf1Bfd20848A9b25814317A)
+* Prime (V1): [`0x59b95BF96D6D5FA1adf1Bfd20848A9b25814317A`](https://sepolia.uniscan.xyz/address/0x59b95BF96D6D5FA1adf1Bfd20848A9b25814317A)
 * Prime Liquidity Provider: [`0xDA4dcFBdC06A9947100a757Ee0eeDe88debaD586`](https://sepolia.uniscan.xyz/address/0xDA4dcFBdC06A9947100a757Ee0eeDe88debaD586)
 * ProtocolShareReserve: [`0xcCcFc9B37A5575ae270352CC85D55C3C52a646C0`](https://sepolia.uniscan.xyz/address/0xcCcFc9B37A5575ae270352CC85D55C3C52a646C0)

--- a/deployed-contracts/oracles.md
+++ b/deployed-contracts/oracles.md
@@ -1,5 +1,13 @@
 # Oracles - Deployed Contracts
 
+This page is a deployment registry, not a list of oracle instances currently consumed by every market. An address can remain deployed after a token configuration changes. Before using a row, read the live `ResilientOracle.getTokenConfig(asset)`, proxy implementation, pause/cache state, feed state, bounds, and the associated market configuration.
+
+The stable deployment/source baseline for these rows is [`oracle` v2.16.0](https://github.com/VenusProtocol/oracle/tree/v2.16.0). The on-chain proxy and token configuration remain authoritative.
+
+{% hint style="warning" %}
+Expiry-dated Pendle rows are retained deployment addresses. A maturity date in the past does not by itself prove that an oracle was removed from every consumer, nor does a deployed address prove it is still enabled. Every testnet section is **Test-only**.
+{% endhint %}
+
 ## BNB Chain Mainnet
 
 * Binance Oracle: [`0x594810b741d136f1960141C0d8Fb4a91bE78A820`](https://bscscan.com/address/0x594810b741d136f1960141C0d8Fb4a91bE78A820)
@@ -22,6 +30,8 @@
 * OneJump Oracle wstETH/ETH/USD (having intermediate oracle Redstone): [`0x90dd7ae1137cC072F7740Ee0b264f2351515B98A`](https://bscscan.com/address/0x90dd7ae1137cC072F7740Ee0b264f2351515B98A)
 * OneJump Oracle weETH/ETH/USD (having intermediate oracle Chainlink): [`0x3b3241698692906310A65ACA199701843404E175`](https://bscscan.com/address/0x3b3241698692906310A65ACA199701843404E175)
 * OneJump Oracle weETH/ETH/USD (having intermediate oracle Redstone): [`0xb661102c399630420A4B9fa0a5cF57161e5452F5`](https://bscscan.com/address/0xb661102c399630420A4B9fa0a5cF57161e5452F5)
+* SolvBTC OneJump Chainlink Oracle (enabled MAIN at BNB block `118373320`): [`0x3f4bC081E749032cffF29dcA2E8408Ec375e745A`](https://bscscan.com/address/0x3f4bC081E749032cffF29dcA2E8408Ec375e745A)
+* SolvBTC OneJump Fundamental Oracle (enabled PIVOT at BNB block `118373320`): [`0x1f785B1AFE0808d69d1188db9e47b7B9Dd95ab09`](https://bscscan.com/address/0x1f785B1AFE0808d69d1188db9e47b7B9Dd95ab09)
 * OneJump Oracle SolvBTC.BBN/BTC/USD (having intermediate oracle Redstone): [`0x98B9bC5a1e7E439ebEB0BEdB7e9f6b24fEc1E8B4`](https://bscscan.com/address/0x98B9bC5a1e7E439ebEB0BEdB7e9f6b24fEc1E8B4)
 * OneJump Oracle sUSDe/USDe/USD (having intermediate oracle Redstone): [`0x2B2895104f958E1EC042E6Ba5cbfeCbAD3C5beDb`](https://bscscan.com/address/0x2B2895104f958E1EC042E6Ba5cbfeCbAD3C5beDb)
 * OneJump Oracle sUSDe/USDe/USD (having intermediate oracle Chainlink): [`0xA67F01322AF8EBa444D788Ee398775b446de51a0`](https://bscscan.com/address/0xA67F01322AF8EBa444D788Ee398775b446de51a0)
@@ -37,7 +47,7 @@
 * Atlas Oracle: [`0x9E6928Ec418948ceb9f1cd9872fD312b13D841D0`](https://bscscan.com/address/0x9E6928Ec418948ceb9f1cd9872fD312b13D841D0)
 * APRO Oracle: [`0x04480f1Ba2252CDF89deB022B58d0a03d1B4cF91`](https://bscscan.com/address/0x04480f1Ba2252CDF89deB022B58d0a03d1B4cF91)
 
-## BNB Chain Testnet
+## BNB Chain Testnet (Test-only)
 
 * Binance Oracle:[`0xB58BFDCE610042311Dc0e034a80Cc7776c1D68f5`](https://testnet.bscscan.com/address/0xB58BFDCE610042311Dc0e034a80Cc7776c1D68f5)
 * Bound Validator:[`0x2842140e4Ad3a92e9af30e27e290300dd785076d`](https://testnet.bscscan.com/address/0x2842140e4Ad3a92e9af30e27e290300dd785076d)
@@ -98,7 +108,7 @@
 * yvWETH-1 ERC4626 Oracle:[`0x38b3643c1b5160591073cc4121Bd91A456F14Acd`](https://etherscan.io/address/0x38b3643c1b5160591073cc4121Bd91A456F14Acd)
 * eBTC Oracle:[`0x04d6096A6F089047C7af6E4644D18fB766B8d4cE`](https://etherscan.io/address/0x04d6096A6F089047C7af6E4644D18fB766B8d4cE)
 
-## Sepolia (Ethereum testnet)
+## Sepolia (Ethereum testnet; Test-only)
 
 * Bound Validator:[`0x60c4Aa92eEb6884a76b309Dd8B3731ad514d6f9B`](https://sepolia.etherscan.io/address/0x60c4Aa92eEb6884a76b309Dd8B3731ad514d6f9B)
 * Chainlink Oracle:[`0x102F0b714E5d321187A4b6E5993358448f7261cE`](https://sepolia.etherscan.io/address/0x102F0b714E5d321187A4b6E5993358448f7261cE)
@@ -134,7 +144,7 @@
 * Resilient Oracle:[`0x8f3618c4F0183e14A218782c116fb2438571dAC9`](https://opbnbscan.com/address/0x8f3618c4F0183e14A218782c116fb2438571dAC9)
 * DefaultProxyAdmin:[`0xF77bD1D893F67b3EB2Cd256239c98Ba3F238fb52`](https://opbnbscan.com/address/0xF77bD1D893F67b3EB2Cd256239c98Ba3F238fb52)
 
-## opBNB testnet
+## opBNB testnet (Test-only)
 
 * Bound Validator:[`0x049537Bb065e6253e9D8D08B45Bf6b753657A746`](https://testnet.opbnbscan.com/address/0x049537Bb065e6253e9D8D08B45Bf6b753657A746)
 * Binance Oracle:[`0x496B6b03469472572C47bdB407d5549b244a74F2`](https://testnet.opbnbscan.com/address/0x496B6b03469472572C47bdB407d5549b244a74F2)
@@ -151,7 +161,7 @@
 * OneJump Oracle weETH/eETH/USD (having intermediate oracle Chainlink): [`0x0afD33490fBcF537ede00F9Cc4607230bBf65774`](https://arbiscan.io/address/0x0afD33490fBcF537ede00F9Cc4607230bBf65774)
 * OneJump Oracle wstETH/stETH/USD (having intermediate oracle Chainlink): [`0x17a5596DF05c7bfB2280D5B9cCcDAf711e957Ed4`](https://arbiscan.io/address/0x17a5596DF05c7bfB2280D5B9cCcDAf711e957Ed4)
 
-## Arbitrum Sepolia
+## Arbitrum Sepolia (Test-only)
 
 * Bound Validator:[`0xfe6bc1545Cc14C131bacA97476D6035ffcC0b889`](https://sepolia.arbiscan.io/address/0xfe6bc1545Cc14C131bacA97476D6035ffcC0b889)
 * Chainlink Oracle:[`0xeDd02c7FfA31490b4107e8f2c25e9198a04F9E45`](https://sepolia.arbiscan.io/address/0xeDd02c7FfA31490b4107e8f2c25e9198a04F9E45)
@@ -172,7 +182,7 @@
 * wUSDM ERC4626 Oracle:[`0x22cE94e302c8C80a6C2dCfa9Da6c5286e9f28692`](https://explorer.zksync.io/address/0x22cE94e302c8C80a6C2dCfa9Da6c5286e9f28692)
 * zkETH Oracle: [`0x407dE1229BCBD2Ec876d063F3F93c4D8a38bd81a`](https://explorer.zksync.io/address/0x407dE1229BCBD2Ec876d063F3F93c4D8a38bd81a)
 
-## ZKsync Sepolia
+## ZKsync Sepolia (Test-only)
 
 * Bound Validator:[`0x0A4daBeF41C83Af7e30FfC33feC56ba769f3D24b`](https://sepolia.explorer.zksync.io/address/0x0A4daBeF41C83Af7e30FfC33feC56ba769f3D24b)
 * Chainlink Oracle:[`0x0DFf10dCdb3526010Df01ECc42076C25C27F8323`](https://sepolia.explorer.zksync.io/address/0x0DFf10dCdb3526010Df01ECc42076C25C27F8323)
@@ -191,7 +201,7 @@
 * Resilient Oracle:[`0x21FC48569bd3a6623281f55FC1F8B48B9386907b`](https://optimistic.etherscan.io/address/0x21FC48569bd3a6623281f55FC1F8B48B9386907b)
 * DefaultProxyAdmin:[`0xeaF9490cBEA6fF9bA1D23671C39a799CeD0DCED2`](https://optimistic.etherscan.io/address/0xeaF9490cBEA6fF9bA1D23671C39a799CeD0DCED2)
 
-## Optimism Sepolia
+## Optimism Sepolia (Test-only)
 
 * Bound Validator:[`0x482469F1DA6Ec736cacF6361Ec41621f811A6800`](https://sepolia-optimism.etherscan.io/address/0x482469F1DA6Ec736cacF6361Ec41621f811A6800)
 * Chainlink Oracle:[`0x493C3f543AEa37EefF17D823f27Cb1feAB9f3143`](https://sepolia-optimism.etherscan.io/address/0x493C3f543AEa37EefF17D823f27Cb1feAB9f3143)
@@ -206,9 +216,9 @@
 * Resilient Oracle:[`0xcBBf58bD5bAdE357b634419B70b215D5E9d6FbeD`](https://basescan.org/address/0xcBBf58bD5bAdE357b634419B70b215D5E9d6FbeD)
 * DefaultProxyAdmin:[`0x7B06EF6b68648C61aFE0f715740fE3950B90746B`](https://basescan.org/address/0x7B06EF6b68648C61aFE0f715740fE3950B90746B)
 * wsuperOETHb ERC4626 Oracle:[`0xcd1d2C99642165440c2CC023AFa2092b487f033e`](https://basescan.org/address/0xcd1d2C99642165440c2CC023AFa2092b487f033e)
-* OneJump Oracle wstETH/ETH/USD (having intermediate oracle Chainlink): [`0xDDD4F0836c8016E11fC6741A4886E97B3c3d20C1`](https:///basescan.org/address/0xDDD4F0836c8016E11fC6741A4886E97B3c3d20C1)
+* OneJump Oracle wstETH/ETH/USD (having intermediate oracle Chainlink): [`0xDDD4F0836c8016E11fC6741A4886E97B3c3d20C1`](https://basescan.org/address/0xDDD4F0836c8016E11fC6741A4886E97B3c3d20C1)
 
-## Base Sepolia
+## Base Sepolia (Test-only)
 
 * Bound Validator:[`0xC76284488E57554A457A75a8b166fB2ADAB430dB`](https://sepolia.basescan.org/address/0xC76284488E57554A457A75a8b166fB2ADAB430dB)
 * Chainlink Oracle:[`0x801aB33A69AD867500fbCda7b3dB66C73151494b`](https://sepolia.basescan.org/address/0x801aB33A69AD867500fbCda7b3dB66C73151494b)
@@ -226,7 +236,7 @@
 * weETHOneJumpOracle (having intermediate oracle RedStone): [`0xF9ECA470E2458Fe2B6FcAe660bEd1e2C0FB87E01`](https://uniscan.xyz/address/0xF9ECA470E2458Fe2B6FcAe660bEd1e2C0FB87E01)
 * wstETHOneJumpOracle (having intermediate oracle RedStone): [`0x3938D6414c261C6F450f1bD059DF9af2BBfb603D`](https://uniscan.xyz/address/0x3938D6414c261C6F450f1bD059DF9af2BBfb603D)
 
-## Unichain Sepolia
+## Unichain Sepolia (Test-only)
 
 * Bound Validator:[`0x51C9F57Ffc0A4dD6d135aa3b856571F5A4e4C6CB`](https://sepolia.uniscan.xyz/address/0x51C9F57Ffc0A4dD6d135aa3b856571F5A4e4C6CB)
 * DefaultProxyAdmin:[`0x256735eFdfDf135bD6991854e0065909e57804aa`](https://sepolia.uniscan.xyz/address/0x256735eFdfDf135bD6991854e0065909e57804aa)


### PR DESCRIPTION
## Summary
- separate PrimeV2 from Prime V1 and label recorded PLP pause/time modes across seven mainnets
- identify current RiskFundV2 versus legacy paused Shortfall, add six stable XVSVaultTreasury deployments, and mark all testnets test-only
- add two BNB SolvBTC oracles proven enabled as MAIN/PIVOT, fix the malformed Base explorer link, and clarify oracle-consumer trust boundaries

## Validation
- targeted Remark checks pass and git diff --check is clean
- all 306 address rows match their explorer URL targets
- all 32 network sections use the expected explorer domain
- stable v10.3.0, v3.5.0, and v2.16.0 source links resolve
- recorded-block reads verify PLP pause/time/prime state, BNB RiskFundV2/Shortfall state, XVSVaultTreasury proxy/configuration, and SolvBTC token config
- no file overlap with earlier audit PRs