### PR TITLE
docs: finish legacy and utility consistency pass

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -54,7 +54,7 @@
 * [Protocol Math](guides/protocol-math.md)
 * [XVS Bridge](guides/xvs-bridge.md)
 * [Borrowing VAI](guides/borrowing-vai.md)
-* [Gasless Transactions on zkSync](guides/gasless-transactions-zksync.md)
+* [Gasless Transactions on ZKsync](guides/gasless-transactions-zksync.md)
 * [Import Positions](guides/import-positions.md)
 * [Enable E-mode](guides/enable-e-mode.md)
 * [Isolated E-mode](guides/isolated-e-mode.md)

--- a/core-pool/admins.md
+++ b/core-pool/admins.md
@@ -1,23 +1,27 @@
-# Admins and ownership
+# Legacy two-step admin pattern
 
-Most of our contracts have a dedicated admin. The admin of most of the contracts is Governance. The admin can be changed with a two-step procedure that guarantees there's no error during transferring the rights.
+This hidden page documents the Compound-style `admin`/`pendingAdmin` transfer used by specific legacy contracts such as Unitroller and older vTokens. It is not a protocol-wide ownership model: other Venus contracts use `Ownable2Step`, proxy admins, AccessControlManager permissions, timelock roles, guardians, or combinations of them.
 
-The interface is similar but for historical reasons some of the contracts do not revert in case of failure. These contracts return 0 if the transaction was successful and an error code otherwise.
+{% hint style="warning" %}
+Governance is not automatically the effective caller for every privileged function. For the exact deployed address, resolve the implementation and read its live admin, pending admin, owner, proxy admin, AccessControlManager, and function permission before preparing a transfer.
+{% endhint %}
+
+Some legacy implementations return `0` on success and an error code on failure instead of reverting. Callers must check the returned value as well as transaction status.
 
 ## _setPendingAdmin
 
-```
+```solidity
 function _setPendingAdmin(
     address newPendingAdmin
-) external [returns (uint256 error)];
+) external returns (uint256 errorCode);
 ```
 
-Begins transfer of admin rights. The newPendingAdmin must call `_acceptAdmin` to finalize the transfer. The function is only callable by admin.
+Begins the legacy two-step transfer. The current admin proposes `newPendingAdmin`; that address must call `_acceptAdmin` to finish.
 
 ## _acceptAdmin
 
 ```solidity
-function _acceptAdmin() external [returns (uint256)];
+function _acceptAdmin() external returns (uint256 errorCode);
 ```
 
-Accepts transfer of admin rights. The function is only callable by pendingAdmin.
+Accepts the legacy transfer. The function is callable only by the recorded pending admin. Read both storage fields after execution instead of assuming the change completed from transaction status alone.

--- a/core-pool/liquidator.md
+++ b/core-pool/liquidator.md
@@ -1,8 +1,12 @@
-# Liquidator
+# Legacy Liquidator API (unversioned)
 
-The Liquidator contract is the only publicly accessible interface for liquidations in the core pool and was introduced in [VIP-64](https://app.venus.io/governance/proposal/64) so that the protocol could capture a part of the liquidation revenue. It has a unified interface for VAI, BNB and BEP-20 token liquidations.
+This hidden generated page describes an older treasury-backed BNB Chain Liquidator source generation. It is retained for legacy analysis while historical deployment-to-implementation coverage remains unresolved; it is not the current integration reference and does not establish that an address still uses this ABI.
 
-# Solidity API
+{% hint style="danger" %}
+Do not encode a transaction from this page without first resolving the target proxy's implementation at the relevant block. The [current public Liquidator reference](../technical-reference/reference-core-pool/liquidator.md) documents a later WBNB, AccessControlManager, and ProtocolShareReserve generation with a different constructor and initializer.
+{% endhint %}
+
+## Solidity API
 
 ## Storage
 
@@ -52,7 +56,7 @@ Percent of seized amount that goes to treasury.
 mapping(address => mapping(address => bool)) allowedLiquidatorsByAccount
 ```
 
-Mapping of addresses allowed to liquidate an account if liquidationRestricted[borrower] == true
+Mapping of addresses allowed to liquidate an account if `liquidationRestricted[borrower] == true`.
 
 ### liquidationRestricted
 
