### PR TITLE
docs: add lifecycle boundaries to remaining registries

### DIFF
--- a/deployed-contracts/fixed-rate-vaults.md
+++ b/deployed-contracts/fixed-rate-vaults.md
@@ -2,6 +2,12 @@
 
 Core contracts for the Fixed Term Vaults system. Each institution's vault is deployed as an EIP-1167 clone by governance via `createVault(...)` on `InstitutionalVaultController`. The canonical, always-current list of deployed vaults lives on-chain — query the controller's `allVaults` array (or the `VaultCreated` event log). The vaults known at the time of writing are listed below for convenience.
 
+The stable implementation and deployment baseline is [`fixed-rate-vaults` v1.0.0](https://github.com/VenusProtocol/fixed-rate-vaults/tree/v1.0.0). Proxy implementations, vault state, terms, balances, pause levels, owners, permissions, and liquidation whitelists can change. Verify the live controller, vault, and adapter before interacting.
+
+{% hint style="warning" %}
+The mainnet vault list and states below are a checkpoint at BNB block `118374393` (August 27, 2026), not an offer. `allVaultsLength()` returned three. State `Matured` means the original term has ended; state `Fundraising` can change as time and governance actions advance the state machine. The testnet section is **Test-only**.
+{% endhint %}
+
 ## BNB Chain Mainnet
 
 ### Fixed Term Vaults Contracts
@@ -12,13 +18,15 @@ Core contracts for the Fixed Term Vaults system. Each institution's vault is dep
 
 #### Deployed vaults
 
-* Vault, position token ID `1`: [`0x7D80A10bEdD13638888e7A946B82878E21fbB820`](https://bscscan.com/address/0x7D80A10bEdD13638888e7A946B82878E21fbB820) — USDT supplied against XAUM collateral over a 30-day term, at a 6% fixed borrow rate; after the 10% reserve factor, suppliers earn 5.4% net.
+* Matrixdock vault, position token ID `1` (**Matured** at the checkpoint): [`0x7D80A10bEdD13638888e7A946B82878E21fbB820`](https://bscscan.com/address/0x7D80A10bEdD13638888e7A946B82878E21fbB820) — its original terms were USDT supplied against XAUM collateral over 30 days at a 6% fixed borrow rate and 10% reserve factor; this is not a current 5.4% supplier offer.
+* Asseto vault, position token ID `2` (**Fundraising** at the checkpoint): [`0x41179fc6ff878b7795B900888E0B61fd8029bceA`](https://bscscan.com/address/0x41179fc6ff878b7795B900888E0B61fd8029bceA)
+* Solv (Ceffu custody) vault, position token ID `3` (**Fundraising** at the checkpoint): [`0x086fd7972510dF9d9cFdc4efB8677fc72d290103`](https://bscscan.com/address/0x086fd7972510dF9d9cFdc4efB8677fc72d290103)
 
 #### Liquidation whitelist
 
-Liquidation entry points on each vault are reachable only through the `LiquidationAdapter`, which keeps two independent, governance-managed lists: one for health-based liquidators and one for overdue settlers (set via `setLiquidatorWhitelist` and `setSettlerWhitelist`). As currently configured on BNB Chain mainnet, both lists contain a single entry — the Venus Critical Guardian multisig [`0x7B1AE5Ea599bC56734624b95589e7E8E64C351c9`](https://bscscan.com/address/0x7B1AE5Ea599bC56734624b95589e7E8E64C351c9) — so it is the only address that can currently perform either a health-based or an overdue liquidation. Governance can add or remove entries on either list at any time. The permissionless `repayBadDebt` path on each vault is independent of these lists and remains open to any address.
+Liquidation entry points on each vault are reachable only through the `LiquidationAdapter`, which keeps two independent, governance-managed mappings: one for health-based liquidators and one for overdue settlers (set via `setLiquidatorWhitelist` and `setSettlerWhitelist`). At the checkpoint, the Venus Critical Guardian multisig [`0x7B1AE5Ea599bC56734624b95589e7E8E64C351c9`](https://bscscan.com/address/0x7B1AE5Ea599bC56734624b95589e7E8E64C351c9) returned `true` in both mappings. The mappings are not enumerable, so this does not prove it is the only authorized address; reconstruct the update events and re-read the selected caller. The permissionless `repayBadDebt` path on each vault is independent of these mappings.
 
-## BNB Chain Testnet
+## BNB Chain Testnet (Test-only)
 
 ### Fixed Term Vaults Contracts
 

--- a/deployed-contracts/governance.md
+++ b/deployed-contracts/governance.md
@@ -1,16 +1,22 @@
 # Governance - Deployed Contracts
 
+This registry is a deployment inventory, not a current authority map. The source and deployment baseline is [`governance-contracts` v2.15.0](https://github.com/VenusProtocol/governance-contracts/tree/v2.15.0). Proxy implementations and owners, AccessControlManager permissions, timelock roles, executor routes, and guardian scopes can change after deployment; verify current on-chain state before relying on an address or role label.
+
+{% hint style="warning" %}
+Since [VIP-645](https://app.venus.io/#/governance/proposal/645?chainId=56), the Critical Timelock has no permissions on any network. Its rows below are retained as deployed and historical addresses, not active authorities. Guardian descriptions are also historical role labels and require current permission checks. Testnet deployments are test-only.
+{% endhint %}
+
 ## BNB Chain Mainnet
 
 * Governor Bravo Delegator: [`0x2d56dc077072b53571b8252008c60e945108c75a`](https://bscscan.com/address/0x2d56dc077072b53571b8252008c60e945108c75a)
 * Access Control Manager: [`0x4788629abc6cfca10f9f969efdeaa1cf70c23555`](https://bscscan.com/address/0x4788629abc6cfca10f9f969efdeaa1cf70c23555)
 * Normal Timelock: [`0x939bD8d64c0A9583A7Dcea9933f7b21697ab6396`](https://bscscan.com/address/0x939bD8d64c0A9583A7Dcea9933f7b21697ab6396)
 * FastTrack Timelock: [`0x555ba73dB1b006F3f2C7dB7126d6e4343aDBce02`](https://bscscan.com/address/0x555ba73dB1b006F3f2C7dB7126d6e4343aDBce02)
-* Critical Timelock: [`0x213c446ec11e45b15a6E29C1C1b402B8897f606d`](https://bscscan.com/address/0x213c446ec11e45b15a6E29C1C1b402B8897f606d)
+* Critical Timelock (deployed; no current permissions after VIP-645): [`0x213c446ec11e45b15a6E29C1C1b402B8897f606d`](https://bscscan.com/address/0x213c446ec11e45b15a6E29C1C1b402B8897f606d)
 * Guardians:
-  * Guardian 1: [`0x7B1AE5Ea599bC56734624b95589e7E8E64C351c9`](https://bscscan.com/address/0x7B1AE5Ea599bC56734624b95589e7E8E64C351c9) - critical risk parameters
-  * Guardian 2: [`0x1C2CAc6ec528c20800B2fe734820D87b581eAA6B`](https://bscscan.com/address/0x1C2CAc6ec528c20800B2fe734820D87b581eAA6B) - pause and resume features
-  * Guardian 3: [`0x3a3284dC0FaFfb0b5F0d074c4C704D14326C98cF`](https://bscscan.com/address/0x3a3284dC0FaFfb0b5F0d074c4C704D14326C98cF) - oracles
+  * Guardian 1: [`0x7B1AE5Ea599bC56734624b95589e7E8E64C351c9`](https://bscscan.com/address/0x7B1AE5Ea599bC56734624b95589e7E8E64C351c9) - historical label: critical risk parameters
+  * Guardian 2: [`0x1C2CAc6ec528c20800B2fe734820D87b581eAA6B`](https://bscscan.com/address/0x1C2CAc6ec528c20800B2fe734820D87b581eAA6B) - historical label: pause and resume features
+  * Guardian 3: [`0x3a3284dC0FaFfb0b5F0d074c4C704D14326C98cF`](https://bscscan.com/address/0x3a3284dC0FaFfb0b5F0d074c4C704D14326C98cF) - historical label: oracles
 * Omnichain Proposal Sender: [`0x36a69dE601381be7b0DcAc5D5dD058825505F8f6`](https://bscscan.com/address/0x36a69dE601381be7b0DcAc5D5dD058825505F8f6)
 * RiskStewardReceiver: [`0x47856bFa74B71d24a5545c7506862B8FddE52baB`](https://bscscan.com/address/0x47856bFa74B71d24a5545c7506862B8FddE52baB)
 * MarketCapsRiskSteward: [`0x816FfD00A274EDE0091421F77817ca260Db3a3E3`](https://bscscan.com/address/0x816FfD00A274EDE0091421F77817ca260Db3a3E3)
@@ -18,13 +24,13 @@
 * InterestRateModelRiskSteward: [`0x8acaBc42Bb98E2e2b091902a7E23f60CcB730aaa`](https://bscscan.com/address/0x8acaBc42Bb98E2e2b091902a7E23f60CcB730aaa)
 * RiskOracle (managed by the risk manager): [`0x0E3E51958b0Daa8C57c949675975CBEDd7b5a1a1`](https://bscscan.com/address/0x0E3E51958b0Daa8C57c949675975CBEDd7b5a1a1)
 
-## BNB Chain Testnet
+## BNB Chain Testnet (Test-only)
 
 * Governor Bravo Delegator: [`0x5573422a1a59385c247ec3a66b93b7c08ec2f8f2`](https://testnet.bscscan.com/address/0x5573422a1a59385c247ec3a66b93b7c08ec2f8f2)
 * Access Control Manager: [`0x45f8a08F534f34A97187626E05d4b6648Eeaa9AA`](https://testnet.bscscan.com/address/0x45f8a08F534f34A97187626E05d4b6648Eeaa9AA)
 * Normal Timelock: [`0xce10739590001705F7FF231611ba4A48B2820327`](https://testnet.bscscan.com/address/0xce10739590001705F7FF231611ba4A48B2820327)
 * FastTrack Timelock: [`0x3CFf21b7AF8390fE68799D58727d3b4C25a83cb6`](https://testnet.bscscan.com/address/0x3CFf21b7AF8390fE68799D58727d3b4C25a83cb6)
-* Critical Timelock: [`0x23B893a7C45a5Eb8c8C062b9F32d0D2e43eD286D`](https://testnet.bscscan.com/address/0x23B893a7C45a5Eb8c8C062b9F32d0D2e43eD286D)
+* Critical Timelock (deployed; no current permissions after VIP-645): [`0x23B893a7C45a5Eb8c8C062b9F32d0D2e43eD286D`](https://testnet.bscscan.com/address/0x23B893a7C45a5Eb8c8C062b9F32d0D2e43eD286D)
 * Omnichain Proposal Sender: [`0xCfD34AEB46b1CB4779c945854d405E91D27A1899`](https://testnet.bscscan.com/address/0xCfD34AEB46b1CB4779c945854d405E91D27A1899)
 * RiskStewardReceiver: [`0x2F6eb64826f3A067eBFFb5909De7AA4e0Cb31b81`](https://testnet.bscscan.com/address/0x2F6eb64826f3A067eBFFb5909De7AA4e0Cb31b81)
 * MarketCapsRiskSteward: [`0xecC583037338D1EFE2C15bb2c6ac81E0294375C2`](https://testnet.bscscan.com/address/0xecC583037338D1EFE2C15bb2c6ac81E0294375C2)
@@ -38,16 +44,16 @@
 * Guardian: [`0x285960C5B22fD66A736C7136967A3eB15e93CC67`](https://etherscan.io/address/0x285960C5B22fD66A736C7136967A3eB15e93CC67)
 * Normal Timelock: [`0xd969E79406c35E80750aAae061D402Aab9325714`](https://etherscan.io/address/0xd969E79406c35E80750aAae061D402Aab9325714)
 * FastTrack Timelock: [`0x8764F50616B62a99A997876C2DEAaa04554C5B2E`](https://etherscan.io/address/0x8764F50616B62a99A997876C2DEAaa04554C5B2E)
-* Critical Timelock: [`0xeB9b85342c34F65af734C7bd4a149c86c472bC00`](https://etherscan.io/address/0xeB9b85342c34F65af734C7bd4a149c86c472bC00)
+* Critical Timelock (deployed; no current permissions after VIP-645): [`0xeB9b85342c34F65af734C7bd4a149c86c472bC00`](https://etherscan.io/address/0xeB9b85342c34F65af734C7bd4a149c86c472bC00)
 * Omnichain Governance Executor: [`0xd70ffB56E4763078b8B814C0B48938F35D83bE0C`](https://etherscan.io/address/0xd70ffB56E4763078b8B814C0B48938F35D83bE0C)
 * Omnichain Executor Owner Proxy: [`0x87Ed3Fd3a25d157637b955991fb1B41B566916Ba`](https://etherscan.io/address/0x87Ed3Fd3a25d157637b955991fb1B41B566916Ba)
-## Sepolia (Ethereum testnet)
+## Sepolia (Ethereum testnet; Test-only)
 
 * Access Control Manager: [`0xbf705C00578d43B6147ab4eaE04DBBEd1ccCdc96`](https://sepolia.etherscan.io/address/0xbf705C00578d43B6147ab4eaE04DBBEd1ccCdc96)
 * Guardian: [`0x94fa6078b6b8a26f0b6edffbe6501b22a10470fb`](https://sepolia.etherscan.io/address/0x94fa6078b6b8a26f0b6edffbe6501b22a10470fb)
 * Normal Timelock: [`0xc332F7D8D5eA72cf760ED0E1c0485c8891C6E0cF`](https://sepolia.etherscan.io/address/0xc332F7D8D5eA72cf760ED0E1c0485c8891C6E0cF)
 * FastTrack Timelock: [`0x7F043F43Adb392072a3Ba0cC9c96e894C6f7e182`](https://sepolia.etherscan.io/address/0x7F043F43Adb392072a3Ba0cC9c96e894C6f7e182)
-* Critical Timelock: [`0xA24A7A65b8968a749841988Bd7d05F6a94329fDe`](https://sepolia.etherscan.io/address/0xA24A7A65b8968a749841988Bd7d05F6a94329fDe)
+* Critical Timelock (deployed; no current permissions after VIP-645): [`0xA24A7A65b8968a749841988Bd7d05F6a94329fDe`](https://sepolia.etherscan.io/address/0xA24A7A65b8968a749841988Bd7d05F6a94329fDe)
 * Omnichain Governance Executor: [`0xD9B18a43Ee9964061c1A1925Aa907462F0249109`](https://sepolia.etherscan.io/address/0xD9B18a43Ee9964061c1A1925Aa907462F0249109)
 * Omnichain Executor Owner Proxy: [`0xf964158C67439D01e5f17F0A3F39DfF46823F27A`](https://sepolia.etherscan.io/address/0xf964158C67439D01e5f17F0A3F39DfF46823F27A)
 ## opBNB mainnet
@@ -56,17 +62,17 @@
 * Guardian: [`0xC46796a21a3A9FAB6546aF3434F2eBfFd0604207`](https://opbnbscan.com/address/0xC46796a21a3A9FAB6546aF3434F2eBfFd0604207)
 * Normal Timelock: [`0x10f504e939b912569Dca611851fDAC9E3Ef86819`](https://opbnbscan.com/address/0x10f504e939b912569Dca611851fDAC9E3Ef86819)
 * FastTrack Timelock: [`0xEdD04Ecef0850e834833789576A1d435e7207C0d`](https://opbnbscan.com/address/0xEdD04Ecef0850e834833789576A1d435e7207C0d)
-* Critical Timelock: [`0xA7DD2b15B24377296F11c702e758cd9141AB34AA`](https://opbnbscan.com/address/0xA7DD2b15B24377296F11c702e758cd9141AB34AA)
+* Critical Timelock (deployed; no current permissions after VIP-645): [`0xA7DD2b15B24377296F11c702e758cd9141AB34AA`](https://opbnbscan.com/address/0xA7DD2b15B24377296F11c702e758cd9141AB34AA)
 * Omnichain Governance Executor: [`0x82598878Adc43F1013A27484E61ad663c5d50A03`](https://opbnbscan.com/address/0x82598878Adc43F1013A27484E61ad663c5d50A03)
 * Omnichain Executor owner proxy: [`0xf7e4c81Cf4A03d52472a4d00c3d9Ef35aF127E45`](https://opbnbscan.com/address/0xf7e4c81Cf4A03d52472a4d00c3d9Ef35aF127E45)
 
-## opBNB testnet
+## opBNB testnet (Test-only)
 
 * Access Control Manager: [`0x049f77F7046266d27C3bC96376f53C17Ef09c986`](https://testnet.opbnbscan.com/address/0x049f77F7046266d27C3bC96376f53C17Ef09c986)
 * Guardian: [`0xb15f6EfEbC276A3b9805df81b5FB3D50C2A62BDf`](https://testnet.opbnbscan.com/address/0xb15f6EfEbC276A3b9805df81b5FB3D50C2A62BDf)
 * Normal Timelock: [`0x1c4e015Bd435Efcf4f58D82B0d0fBa8fC4F81120`](https://testnet.opbnbscan.com/address/0x1c4e015Bd435Efcf4f58D82B0d0fBa8fC4F81120)
 * FastTrack Timelock: [`0xB2E6268085E75817669479b22c73C2AfEaADF7A6`](https://testnet.opbnbscan.com/address/0xB2E6268085E75817669479b22c73C2AfEaADF7A6)
-* Critical Timelock: [`0xBd06aCDEF38230F4EdA0c6FD392905Ad463e42E3`](https://testnet.opbnbscan.com/address/0xBd06aCDEF38230F4EdA0c6FD392905Ad463e42E3)
+* Critical Timelock (deployed; no current permissions after VIP-645): [`0xBd06aCDEF38230F4EdA0c6FD392905Ad463e42E3`](https://testnet.opbnbscan.com/address/0xBd06aCDEF38230F4EdA0c6FD392905Ad463e42E3)
 * Omnichain Governance Executor: [`0x0aa644c4408268E9fED5089A113470B6e706bc0C`](https://testnet.opbnbscan.com/address/0x0aa644c4408268E9fED5089A113470B6e706bc0C)
 * Omnichain Executor Owner Proxy: [`0x4F570240FF6265Fbb1C79cE824De6408F1948913`](https://testnet.opbnbscan.com/address/0x4F570240FF6265Fbb1C79cE824De6408F1948913)
 
@@ -76,17 +82,17 @@
 * Guardian: [`0x14e0E151b33f9802b3e75b621c1457afc44DcAA0`](https://arbiscan.io/address/0x14e0e151b33f9802b3e75b621c1457afc44dcaa0)
 * Normal Timelock: [`0x4b94589Cc23F618687790036726f744D602c4017`](https://arbiscan.io/address/0x4b94589Cc23F618687790036726f744D602c4017)
 * Fasttrack Timelock: [`0x2286a9B2a5246218f2fC1F380383f45BDfCE3E04`](https://arbiscan.io/address/0x2286a9B2a5246218f2fC1F380383f45BDfCE3E04)
-* Critical Timelock: [`0x181E4f8F21D087bF02Ea2F64D5e550849FBca674`](https://arbiscan.io/address/0x181E4f8F21D087bF02Ea2F64D5e550849FBca674)
+* Critical Timelock (deployed; no current permissions after VIP-645): [`0x181E4f8F21D087bF02Ea2F64D5e550849FBca674`](https://arbiscan.io/address/0x181E4f8F21D087bF02Ea2F64D5e550849FBca674)
 * Omnichain Governance Executor: [`0xc1858cCE6c28295Efd3eE742795bDa316D7c7526`](https://arbiscan.io/address/0xc1858cCE6c28295Efd3eE742795bDa316D7c7526)
 * Omnichain Executor Owner Proxy: [`0xf72C1Aa0A1227B4bCcB28E1B1015F0616E2db7fD`](https://arbiscan.io/address/0xf72C1Aa0A1227B4bCcB28E1B1015F0616E2db7fD)
 
-## Arbitrum Sepolia
+## Arbitrum Sepolia (Test-only)
 
 * Access Control Manager: [`0xa36AD96441cB931D8dFEAAaC97D3FaB4B39E590F`](https://sepolia.arbiscan.io/address/0xa36AD96441cB931D8dFEAAaC97D3FaB4B39E590F)
 * Guardian: [`0x1426A5Ae009c4443188DA8793751024E358A61C2`](https://sepolia.arbiscan.io/address/0x1426A5Ae009c4443188DA8793751024E358A61C2)
 * Normal Timelock: [`0x794BCA78E606f3a462C31e5Aba98653Efc1322F8`](https://sepolia.arbiscan.io/address/0x794BCA78E606f3a462C31e5Aba98653Efc1322F8)
 * Fasttrack Timelock: [`0x14642991184F989F45505585Da52ca6A6a7dD4c8`](https://sepolia.arbiscan.io/address/0x14642991184F989F45505585Da52ca6A6a7dD4c8)
-* Critical Timelock: [`0x0b32Be083f7041608E023007e7802430396a2123`](https://sepolia.arbiscan.io/address/0x0b32Be083f7041608E023007e7802430396a2123)
+* Critical Timelock (deployed; no current permissions after VIP-645): [`0x0b32Be083f7041608E023007e7802430396a2123`](https://sepolia.arbiscan.io/address/0x0b32Be083f7041608E023007e7802430396a2123)
 * Omnichain Governance Executor: [`0xcf3e6972a8e9c53D33b642a2592938944956f138`](https://sepolia.arbiscan.io/address/0xcf3e6972a8e9c53D33b642a2592938944956f138)
 * Omnichain Executor Owner Proxy: [`0xfCA70dd553b7dF6eB8F813CFEA6a9DD039448878`](https://sepolia.arbiscan.io/address/0xfCA70dd553b7dF6eB8F813CFEA6a9DD039448878)
 ## ZKsync Mainnet
@@ -95,17 +101,17 @@
 * Guardian: [`0x751Aa759cfBB6CE71A43b48e40e1cCcFC66Ba4aa`](https://explorer.zksync.io/address/0x751Aa759cfBB6CE71A43b48e40e1cCcFC66Ba4aa)
 * Normal Timelock: [`0x093565Bc20AA326F4209eBaF3a26089272627613`](https://explorer.zksync.io/address/0x093565Bc20AA326F4209eBaF3a26089272627613)
 * Fasttrack Timelock: [`0x32f71c95BC8F9d996f89c642f1a84d06B2484AE9`](https://explorer.zksync.io/address/0x32f71c95BC8F9d996f89c642f1a84d06B2484AE9)
-* Critical Timelock: [`0xbfbc79D4198963e4a66270F3EfB1fdA0F382E49c`](https://explorer.zksync.io/address/0xbfbc79D4198963e4a66270F3EfB1fdA0F382E49c)
+* Critical Timelock (deployed; no current permissions after VIP-645): [`0xbfbc79D4198963e4a66270F3EfB1fdA0F382E49c`](https://explorer.zksync.io/address/0xbfbc79D4198963e4a66270F3EfB1fdA0F382E49c)
 * Omnichain Governance Executor: [`0xA1b56f19CA5E5b15EF29d38238930Ce9f0235312`](https://explorer.zksync.io/address/0xA1b56f19CA5E5b15EF29d38238930Ce9f0235312)
 * Omnichain Executor Owner Proxy: [`0xdfaed3E5d9707629Ed5c225b4fB980c064286771`](https://explorer.zksync.io/address/0xdfaed3E5d9707629Ed5c225b4fB980c064286771)
 
-## ZKsync Sepolia
+## ZKsync Sepolia (Test-only)
 
 * Access Control Manager: [`0xD07f543d47c3a8997D6079958308e981AC14CD01`](https://sepolia.explorer.zksync.io/address/0xD07f543d47c3a8997D6079958308e981AC14CD01)
 * Guardian: [`0xa2f83de95E9F28eD443132C331B6a9C9B7a9F866`](https://sepolia.explorer.zksync.io/address/0xa2f83de95E9F28eD443132C331B6a9C9B7a9F866)
 * Normal Timelock: [`0x1730527a0f0930269313D77A317361b42971a67E`](https://sepolia.explorer.zksync.io/address/0x1730527a0f0930269313D77A317361b42971a67E)
 * Fasttrack Timelock: [`0xb055e028b27d53a455a6c040a6952e44E9E615c4`](https://sepolia.explorer.zksync.io/address/0xb055e028b27d53a455a6c040a6952e44E9E615c4)
-* Critical Timelock: [`0x0E6138bE0FA1915efC73670a20A10EFd720a6Cc8`](https://sepolia.explorer.zksync.io/address/0x0E6138bE0FA1915efC73670a20A10EFd720a6Cc8)
+* Critical Timelock (deployed; no current permissions after VIP-645): [`0x0E6138bE0FA1915efC73670a20A10EFd720a6Cc8`](https://sepolia.explorer.zksync.io/address/0x0E6138bE0FA1915efC73670a20A10EFd720a6Cc8)
 * Omnichain Governance Executor: [`0x83F79CfbaEee738173c0dfd866796743F4E25C9e`](https://sepolia.explorer.zksync.io/address/0x83F79CfbaEee738173c0dfd866796743F4E25C9e)
 * Omnichain Executor Owner Proxy: [`0xa34607D58146FA02aF5f920f29C3D916acAb0bC5`](https://sepolia.explorer.zksync.io/address/0xa34607D58146FA02aF5f920f29C3D916acAb0bC5)
 ## Optimism Mainnet
@@ -114,18 +120,17 @@
 * Guardian: [`0x2e94dd14E81999CdBF5deDE31938beD7308354b3`](https://optimistic.etherscan.io/address/0x2e94dd14E81999CdBF5deDE31938beD7308354b3)
 * Normal Timelock: [`0x0C6f1E6B4fDa846f63A0d5a8a73EB811E0e0C04b`](https://optimistic.etherscan.io/address/0x0C6f1E6B4fDa846f63A0d5a8a73EB811E0e0C04b)
 * Fasttrack Timelock: [`0x508bD9C31E8d6760De04c70fe6c2b24B3cDea7E7`](https://optimistic.etherscan.io/address/0x508bD9C31E8d6760De04c70fe6c2b24B3cDea7E7)
-* Critical Timelock: [`0xB82479bc345CAA7326D7d21306972033226fC185`](https://optimistic.etherscan.io/address/0xB82479bc345CAA7326D7d21306972033226fC185)
+* Critical Timelock (deployed; no current permissions after VIP-645): [`0xB82479bc345CAA7326D7d21306972033226fC185`](https://optimistic.etherscan.io/address/0xB82479bc345CAA7326D7d21306972033226fC185)
 * Omnichain Governance Executor: [`0x09b11b1CAdC08E239970A8993783f0f8EeC60ABf`](https://optimistic.etherscan.io/address/0x09b11b1CAdC08E239970A8993783f0f8EeC60ABf)
 * Omnichain Executor Owner Proxy: [`0xe6d9Eb3A07a1dc4496fc71417D7A7b9d5666BaA3`](https://optimistic.etherscan.io/address/0xe6d9Eb3A07a1dc4496fc71417D7A7b9d5666BaA3)
 
-## Optimism Sepolia
+## Optimism Sepolia (Test-only)
 
 * Access Control Manager: [`0x1652E12C8ABE2f0D84466F0fc1fA4286491B3BC1`](https://sepolia-optimism.etherscan.io/address/0x1652E12C8ABE2f0D84466F0fc1fA4286491B3BC1)
-* Guardian: [`0xd57365EE4E850e881229e2F8Aa405822f289e78d`](https://sepolia-optimism.etherscan.io/address/0xd57365EE4E850e881229e2F8Aa405822f289e78d
-)
+* Guardian: [`0xd57365EE4E850e881229e2F8Aa405822f289e78d`](https://sepolia-optimism.etherscan.io/address/0xd57365EE4E850e881229e2F8Aa405822f289e78d)
 * Normal Timelock: [`0xdDe31d7eEEAD7Cf9790F833C4FF4c6e61404402a`](https://sepolia-optimism.etherscan.io/address/0xdDe31d7eEEAD7Cf9790F833C4FF4c6e61404402a)
 * Fasttrack Timelock: [`0xe0Fa35b6279dd802C382ae54c50C8B16deaC0885`](https://sepolia-optimism.etherscan.io/address/0xe0Fa35b6279dd802C382ae54c50C8B16deaC0885)
-* Critical Timelock: [`0x45d2263c6E0dbF84eBffB1Ee0b80aC740607990B`](https://sepolia-optimism.etherscan.io/address/0x45d2263c6E0dbF84eBffB1Ee0b80aC740607990B)
+* Critical Timelock (deployed; no current permissions after VIP-645): [`0x45d2263c6E0dbF84eBffB1Ee0b80aC740607990B`](https://sepolia-optimism.etherscan.io/address/0x45d2263c6E0dbF84eBffB1Ee0b80aC740607990B)
 * Omnichain Governance Executor: [`0xC7D6D33adcdBfccD416C3aAB1878360ea8b79ac6`](https://sepolia-optimism.etherscan.io/address/0xC7D6D33adcdBfccD416C3aAB1878360ea8b79ac6)
 * Omnichain Executor Owner Proxy: [`0xE92E31df479BC1031B866063F65CF71B6bAC4FC6`](https://sepolia-optimism.etherscan.io/address/0xE92E31df479BC1031B866063F65CF71B6bAC4FC6)
 
@@ -135,17 +140,17 @@
 * Guardian: [`0x1803Cf1D3495b43cC628aa1d8638A981F8CD341C`](https://basescan.org/address/0x1803Cf1D3495b43cC628aa1d8638A981F8CD341C)
 * Normal Timelock: [`0x21c12f2946a1a66cBFf7eb997022a37167eCf517`](https://basescan.org/address/0x21c12f2946a1a66cBFf7eb997022a37167eCf517)
 * Fasttrack Timelock: [`0x209F73Ee2Fa9A72aF3Fa6aF1933A3B58ed3De5D7`](https://basescan.org/address/0x209F73Ee2Fa9A72aF3Fa6aF1933A3B58ed3De5D7)
-* Critical Timelock: [`0x47F65466392ff2aE825d7a170889F7b5b9D8e60D`](https://basescan.org/address/0x47F65466392ff2aE825d7a170889F7b5b9D8e60D)
+* Critical Timelock (deployed; no current permissions after VIP-645): [`0x47F65466392ff2aE825d7a170889F7b5b9D8e60D`](https://basescan.org/address/0x47F65466392ff2aE825d7a170889F7b5b9D8e60D)
 * Omnichain Governance Executor: [`0xE7C56EaA4b6eafCe787B3E1AB8BCa0BC6CBDDb9e`](https://basescan.org/address/0xE7C56EaA4b6eafCe787B3E1AB8BCa0BC6CBDDb9e)
 * Omnichain Executor Owner Proxy: [`0x8BA591f72a90fb379b9a82087b190d51b226F0a9`](https://basescan.org/address/0x8BA591f72a90fb379b9a82087b190d51b226F0a9)
 
-## Base Sepolia
+## Base Sepolia (Test-only)
 
 * Access Control Manager: [`0x724138223D8F76b519fdE715f60124E7Ce51e051`](https://sepolia.basescan.org/address/0x724138223D8F76b519fdE715f60124E7Ce51e051)
 * Guardian: [`0xdf3b635d2b535f906BB02abb22AED71346E36a00`](https://sepolia.basescan.org/address/0xdf3b635d2b535f906BB02abb22AED71346E36a00)
 * Normal Timelock: [`0xCc84f6122649eDc48f4a426814e6b6C6fF9bBe0a`](https://sepolia.basescan.org/address/0xCc84f6122649eDc48f4a426814e6b6C6fF9bBe0a)
 * Fasttrack Timelock: [`0x3dFA652D3aaDcb93F9EA7d160d674C441AaA8EE2`](https://sepolia.basescan.org/address/0x3dFA652D3aaDcb93F9EA7d160d674C441AaA8EE2)
-* Critical Timelock: [`0xbeDb7F2d0617292364bA4D73cf016c0f6BB5542E`](https://sepolia.basescan.org/address/0xbeDb7F2d0617292364bA4D73cf016c0f6BB5542E)
+* Critical Timelock (deployed; no current permissions after VIP-645): [`0xbeDb7F2d0617292364bA4D73cf016c0f6BB5542E`](https://sepolia.basescan.org/address/0xbeDb7F2d0617292364bA4D73cf016c0f6BB5542E)
 * Omnichain Governance Executor: [`0xDD59be81B3B5BFa391bDA3a84c9f5233BfEF52a4`](https://sepolia.basescan.org/address/0xDD59be81B3B5BFa391bDA3a84c9f5233BfEF52a4)
 * Omnichain Executor Owner Proxy: [`0xe3fb08B8817a0c88d39A4DA4eFFD586D3326b73b`](https://sepolia.basescan.org/address/0xe3fb08B8817a0c88d39A4DA4eFFD586D3326b73b)
 ## Unichain Mainnet
@@ -154,16 +159,16 @@
 * Guardian: [`0x1803Cf1D3495b43cC628aa1d8638A981F8CD341C`](https://uniscan.xyz/address/0x1803Cf1D3495b43cC628aa1d8638A981F8CD341C)
 * Normal Timelock: [`0x918532A78d22419Da4091930d472bDdf532BE89a`](https://uniscan.xyz/address/0x918532A78d22419Da4091930d472bDdf532BE89a)
 * Fasttrack Timelock: [`0x4121995b87f9EE8bA0a89e87470255e2E0fe48c7`](https://uniscan.xyz/address/0x4121995b87f9EE8bA0a89e87470255e2E0fe48c7)
-* Critical Timelock: [`0x1b05eCb489842786776a9A10e91AAb56e2CFe15e`](https://uniscan.xyz/address/0x1b05eCb489842786776a9A10e91AAb56e2CFe15e)
+* Critical Timelock (deployed; no current permissions after VIP-645): [`0x1b05eCb489842786776a9A10e91AAb56e2CFe15e`](https://uniscan.xyz/address/0x1b05eCb489842786776a9A10e91AAb56e2CFe15e)
 * Omnichain Governance Executor: [`0x3E281461efb3D53EC20DB207674373Ed8Ef3BbA9`](https://uniscan.xyz/address/0x3E281461efb3D53EC20DB207674373Ed8Ef3BbA9)
 * Omnichain Executor Owner Proxy: [`0x6E78a0d96257F8F2615d72F3ee48cb6fb2c970bd`](https://uniscan.xyz/address/0x6E78a0d96257F8F2615d72F3ee48cb6fb2c970bd)
 
-## Unichain Sepolia
+## Unichain Sepolia (Test-only)
 
 * Access Control Manager: [`0x854C064EA6b503A97980F481FA3B7279012fdeDd`](https://sepolia.uniscan.xyz/address/0x854C064EA6b503A97980F481FA3B7279012fdeDd)
 * Guardian: [`0x9831D3A641E8c7F082EEA75b8249c99be9D09a34`](https://sepolia.uniscan.xyz/address/0x9831D3A641E8c7F082EEA75b8249c99be9D09a34)
 * Normal Timelock: [`0x5e20F5A2e23463D39287185DF84607DF7068F314`](https://sepolia.uniscan.xyz/address/0x5e20F5A2e23463D39287185DF84607DF7068F314)
 * Fasttrack Timelock: [`0x668cDb1A414006D0a26e9e13881D4Cd30B8b2a4A`](https://sepolia.uniscan.xyz/address/0x668cDb1A414006D0a26e9e13881D4Cd30B8b2a4A)
-* Critical Timelock: [`0x86C093266e824FA4345484a7B9109e9567923DA6`](https://sepolia.uniscan.xyz/address/0x86C093266e824FA4345484a7B9109e9567923DA6)
+* Critical Timelock (deployed; no current permissions after VIP-645): [`0x86C093266e824FA4345484a7B9109e9567923DA6`](https://sepolia.uniscan.xyz/address/0x86C093266e824FA4345484a7B9109e9567923DA6)
 * Omnichain Governance Executor: [`0x4FD69A0821e35104Fc86B8B7fF09026956B45947`](https://sepolia.uniscan.xyz/address/0x4FD69A0821e35104Fc86B8B7fF09026956B45947)
 * Omnichain Executor Owner Proxy: [`0xD755873C16Eaeb26993D283292d3F6C605D9BC26`](https://sepolia.uniscan.xyz/address/0xD755873C16Eaeb26993D283292d3F6C605D9BC26)

--- a/deployed-contracts/periphery.md
+++ b/deployed-contracts/periphery.md
@@ -1,9 +1,15 @@
 # Periphery - Deployed Contracts
 
+The stable source/deployment baseline for these address families is [`venus-periphery` v1.2.0](https://github.com/VenusProtocol/venus-periphery/tree/v1.2.0). This registry does not certify the current proxy implementation, clone instance, owner, signer, router/DEX configuration, pause level, EBrake control, or oracle consumer. Verify those values on-chain before a trade or emergency action.
+
+{% hint style="warning" %}
+BNB Trade contracts are money-moving. `PositionAccount` below is the implementation template used by cloned user accounts, not a shared account to fund. The BNB testnet section is **Test-only**.
+{% endhint %}
+
 ## BNB Chain Mainnet
 
 - RelativePositionManager: [`0x1525D804DFff218DcC8B9359940F423209356C42`](https://bscscan.com/address/0x1525D804DFff218DcC8B9359940F423209356C42)
-- PositionAccount: [`0xa75C5b438226bc73BDCc83408E7Aa41771b33E2C`](https://bscscan.com/address/0xa75C5b438226bc73BDCc83408E7Aa41771b33E2C)
+- PositionAccount implementation template: [`0xa75C5b438226bc73BDCc83408E7Aa41771b33E2C`](https://bscscan.com/address/0xa75C5b438226bc73BDCc83408E7Aa41771b33E2C)
 - SwapHelper: [`0xD79be25aEe798Aa34A9Ba1230003d7499be29A24`](https://bscscan.com/address/0xD79be25aEe798Aa34A9Ba1230003d7499be29A24)
 - LeverageStrategiesManager: [`0x03F079E809185a669Ca188676D0ADb09cbAd6dC1`](https://bscscan.com/address/0x03F079E809185a669Ca188676D0ADb09cbAd6dC1)
 - SwapRouter: [`0xde7E4f67Af577F29e5F3B995f9e67FD425F73621`](https://bscscan.com/address/0xde7E4f67Af577F29e5F3B995f9e67FD425F73621)
@@ -13,10 +19,10 @@
 - PancakeSwapOracle: [`0x44B72078240A3509979faF450085Fa818401D32E`](https://bscscan.com/address/0x44B72078240A3509979faF450085Fa818401D32E)
 - EBrake: [`0x35eBaBB99c7Fb7ba0C90bCc26e5d55Cdf89C23Ec`](https://bscscan.com/address/0x35eBaBB99c7Fb7ba0C90bCc26e5d55Cdf89C23Ec)
 
-## BNB Chain Testnet
+## BNB Chain Testnet (Test-only)
 
 - RelativePositionManager: [`0x25dbA64B28F93cC40e9cAf9691266043fe1000a2`](https://testnet.bscscan.com/address/0x25dbA64B28F93cC40e9cAf9691266043fe1000a2)
-- PositionAccount: [`0xC9A5f1598e434E3E52CE25D7ff290E4CF167ee52`](https://testnet.bscscan.com/address/0xC9A5f1598e434E3E52CE25D7ff290E4CF167ee52)
+- PositionAccount implementation template: [`0xC9A5f1598e434E3E52CE25D7ff290E4CF167ee52`](https://testnet.bscscan.com/address/0xC9A5f1598e434E3E52CE25D7ff290E4CF167ee52)
 - SwapHelper: [`0xf7Cfd0eDfAC7AA473813559b372297332EdEbB8B`](https://testnet.bscscan.com/address/0xf7Cfd0eDfAC7AA473813559b372297332EdEbB8B)
 - LeverageStrategiesManager: [`0x5187226337C95c4BE683D37Ffc66D41f5b6cE38f`](https://testnet.bscscan.com/address/0x5187226337C95c4BE683D37Ffc66D41f5b6cE38f)
 - SwapRouter: [`0xd3F226acA3210990DBA3f410b74E36b08F31FCf2`](https://testnet.bscscan.com/address/0xd3F226acA3210990DBA3f410b74E36b08F31FCf2)

--- a/deployed-contracts/token-converters.md
+++ b/deployed-contracts/token-converters.md
@@ -1,5 +1,11 @@
 # Token Converters - Deployed Contracts
 
+The stable source/deployment baseline for these converter families is [`protocol-reserve` v3.5.0](https://github.com/VenusProtocol/protocol-reserve/tree/v3.5.0). A deployed proxy or beacon does not prove that conversion is enabled, funded, still connected to a keeper/network, or safe to call. Re-read pause state, balances, owner/ACM permissions, beacon/proxy implementation, base asset, and destination.
+
+{% hint style="warning" %}
+The BNB Phase 2 migration labels apply only to the BNB mainnet rows described below. The Ethereum and Arbitrum rows are earlier converter families whose current pause, balance, and integration state must be verified independently. Every testnet section is **Test-only**.
+{% endhint %}
+
 ## BNB Chain Mainnet
 
 Phase 2 [TokenBuyback](../whats-new/token-converter.md) instances replaced the original community-driven Token Converters via [VIP-620](https://app.venus.io/#/governance/proposal/620?chainId=56) and [VIP-621](https://app.venus.io/#/governance/proposal/621?chainId=56). The migration was originally proposed as [VIP-618](https://app.venus.io/#/governance/proposal/618?chainId=56), which became unexecutable when BSC's Osaka hardfork enforced a hard per-tx gas cap of 2^24 = 16,777,216 (the single-call `helper.execute()` required ~17.5M gas). VIP-620 + VIP-621 split the work across two transactions and use a redeployed set of buyback proxies. The six timelock-owned legacy converters remain deployed for reference but are no longer operational — conversion is paused on each and balances have been drained into the corresponding new buyback. `WBNBBurnConverter` (Guardian-owned) is wound down via a separate multisig transaction; `ConverterNetwork` is unreferenced. Pre-existing ACM grants on the legacy converters are not explicitly revoked, but the paused state renders them inert.
@@ -21,7 +27,7 @@ Phase 2 [TokenBuyback](../whats-new/token-converter.md) instances replaced the o
 
 ### Helpers
 
-* TreasuryTokenBuybackDistributor: [`0xc594053D4b2FaA311b55dDbFAb2338f7c90D6632`](https://bscscan.com/address/0xc594053D4b2FaA311b55dDbFAb2338f7c90D6632) — one-shot helper for the Venus Treasury Cleanup VIP: splits treasury-withdrawn tokens across the six Treasury `TokenBuyback` contracts by fixed weights (BTCB 15% / ETH 15% / XVS 10% / USDT 15% / USDC 15% / U 30%, U absorbing rounding dust) and redeems VAI for USDT at the VAI Peg Stability Module, returning the USDT to `VTreasury`.
+* TreasuryTokenBuybackDistributor: [`0xc594053D4b2FaA311b55dDbFAb2338f7c90D6632`](https://bscscan.com/address/0xc594053D4b2FaA311b55dDbFAb2338f7c90D6632) — historical one-shot helper for the Venus Treasury Cleanup VIP. Its deployment does not imply that it remains unexecuted or authorized; inspect its transaction history and current permissions before reuse.
 
 ### Retired converters (Phase 1 — non-operational post VIP-620 / VIP-621)
 
@@ -35,7 +41,7 @@ Phase 2 [TokenBuyback](../whats-new/token-converter.md) instances replaced the o
 * WBNBBurnConverter: [`0x9eF79830e626C8ccA7e46DCEd1F90e51E7cFCeBE`](https://bscscan.com/address/0x9eF79830e626C8ccA7e46DCEd1F90e51E7cFCeBE)
 * ConverterNetwork: [`0xF7Caad5CeB0209165f2dFE71c92aDe14d0F15995`](https://bscscan.com/address/0xF7Caad5CeB0209165f2dFE71c92aDe14d0F15995)
 
-## Ethereum
+## Ethereum (V1 family; live state required)
 
 * XVSVaultTreasury: [`0xaE39C38AF957338b3cEE2b3E5d825ea88df02EfE`](https://etherscan.io/address/0xaE39C38AF957338b3cEE2b3E5d825ea88df02EfE)
 * SingleTokenConverterBeacon: [`0x5C0b5D09388F2BA6441E74D40666C4d96e4527D1`](https://etherscan.io/address/0x5C0b5D09388F2BA6441E74D40666C4d96e4527D1)
@@ -46,7 +52,7 @@ Phase 2 [TokenBuyback](../whats-new/token-converter.md) instances replaced the o
 * XVSVaultConverter: [`0x1FD30e761C3296fE36D9067b1e398FD97B4C0407`](https://etherscan.io/address/0x1FD30e761C3296fE36D9067b1e398FD97B4C0407)
 * ConverterNetwork: [`0x232CC47AECCC55C2CAcE4372f5B268b27ef7cac8`](https://etherscan.io/address/0x232CC47AECCC55C2CAcE4372f5B268b27ef7cac8)
 
-## Arbitrum One
+## Arbitrum One (V1 family; live state required)
 
 * XVSVaultTreasury: [`0xb076D4f15c08D7A7B89466327Ba71bc7e1311b58`](https://arbiscan.io/address/0xb076D4f15c08D7A7B89466327Ba71bc7e1311b58)
 * SingleTokenConverterBeacon: [`0x993900Ab4ef4092e5B76d4781D09A2732086F0F0`](https://arbiscan.io/address/0x993900Ab4ef4092e5B76d4781D09A2732086F0F0)
@@ -57,7 +63,7 @@ Phase 2 [TokenBuyback](../whats-new/token-converter.md) instances replaced the o
 * XVSVaultConverter: [`0x9c5A7aB705EA40876c1B292630a3ff2e0c213DB1`](https://arbiscan.io/address/0x9c5A7aB705EA40876c1B292630a3ff2e0c213DB1)
 * ConverterNetwork: [`0x2F6672C9A0988748b0172D97961BecfD9DC6D6d5`](https://arbiscan.io/address/0x2F6672C9A0988748b0172D97961BecfD9DC6D6d5)
 
-## BNB Chain Testnet
+## BNB Chain Testnet (Test-only)
 
 * RiskFundConverter: [`0x32Fbf7bBbd79355B86741E3181ef8c1D9bD309Bb`](https://testnet.bscscan.com/address/0x32Fbf7bBbd79355B86741E3181ef8c1D9bD309Bb)
 * XVSVaultTreasury: [`0x317c6C4c9AA7F87170754DB08b4804dD689B68bF`](https://testnet.bscscan.com/address/0x317c6C4c9AA7F87170754DB08b4804dD689B68bF)
@@ -70,7 +76,7 @@ Phase 2 [TokenBuyback](../whats-new/token-converter.md) instances replaced the o
 * WBNBBurnConverter: [`0x42DBA48e7cCeB030eC73AaAe29d4A3F0cD4facba`](https://testnet.bscscan.com/address/0x42DBA48e7cCeB030eC73AaAe29d4A3F0cD4facba)
 * ConverterNetwork: [`0xC8f2B705d5A2474B390f735A5aFb570e1ce0b2cf`](https://testnet.bscscan.com/address/0xC8f2B705d5A2474B390f735A5aFb570e1ce0b2cf)
 
-## Sepolia
+## Sepolia (Test-only)
 
 * XVSVaultTreasury: [`0xCCB08e5107b406E67Ad8356023dd489CEbc79B40`](https://sepolia.etherscan.io/address/0xCCB08e5107b406E67Ad8356023dd489CEbc79B40)
 * SingleTokenConverterBeacon: [`0xb86e532a5333d413A1c35d86cCdF1484B40219eF`](https://sepolia.etherscan.io/address/0xb86e532a5333d413A1c35d86cCdF1484B40219eF)
@@ -81,7 +87,7 @@ Phase 2 [TokenBuyback](../whats-new/token-converter.md) instances replaced the o
 * XVSVaultConverter: [`0xc203bfA9dCB0B5fEC510Db644A494Ff7f4968ed2`](https://sepolia.etherscan.io/address/0xc203bfA9dCB0B5fEC510Db644A494Ff7f4968ed2)
 * ConverterNetwork: [`0xB5A4208bFC4cC2C4670744849B8fC35B21A690Fa`](https://sepolia.etherscan.io/address/0xB5A4208bFC4cC2C4670744849B8fC35B21A690Fa)
 
-## Arbitrum Sepolia
+## Arbitrum Sepolia (Test-only)
 
 * XVSVaultTreasury: [`0x309b71a417dA9CfA8aC47e6038000B1739d9A3A6`](https://sepolia.arbiscan.io/address/0x309b71a417dA9CfA8aC47e6038000B1739d9A3A6)
 * SingleTokenConverterBeacon: [`0xC77D0F75f1e4e3720DA1D2F5D809F439125a2Fd4`](https://sepolia.arbiscan.io/address/0xC77D0F75f1e4e3720DA1D2F5D809F439125a2Fd4)

--- a/deployed-contracts/venus-erc4626.md
+++ b/deployed-contracts/venus-erc4626.md
@@ -1,71 +1,91 @@
 # VenusERC4626 - Deployed Contracts
 
+Each factory owns an `UpgradeableBeacon` and creates a `BeaconProxy` vault for a vToken. The factory address, beacon address, and current beacon implementation are distinct; a historical implementation address is not enough to determine the code used by created vaults. Enumerate actual wrappers with `createdVaults(vToken)` or `CreateERC4626` events.
+
+{% hint style="warning" %}
+The beacon and implementation rows below were read on August 27, 2026 at the block shown in each implementation label. They can change through governance. Factory configuration, owner/ACM, reward recipient, created vaults, balances, and integration support are not certified by this address list. Every testnet section is **Test-only**.
+{% endhint %}
+
 ## Ethereum Mainnet
 
 * VenusERC4626Factory: [`0x39cb747453Be3416E659dAeA169540b6F000c885`](https://etherscan.io/address/0x39cb747453Be3416E659dAeA169540b6F000c885)
-* VenusERC4626Implementation: [`0x6F0AB9E23f66ceB2b1BA0BB23C0e1f5f089a3cA1`](https://etherscan.io/address/0x6F0AB9E23f66ceB2b1BA0BB23C0e1f5f089a3cA1)
+* Factory beacon: [`0x402a1798E09F8895b0A347A5cD5934fBd6b5449d`](https://etherscan.io/address/0x402a1798E09F8895b0A347A5cD5934fBd6b5449d)
+* Current beacon implementation at block `25846206`: [`0x6F0AB9E23f66ceB2b1BA0BB23C0e1f5f089a3cA1`](https://etherscan.io/address/0x6F0AB9E23f66ceB2b1BA0BB23C0e1f5f089a3cA1)
 
-## Sepolia (Ethereum Testnet)
+## Sepolia (Ethereum Testnet; Test-only)
 
 * VenusERC4626Factory: [`0xbf76e9429BA565220d77831A9eC3606434e2106e`](https://sepolia.etherscan.io/address/0xbf76e9429BA565220d77831A9eC3606434e2106e)
-* VenusERC4626Implementation: [`0xd1B290832F3094647a063db7C293cD5DF2843255`](https://sepolia.etherscan.io/address/0xd1B290832F3094647a063db7C293cD5DF2843255)
+* Factory beacon: [`0x996c65EceF9f1456fB6206e7bd621cEbaFA1153e`](https://sepolia.etherscan.io/address/0x996c65EceF9f1456fB6206e7bd621cEbaFA1153e)
+* Current beacon implementation at block `11577515`: [`0xd1B290832F3094647a063db7C293cD5DF2843255`](https://sepolia.etherscan.io/address/0xd1B290832F3094647a063db7C293cD5DF2843255)
 
 ## opBNB Mainnet
 
 * VenusERC4626Factory: [`0x89A5Ce0A6db7e66E53F148B50D879b700dEB81C8`](https://opbnbscan.com/address/0x89A5Ce0A6db7e66E53F148B50D879b700dEB81C8)
-* VenusERC4626Implementation: [`0x2C0E328c118d22A549C8CB758C46775b9560A026`](https://opbnbscan.com/address/0x2C0E328c118d22A549C8CB758C46775b9560A026)
+* Factory beacon: [`0xeBF538fA3dDB199c5AC9816Ea7101ddbc47d0D7f`](https://opbnbscan.com/address/0xeBF538fA3dDB199c5AC9816Ea7101ddbc47d0D7f)
+* Current beacon implementation at block `178850100`: [`0x2C0E328c118d22A549C8CB758C46775b9560A026`](https://opbnbscan.com/address/0x2C0E328c118d22A549C8CB758C46775b9560A026)
 
-## opBNB Testnet
+## opBNB Testnet (Test-only)
 
 * VenusERC4626Factory: [`0x3dEDBD90EFC6E2257887FF36842337dF0739B8A1`](https://testnet.opbnbscan.com/address/0x3dEDBD90EFC6E2257887FF36842337dF0739B8A1)
-* VenusERC4626Implementation: [`0x5b97A053a8c153f5BE27b84370FecD3959D8898f`](https://testnet.opbnbscan.com/address/0x5b97A053a8c153f5BE27b84370FecD3959D8898f)
+* Factory beacon: [`0x904C9935fE85135d3169A41beACcc87F28a7e1a8`](https://testnet.opbnbscan.com/address/0x904C9935fE85135d3169A41beACcc87F28a7e1a8)
+* Current beacon implementation at block `196080622`: [`0x5b97A053a8c153f5BE27b84370FecD3959D8898f`](https://testnet.opbnbscan.com/address/0x5b97A053a8c153f5BE27b84370FecD3959D8898f)
 
 ## Arbitrum One
 
 * VenusERC4626Factory: [`0xC1422B928cb6FC9BA52880892078578a93aa5Cc7`](https://arbiscan.io/address/0xC1422B928cb6FC9BA52880892078578a93aa5Cc7)
-* VenusERC4626Implementation: [`0xff2C112F0FC927E89eA1f7ec56D0c76263708Bcb`](https://arbiscan.io/address/0xff2C112F0FC927E89eA1f7ec56D0c76263708Bcb)
+* Factory beacon: [`0xe87D357Fa78e961CbB12647012Bab418288B47f2`](https://arbiscan.io/address/0xe87D357Fa78e961CbB12647012Bab418288B47f2)
+* Current beacon implementation at block `498900326`: [`0xff2C112F0FC927E89eA1f7ec56D0c76263708Bcb`](https://arbiscan.io/address/0xff2C112F0FC927E89eA1f7ec56D0c76263708Bcb)
 
-## Arbitrum Sepolia
+## Arbitrum Sepolia (Test-only)
 
 * VenusERC4626Factory: [`0xC6C8249a0B44973673f3Af673e530B85038a0480`](https://sepolia.arbiscan.io/address/0xC6C8249a0B44973673f3Af673e530B85038a0480)
-* VenusERC4626Implementation: [`0x3442ACDbCc927cC401236C69a14ca909fC5B14ba`](https://sepolia.arbiscan.io/address/0x3442ACDbCc927cC401236C69a14ca909fC5B14ba)
+* Factory beacon: [`0xf443c323d2e7685231E8a9FB1052427B441C9ee4`](https://sepolia.arbiscan.io/address/0xf443c323d2e7685231E8a9FB1052427B441C9ee4)
+* Current beacon implementation at block `302536698`: [`0x3442ACDbCc927cC401236C69a14ca909fC5B14ba`](https://sepolia.arbiscan.io/address/0x3442ACDbCc927cC401236C69a14ca909fC5B14ba)
 
 ## ZKSync Mainnet
 
 * VenusERC4626Factory: [`0xDC59Dd76Dd7A64d743C764a9aa8C96Ff2Ea8BAc3`](https://explorer.zksync.io/address/0xDC59Dd76Dd7A64d743C764a9aa8C96Ff2Ea8BAc3)
-* VenusERC4626Implementation: [`0xBd86974B3a7348AC153aEFEe5Dc5111246a99c11`](https://explorer.zksync.io/address/0xBd86974B3a7348AC153aEFEe5Dc5111246a99c11)
+* Factory beacon: [`0x7C973844F97D7C6Dc994145B9F283081876DF6Df`](https://explorer.zksync.io/address/0x7C973844F97D7C6Dc994145B9F283081876DF6Df)
+* Current beacon implementation at block `71738908`: [`0xBd86974B3a7348AC153aEFEe5Dc5111246a99c11`](https://explorer.zksync.io/address/0xBd86974B3a7348AC153aEFEe5Dc5111246a99c11)
 
-## ZKSync Sepolia
+## ZKSync Sepolia (Test-only)
 
 * VenusERC4626Factory: [`0xa30dcc21B8393A4031cD6364829CDfE2b6D7B283`](https://sepolia.explorer.zksync.io/address/0xa30dcc21B8393A4031cD6364829CDfE2b6D7B283)
-* VenusERC4626Implementation: [`0x97ab473c81C5E654B71690e3B4225180C687E3eB`](https://sepolia.explorer.zksync.io/address/0x97ab473c81C5E654B71690e3B4225180C687E3eB)
+* Factory beacon: [`0x832Db8eEB5f9502E49b9699f33B593A47603fDfC`](https://sepolia.explorer.zksync.io/address/0x832Db8eEB5f9502E49b9699f33B593A47603fDfC)
+* Current beacon implementation at block `8260606`: [`0x97ab473c81C5E654B71690e3B4225180C687E3eB`](https://sepolia.explorer.zksync.io/address/0x97ab473c81C5E654B71690e3B4225180C687E3eB)
 
 ## Optimism Mainnet
 
 * VenusERC4626Factory: [`0xc801B471F00Dc22B9a7d7b839CBE87E46d70946F`](https://optimistic.etherscan.io/address/0xc801B471F00Dc22B9a7d7b839CBE87E46d70946F)
-* VenusERC4626Implementation: [`0x28d408ad7E66c8de66FBf8D6724747250C8B349E`](https://optimistic.etherscan.io/address/0x28d408ad7E66c8de66FBf8D6724747250C8B349E)
+* Factory beacon: [`0x18ed0A737DAa5ade55Cb66bcAcEEF59b3E5B07C1`](https://optimistic.etherscan.io/address/0x18ed0A737DAa5ade55Cb66bcAcEEF59b3E5B07C1)
+* Current beacon implementation at block `156115339`: [`0x28d408ad7E66c8de66FBf8D6724747250C8B349E`](https://optimistic.etherscan.io/address/0x28d408ad7E66c8de66FBf8D6724747250C8B349E)
 
-## Optimism Sepolia
+## Optimism Sepolia (Test-only)
 
 * VenusERC4626Factory: [`0xc66c4058A8524253C22a9461Df6769CE09F7d61e`](https://sepolia-optimism.etherscan.io/address/0xc66c4058A8524253C22a9461Df6769CE09F7d61e)
-* VenusERC4626Implementation: [`0x057E95A55E93DB89610AE2d64653b6384dFE7c0d`](https://sepolia-optimism.etherscan.io/address/0x057E95A55E93DB89610AE2d64653b6384dFE7c0d)
+* Factory beacon: [`0x625fa924ABf377F53deeb9735f985FD66526426E`](https://sepolia-optimism.etherscan.io/address/0x625fa924ABf377F53deeb9735f985FD66526426E)
+* Current beacon implementation at block `48013471`: [`0x057E95A55E93DB89610AE2d64653b6384dFE7c0d`](https://sepolia-optimism.etherscan.io/address/0x057E95A55E93DB89610AE2d64653b6384dFE7c0d)
 
 ## Base Mainnet
 
 * VenusERC4626Factory: [`0x1A430825B31DdA074751D6731Ce7Dca38D012D13`](https://basescan.org/address/0x1A430825B31DdA074751D6731Ce7Dca38D012D13)
-* VenusERC4626Implementation: [`0x1062F74081026eE4777981B75D8DA7e6a5640010`](https://basescan.org/address/0x1062F74081026eE4777981B75D8DA7e6a5640010)
+* Factory beacon: [`0x2fe39Fa6F7723c4CAF1457D5Dca59b373A641812`](https://basescan.org/address/0x2fe39Fa6F7723c4CAF1457D5Dca59b373A641812)
+* Current beacon implementation at block `50520054`: [`0x1062F74081026eE4777981B75D8DA7e6a5640010`](https://basescan.org/address/0x1062F74081026eE4777981B75D8DA7e6a5640010)
 
-## Base Sepolia
+## Base Sepolia (Test-only)
 
 * VenusERC4626Factory: [`0xD13c5527d1a2a8c2cC9c9eb260AC4D9D811a02a4`](https://sepolia.basescan.org/address/0xD13c5527d1a2a8c2cC9c9eb260AC4D9D811a02a4)
-* VenusERC4626Implementation: [`0x66A2cC7c0ca012DfBfd7BDC5DC06A315A0269b20`](https://sepolia.basescan.org/address/0x66A2cC7c0ca012DfBfd7BDC5DC06A315A0269b20)
+* Factory beacon: [`0xaB28af647BF5c2cDF5ca6Da11531b1A9ccB3CEda`](https://sepolia.basescan.org/address/0xaB28af647BF5c2cDF5ca6Da11531b1A9ccB3CEda)
+* Current beacon implementation at block `46030597`: [`0x66A2cC7c0ca012DfBfd7BDC5DC06A315A0269b20`](https://sepolia.basescan.org/address/0x66A2cC7c0ca012DfBfd7BDC5DC06A315A0269b20)
 
 ## Unichain Mainnet
 
 * VenusERC4626Factory: [`0x102fEb723C25c67dbdfDccCa3B1c1a6e1a662D2f`](https://uniscan.xyz/address/0x102fEb723C25c67dbdfDccCa3B1c1a6e1a662D2f)
-* VenusERC4626Implementation: [`0xE5b7978b0DB9e6d6026d1C79B8174D47295f8117`](https://uniscan.xyz/address/0xE5b7978b0DB9e6d6026d1C79B8174D47295f8117)
+* Factory beacon: [`0xEad5cc78de66E96E2285304Ba51FE75A7E29B33C`](https://uniscan.xyz/address/0xEad5cc78de66E96E2285304Ba51FE75A7E29B33C)
+* Current beacon implementation at block `57081097`: [`0xE5b7978b0DB9e6d6026d1C79B8174D47295f8117`](https://uniscan.xyz/address/0xE5b7978b0DB9e6d6026d1C79B8174D47295f8117)
 
-## Unichain Sepolia
+## Unichain Sepolia (Test-only)
 
 * VenusERC4626Factory: [`0x1365820B9ba3B1b5601208437a5A24192a12C1fB`](https://sepolia.uniscan.xyz/address/0x1365820B9ba3B1b5601208437a5A24192a12C1fB)
-* VenusERC4626Implementation: [`0x7c0160E6638df7e7E6132Da4B60F210c38655D6e`](https://sepolia.uniscan.xyz/address/0x7c0160E6638df7e7E6132Da4B60F210c38655D6e)
+* Factory beacon: [`0x676e182AD866f84a6bEE29a83FC316332821959a`](https://sepolia.uniscan.xyz/address/0x676e182AD866f84a6bEE29a83FC316332821959a)
+* Current beacon implementation at block `60977075`: [`0x7c0160E6638df7e7E6132Da4B60F210c38655D6e`](https://sepolia.uniscan.xyz/address/0x7c0160E6638df7e7E6132Da4B60F210c38655D6e)

--- a/deployed-contracts/xvs-omnichain.md
+++ b/deployed-contracts/xvs-omnichain.md
@@ -1,5 +1,11 @@
 # XVS Omnichain - Deployed Contracts
 
+These addresses implement the stable [`token-bridge` v2.7.0](https://github.com/VenusProtocol/token-bridge/tree/v2.7.0) LayerZero V1 bridge family. They are an address inventory, not a live route matrix. Before bridging, verify both local and remote bridges, `paused()`, trusted remotes, endpoint/library configuration, send/receive limits, destination mint cap, owner/ACM permissions, and any failed-message recovery state.
+
+{% hint style="warning" %}
+BNB uses the source OFT that locks canonical XVS; destination networks use destination OFTs that burn and mint their local XVS. A pair of deployed endpoints does not by itself prove that the route between them is configured or currently usable. All networks under the testnet heading are **Test-only**.
+{% endhint %}
+
 ## Mainnet chains
 
 ### BNB Chain
@@ -50,7 +56,7 @@
 * XVSProxyOFTDest: [`0x9c95f8aa28fFEB7ECdC0c407B9F632419c5daAF8`](https://uniscan.xyz/address/0x9c95f8aa28fFEB7ECdC0c407B9F632419c5daAF8)
 * XVS: [`0x81908BBaad3f6fC74093540Ab2E9B749BB62aA0d`](https://uniscan.xyz/address/0x81908BBaad3f6fC74093540Ab2E9B749BB62aA0d)
 
-## Testnet chains
+## Testnet chains (Test-only)
 
 ### BNB Chain
 


### PR DESCRIPTION
## Summary

- enumerate all three fixed-term vaults and their checkpoint states, and avoid treating non-enumerable liquidation mappings as an exclusive whitelist
- distinguish ERC-4626 factories, live beacons, and current beacon implementations across 14 networks
- clarify dynamic authority and lifecycle boundaries for governance, converter, periphery, and XVS omnichain registries
- mark testnet sections as test-only and repair the Optimism Sepolia Guardian explorer link

## Validation

- Remark passed for all six changed Markdown files
- git diff --check passed
- validated 320 address links for display/URL equality and chain-specific explorer domains
- verified five stable source tag links return HTTP 200
- read fixed-vault state at BNB block 118374393 and ERC-4626 factory beacon/implementation pairs at recorded per-chain blocks

This PR is based directly on the fixed documentation audit baseline and is independent of the preceding cleanup PRs.