@@ -423,4 +427,3 @@ function _splitLiquidationIncentive(uint256 seizedAmount) internal view returns 
 {% hint style="info" %}
 Computes the amounts that would go to treasury and to the liquidator.
 {% endhint %}
-

--- a/guides/gasless-transactions-zksync.md
+++ b/guides/gasless-transactions-zksync.md
@@ -1,4 +1,10 @@
-This guide will walk you through the steps to interact with Venus Protocol on ZKsync without needing ETH to cover gas fees, thanks to the integration of [Zyfi Paymaster](https://www.zyfi.org/). All transactions will be sponsored, so you can focus on using the protocol without worrying about gas expenses.
+# Gasless transactions on ZKsync
+
+The Venus app can offer transactions that use a [Zyfi Paymaster](https://docs.zyfi.org/integration-guide/paymasters-integration/sponsored-paymaster) on ZKsync. Paymaster availability, supported actions, sponsorship percentage, fee token, quota, and quote expiry are dynamic; a displayed option is not a promise that every transaction will be fully sponsored.
+
+{% hint style="danger" %}
+Do not depend on sponsorship for urgent position management. Keep enough ETH for a standard ZKsync transaction, or use a fee token only when the current Venus quote explicitly identifies it and its maximum cost. Never sign an opaque or unexpected payload: verify the ZKsync network, contract, action, token, amount, fee, and expiry shown by the app and wallet.
+{% endhint %}
 
 ## Step-by-Step Guide
 
@@ -9,25 +15,25 @@ This guide will walk you through the steps to interact with Venus Protocol on ZK
 
 <figure><img src="../.gitbook/assets/gasless-zksync-network-selection.png" alt="Selection of ZKsync network"><figcaption>Selection of ZKsync network</figcaption></figure>
 
-### Step 2: Interact with the Venus Protocol
+### Step 2: Prepare the Venus action
 
-In this example, we will approve the use of the ZK market as collateral.
+In this example, the action enables the ZK market as collateral. Enabling collateral changes liquidation risk; review the market and resulting account health before continuing.
 
 1. Navigate to the ZK market on Venus.
 2. Click on "Collateral" to enable the use of this market as collateral.
 
 <figure><img src="../.gitbook/assets/gasless-zksync-features.png" alt="Interaction with any feature on ZKsync"><figcaption>Interaction with any feature on ZKsync</figcaption></figure>
 
-### Step 3: Sign the Transaction
+### Step 3: Review the quote and authorize the transaction
 
-1. Instead of sending a typical transaction, you will be prompted to **sign a message**. This step authorizes Zyfi to pay for the gas fee of the transaction on your behalf.
-2. Sign the message in your wallet. The gas for the transaction will be covered by Zyfi Paymaster, so you **don’t need ETH** in your wallet.
-3. Once signed, Zyfi processes the transaction, and it is sent to the ZKsync blockchain with gas paid through their vault.
+1. If sponsorship is currently available for the action, the app displays a paymaster quote. Check whether sponsorship is full or partial, which token pays any remainder, the maximum fee, and the quote expiry.
+2. Review the wallet request. Wallets and integration versions can present a transaction or typed authorization differently; confirm the decoded target and action match the Venus action you prepared. Reject an unexpected chain, contract, spender, amount, fee token, value, nonce, or deadline.
+3. Authorize only after those values match. If the quote has expired or sponsorship is unavailable, cancel and use the normal wallet transaction flow with ETH rather than repeatedly signing stale payloads.
 
-<figure><img src="../.gitbook/assets/gasless-zksync-rabby.png" alt="Sign a message with Rabby, instead of sending a transaction"><figcaption>Sign a message with Rabby, instead of sending a transaction</figcaption></figure>
+<figure><img src="../.gitbook/assets/gasless-zksync-rabby.png" alt="Example Zyfi authorization prompt in Rabby"><figcaption>Example Zyfi authorization prompt in Rabby; verify the current decoded request.</figcaption></figure>
 
-<figure><img src="../.gitbook/assets/gasless-zksync-metamask.png" alt="Sign a message with Metamask, instead of sending a transaction"><figcaption>Sign a message with Metamask, instead of sending a transaction</figcaption></figure>
+<figure><img src="../.gitbook/assets/gasless-zksync-metamask.png" alt="Example Zyfi authorization prompt in MetaMask"><figcaption>Example Zyfi authorization prompt in MetaMask; verify the current decoded request.</figcaption></figure>
 
 ### Viewing the Transaction
 
-You can verify the transaction on the [ZKsync Explorer](https://explorer.zksync.io/). The transaction will display Zyfi as the Paymaster, covering the gas fees.
+Verify the submitted transaction on the [ZKsync Explorer](https://explorer.zksync.io/). If a paymaster was used, the transaction details identify it; also confirm the called Venus contract, status, token movements, and final fee. The screenshots above are illustrative and may not match the current wallet or app flow.

--- a/technical-reference/reference-core-pool/liquidator.md
+++ b/technical-reference/reference-core-pool/liquidator.md
@@ -1,6 +1,24 @@
-#
+# Liquidator
 
-# Solidity API
+This BNB Chain Core Pool reference corresponds to the [`Liquidator` source family in `venus-protocol` v10.3.0](https://github.com/VenusProtocol/venus-protocol/blob/v10.3.0/contracts/Liquidator/Liquidator.sol). It does not prove which implementation is behind a deployed proxy. Resolve the live implementation, immutable constructor addresses, owner, AccessControlManager, ProtocolShareReserve destination, treasury percentage, force-VAI settings, and per-borrower restrictions before encoding a call.
+
+{% hint style="danger" %}
+Liquidation repays debt and transfers seized collateral. Use the verified BNB Chain Liquidator proxy for this source generation, not its implementation address and not a Liquidator from another contract generation. The beacon-based Core Pools on other networks use their own VToken liquidation entry points.
+{% endhint %}
+
+## Access and routing summary
+
+| Entry points | Source-level access in v10.3.0 |
+| --- | --- |
+| `liquidateBorrow` | Public, subject to live force-VAI and borrower-specific restriction/allowlist state |
+| `restrictLiquidation`, `unrestrictLiquidation`, `addToAllowlist`, `removeFromAllowlist` | Signature-specific AccessControlManager permission |
+| `setTreasuryPercent`, `setMinLiquidatableVAI`, `setPendingRedeemChunkLength`, `pauseForceVAILiquidate`, `resumeForceVAILiquidate` | Signature-specific AccessControlManager permission |
+| `setProtocolShareReserve` | Owner only |
+| `reduceReserves` | Public; transfers accrued reserves to the configured ProtocolShareReserve |
+
+Permissions and configured destinations can change. Re-read them at the block where the transaction will execute.
+
+## Solidity API
 
 ### vBnb
 

--- a/technical-reference/reference-core-pool/vtreasury.md
+++ b/technical-reference/reference-core-pool/vtreasury.md
@@ -1,22 +1,28 @@
 # VTreasury
 
-Contract for treasury all tokens as fee and transfer to governance
+This page documents the BNB-specific legacy [`VTreasury` source in `venus-protocol` v10.3.0](https://github.com/VenusProtocol/venus-protocol/blob/v10.3.0/contracts/Governance/VTreasury.sol), an `Ownable` contract that can receive native BNB and hold BEP-20 tokens.
 
-# Solidity API
+{% hint style="danger" %}
+Both withdrawal functions can move the contract's full available balance to an arbitrary recipient and are owner-only in this source. The deployed address, owner, balances, allowances, and continuing operational duty are dynamic. Use the [Funds registry](../../deployed-contracts/funds.md) to select a chain address, then verify its exact implementation and live owner; do not treat this legacy API as the treasury model for every network.
+{% endhint %}
+
+If the requested withdrawal exceeds the live balance, this implementation withdraws the available balance rather than reverting for an excessive amount.
+
+## Solidity API
 
 ### fallback
 
 To receive BNB
 
 ```solidity
-fallback() external payable
+function() external payable
 ```
 
 ---
 
 ### withdrawTreasuryBEP20
 
-Withdraw Treasury BEP20 Tokens, Only owner call it
+Withdraws up to the available balance of a BEP-20 token. Only the live owner can call this function.
 
 ```solidity
 function withdrawTreasuryBEP20(address tokenAddress, uint256 withdrawAmount, address withdrawAddress) external
@@ -27,14 +33,14 @@ function withdrawTreasuryBEP20(address tokenAddress, uint256 withdrawAmount, add
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | tokenAddress | address | The address of treasury token |
-| withdrawAmount | uint256 | The withdraw amount to owner |
-| withdrawAddress | address | The withdraw address |
+| withdrawAmount | uint256 | Requested amount; capped to the contract's token balance |
+| withdrawAddress | address | Recipient of the withdrawn tokens |
 
 ---
 
 ### withdrawTreasuryBNB
 
-Withdraw Treasury BNB, Only owner call it
+Withdraws up to the available native BNB balance. Only the live owner can call this function.
 
 ```solidity
 function withdrawTreasuryBNB(uint256 withdrawAmount, address payable withdrawAddress) external payable
@@ -44,7 +50,7 @@ function withdrawTreasuryBNB(uint256 withdrawAmount, address payable withdrawAdd
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| withdrawAmount | uint256 | The withdraw amount to owner |
-| withdrawAddress | address payable | The withdraw address |
+| withdrawAmount | uint256 | Requested amount; capped to the contract's BNB balance |
+| withdrawAddress | address payable | Recipient of the withdrawn BNB |
 
 ---

--- a/technical-reference/reference-isolated-pools/utility/error-reporter.md
+++ b/technical-reference/reference-isolated-pools/utility/error-reporter.md
@@ -1,5 +1,167 @@
 # TokenErrorReporter
 
-Errors that can be thrown by the `VToken` contract.
+This reference matches [`TokenErrorReporter` in `isolated-pools` v4.4.0](https://github.com/VenusProtocol/isolated-pools/blob/v4.4.0/contracts/ErrorReporter.sol). It defines the legacy success code and custom errors inherited by that source generation's `VToken` implementation.
 
-# Solidity API
+{% hint style="warning" %}
+Decode a revert with the ABI for the implementation behind the selected VToken beacon or proxy. Error names and selectors can differ across deployed generations; this page does not prove that every listed error is reachable at every market.
+{% endhint %}
+
+## Solidity API
+
+### NO_ERROR
+
+Legacy success code retained for compatibility.
+
+```solidity
+uint256 public constant NO_ERROR = 0
+```
+
+### TransferNotAllowed
+
+```solidity
+error TransferNotAllowed()
+```
+
+### MintFreshnessCheck
+
+```solidity
+error MintFreshnessCheck()
+```
+
+### RedeemFreshnessCheck
+
+```solidity
+error RedeemFreshnessCheck()
+```
+
+### RedeemTransferOutNotPossible
+
+```solidity
+error RedeemTransferOutNotPossible()
+```
+
+### BorrowFreshnessCheck
+
+```solidity
+error BorrowFreshnessCheck()
+```
+
+### BorrowCashNotAvailable
+
+```solidity
+error BorrowCashNotAvailable()
+```
+
+### DelegateNotApproved
+
+```solidity
+error DelegateNotApproved()
+```
+
+### RepayBorrowFreshnessCheck
+
+```solidity
+error RepayBorrowFreshnessCheck()
+```
+
+### HealBorrowUnauthorized
+
+```solidity
+error HealBorrowUnauthorized()
+```
+
+### ForceLiquidateBorrowUnauthorized
+
+```solidity
+error ForceLiquidateBorrowUnauthorized()
+```
+
+### LiquidateFreshnessCheck
+
+```solidity
+error LiquidateFreshnessCheck()
+```
+
+### LiquidateCollateralFreshnessCheck
+
+```solidity
+error LiquidateCollateralFreshnessCheck()
+```
+
+### LiquidateAccrueCollateralInterestFailed
+
+```solidity
+error LiquidateAccrueCollateralInterestFailed(uint256 errorCode)
+```
+
+### LiquidateLiquidatorIsBorrower
+
+```solidity
+error LiquidateLiquidatorIsBorrower()
+```
+
+### LiquidateCloseAmountIsZero
+
+```solidity
+error LiquidateCloseAmountIsZero()
+```
+
+### LiquidateCloseAmountIsUintMax
+
+```solidity
+error LiquidateCloseAmountIsUintMax()
+```
+
+### LiquidateSeizeLiquidatorIsBorrower
+
+```solidity
+error LiquidateSeizeLiquidatorIsBorrower()
+```
+
+### ProtocolSeizeShareTooBig
+
+```solidity
+error ProtocolSeizeShareTooBig()
+```
+
+### SetReserveFactorFreshCheck
+
+```solidity
+error SetReserveFactorFreshCheck()
+```
+
+### SetReserveFactorBoundsCheck
+
+```solidity
+error SetReserveFactorBoundsCheck()
+```
+
+### AddReservesFactorFreshCheck
+
+```solidity
+error AddReservesFactorFreshCheck(uint256 actualAddAmount)
+```
+
+### ReduceReservesFreshCheck
+
+```solidity
+error ReduceReservesFreshCheck()
+```
+
+### ReduceReservesCashNotAvailable
+
+```solidity
+error ReduceReservesCashNotAvailable()
+```
+
+### ReduceReservesCashValidation
+
+```solidity
+error ReduceReservesCashValidation()
+```
+
+### SetInterestRateModelFreshCheck
+
+```solidity
+error SetInterestRateModelFreshCheck()
+```

--- a/technical-reference/reference-isolated-pools/utility/max-loops-limit-helper.md
+++ b/technical-reference/reference-isolated-pools/utility/max-loops-limit-helper.md
@@ -1,5 +1,51 @@
 # MaxLoopsLimitHelper
 
-## MaxLoopsLimitHelper
+This reference matches [`MaxLoopsLimitHelper` in `isolated-pools` v4.4.0](https://github.com/VenusProtocol/isolated-pools/blob/v4.4.0/contracts/MaxLoopsLimitHelper.sol). It is an inherited abstract storage/helper module, not a separately deployed contract.
 
 Abstract contract used to avoid collection with too many items that would generate gas errors and DoS.
+
+{% hint style="warning" %}
+The internal setter only permits increasing the limit. The public administrator entry point and its permission, if any, belong to the inheriting implementation. Resolve that implementation before assuming a caller can change the value.
+{% endhint %}
+
+## Solidity API
+
+### maxLoopsLimit
+
+Maximum number of items accepted by guarded loops. Solidity generates a public getter for this storage field.
+
+```solidity
+uint256 public maxLoopsLimit
+```
+
+### MaxLoopsLimitUpdated
+
+Emitted after the limit is increased.
+
+```solidity
+event MaxLoopsLimitUpdated(uint256 oldMaxLoopsLimit, uint256 newmaxLoopsLimit)
+```
+
+### MaxLoopsLimitExceeded
+
+Thrown when a guarded collection is longer than the configured limit.
+
+```solidity
+error MaxLoopsLimitExceeded(uint256 loopsLimit, uint256 requiredLoops)
+```
+
+### _setMaxLoopsLimit
+
+Increases the limit. The call reverts unless `limit > maxLoopsLimit`; it cannot reduce the value.
+
+```solidity
+function _setMaxLoopsLimit(uint256 limit) internal
+```
+
+### _ensureMaxLoops
+
+Reverts with `MaxLoopsLimitExceeded(maxLoopsLimit, len)` when `len` exceeds the configured limit.
+
+```solidity
+function _ensureMaxLoops(uint256 len) internal view
+```

--- a/whats-new/token-converter.md
+++ b/whats-new/token-converter.md
@@ -87,7 +87,7 @@ Governance-only. Emergency token recovery from the contract. Also the canonical 
 | `DailyCapUpdated(oldCap, newCap)` | `setDailyCapUsd` succeeds |
 | `SlippageEventUsdUpdated(oldThreshold, newThreshold)` | `setSlippageEventUsd` succeeds |
 
-### BSC: Before & After
+### BNB Chain: Before & After
 
 **Before (8 contracts)**
 
@@ -102,7 +102,7 @@ Governance-only. Emergency token recovery from the contract. Also the canonical 
 | `WBNBBurnConverter` | Retired (was burn path) |
 | `ConverterNetwork` | Retired (registry) |
 
-**After (10 TokenBuyback instances, deployed on BSC mainnet)**
+**After (10 TokenBuyback instances, deployed on BNB Chain mainnet)**
 
 | Instance | Base Asset | Destination | Proxy address |
 |---|---|---|---|
@@ -130,7 +130,7 @@ Governance-only. Emergency token recovery from the contract. Also the canonical 
 
 ### Migration
 
-BSC mainnet migration executed across two governance proposals — [VIP-620](https://app.venus.io/#/governance/proposal/620?chainId=56) and [VIP-621](https://app.venus.io/#/governance/proposal/621?chainId=56) ([vips PR #708](https://github.com/VenusProtocol/vips/pull/708)). The work was originally proposed as a single transaction in [VIP-618](https://app.venus.io/#/governance/proposal/618?chainId=56), which became unexecutable when BSC's Osaka hardfork enforced a hard per-tx gas cap of 2^24 = 16,777,216: the single-call `helper.execute()` required ~17.5M gas, driven primarily by the converter drain (6 converters × 47 core-pool tokens) and the router allowlist (10 buybacks × 9 routers). Splitting the drain + router allowlist into a separate `execute2()` entrypoint drops both halves comfortably under the cap.
+The BNB Chain mainnet migration executed across two governance proposals — [VIP-620](https://app.venus.io/#/governance/proposal/620?chainId=56) and [VIP-621](https://app.venus.io/#/governance/proposal/621?chainId=56) ([vips PR #708](https://github.com/VenusProtocol/vips/pull/708)). The work was originally proposed as a single transaction in [VIP-618](https://app.venus.io/#/governance/proposal/618?chainId=56), which became unexecutable when the BNB Smart Chain (BSC) Osaka hardfork enforced a hard per-transaction gas cap of 2^24 = 16,777,216: the single-call `helper.execute()` required ~17.5M gas, driven primarily by the converter drain (6 converters × 47 core-pool tokens) and the router allowlist (10 buybacks × 9 routers). Splitting the drain and router allowlist into a separate `execute2()` entrypoint drops both halves comfortably under the cap.
 
 **Pre-VIP** (deploy-script setup):
 
@@ -168,7 +168,7 @@ BSC mainnet migration executed across two governance proposals — [VIP-620](htt
 | Metric | Before | After |
 |---|---|---|
 | Solidity lines | ~2,160 across 5 contracts | ~425 lines, single contract class |
-| Deployed instances (BSC) | 8 | 10 (all `TokenBuyback`) |
+| Deployed instances (BNB Chain) | 8 | 10 (all `TokenBuyback`) |
 | Conversion trigger | External community (voluntary) | Finance cron (scheduled) |
 | Pricing | Oracle + up to 50% premium | DEX market rate |
 | Community dependency | Required | None |


### PR DESCRIPTION
## Summary

- replace absolute ZKsync paymaster sponsorship and opaque message-signing guidance with quote, fee, expiry, decoded-request, and ETH fallback checks
- separate the current v10.3.0 BNB Liquidator family from the hidden unversioned treasury-backed generation and document source-level access routes
- scope the hidden two-step admin page to legacy contracts and scope VTreasury to its BNB-specific Ownable API
- fully document all 25 TokenErrorReporter custom errors and the MaxLoopsLimitHelper surface from isolated-pools v4.4.0
- normalize the remaining touched BNB Chain and ZKsync navigation terminology

## Validation

- targeted Remark passed for all nine changed Markdown files
- git diff --check passed
- changed-file relative-link scan found zero missing targets
- TokenErrorReporter source/documentation comparison: 25 source errors, 25 documented, zero missing or extra
- verified MaxLoopsLimitHelper surface and all 12 Liquidator access-summary entry points against stable tagged source
- verified the four stable source links and official Zyfi sponsored-paymaster link return HTTP 200

This is the final ordered cleanup batch. It is based directly on the fixed documentation audit baseline and is independent of the preceding cleanup PRs.