### PR TITLE
docs(liquidity-hub): add HubLens deposit sizing

### DIFF
--- a/deployed-contracts/liquidity-hub.md
+++ b/deployed-contracts/liquidity-hub.md
@@ -69,6 +69,10 @@ Stateless, non-upgradeable singletons shared by every Hub; mutating calls reach 
 
 Stateless, permissionless and non-upgradeable; one-click migration of a Venus Core position into a Hub via `migrateFromCore` / `migrateFromCoreBNB` (plus the `*WithConsent` variants).
 
+* HubLens: `TBD` — not yet deployed
+
+Stateless, unowned and non-upgradeable; read-only. The Hub itself computes no deposit ceiling, so this is where a frontend or an integrator reads one: `maxDeposit(hub)`, `maxMint(hub)`, `depositCapacityBreakdown(hub)` and `spotAPYBps(hub)`. The Hub is a call parameter, so this single deployment serves every Hub. It is **not** registered in the `HubRegistry` and no Hub exposes its address, so this entry is the only place to find it — see [Sizing a deposit](../technical-reference/reference-liquidity-hub/hub.md#sizing-a-deposit).
+
 ### Access control
 
 Every gated function on the Hubs and YieldGroups is checked against `AccessControlManagerV8` [`0x4788629ABc6cFCA10F9f969efdEAa1cF70c23555`](https://bscscan.com/address/0x4788629ABc6cFCA10F9f969efdEAa1cF70c23555). Role holders (governance, Operator, Guardian) are granted by proposal rather than baked into the bytecode — see [Permissions](../technical-reference/reference-liquidity-hub/hub.md#permissions).
@@ -128,3 +132,4 @@ Unlike mainnet, **FRV is fully wired on testnet**: the FRV YieldGroup has a Fixe
 ### Periphery
 
 * Migrator: [`0x343D518d8C89f9B5D770000F1ed80f45bF1419f5`](https://testnet.bscscan.com/address/0x343D518d8C89f9B5D770000F1ed80f45bF1419f5)
+* HubLens: `TBD` — not yet deployed

--- a/technical-reference/reference-liquidity-hub/README.md
+++ b/technical-reference/reference-liquidity-hub/README.md
@@ -37,6 +37,7 @@ Routing is three-tiered. The Hub depends only on the `IYieldGroupBase` interface
 * [**Adapters**](adapters.md) — `AdapterCoreV1`, `AdapterFlux`, `AdapterFRV`: the stateless, delegatecall-dispatched protocol translators.
 * [**Interfaces**](interfaces.md) — `IYieldGroupBase` (with its family extensions `IYieldGroup` and `IYieldGroupFRV`) and `IResourceAdapter`, the boundary contracts.
 * **`Migrator`** — a stateless, permissionless, non-upgradeable helper for one-click migration of a Venus Core position into a Hub (`migrateFromCore` / `migrateFromCoreBNB`).
+* **`HubLens`** — a stateless, unowned, non-upgradeable read-only helper. The Hub does not compute a deposit ceiling, so `HubLens` is where a frontend or an integrator reads one: `maxDeposit(hub)`, `maxMint(hub)`, `depositCapacityBreakdown(hub)` and the blended `spotAPYBps(hub)`. Every function takes the Hub as a parameter, so one deployment serves every Hub — see [Sizing a deposit](hub.md#sizing-a-deposit).
 
 **`HubRegistry`** — one per chain, the canonical directory of deployed Hubs. Governance calls `addHub(address)` / `removeHub(address)` (both ACM-gated); everyone else reads `hubForAsset(address)`, `assetForHub(address)`, `isHub(address)`, `getHubs()` and `getHubsCount()`. It emits `HubAdded` / `HubRemoved`, and an indexer should seed from state on `HubAdded` rather than relying on log ordering. Each asset may have at most one Hub (`AssetAlreadyHasHub`).
 

--- a/technical-reference/reference-liquidity-hub/hub.md
+++ b/technical-reference/reference-liquidity-hub/hub.md
@@ -73,7 +73,7 @@ Hub.totalAssets()
              = Σ adapter.totalAssets(resource, yieldGroup)  +  Source idle balance
 ```
 
-* `totalAssets()` **fails closed**. It sums every registered Source with no error isolation, so a Source whose `totalAssets()` view reverts makes the whole NAV read revert — and with it every `convertTo*` / `preview*` view and every deposit / mint / withdraw / redeem / `accrueFees` / `reallocate` — until the Source is fixed or evicted. This is deliberate: NAV is the share-price denominator, so silently counting a live Source as 0 would under-pay redeemers and over-credit depositors. Fault isolation applies only one level out, to the quantity-gate views (`maxDeposit` / `maxWithdraw`) and the deposit / withdraw routing, which do skip a faulting Source. Recovery is the emergency path of `removeYieldGroup`, which permits removal precisely when the view reverts.
+* `totalAssets()` **fails closed**. It sums every registered Source with no error isolation, so a Source whose `totalAssets()` view reverts makes the whole NAV read revert — and with it every `convertTo*` / `preview*` view and every deposit / mint / withdraw / redeem / `accrueFees` / `reallocate` — until the Source is fixed or evicted. This is deliberate: NAV is the share-price denominator, so silently counting a live Source as 0 would under-pay redeemers and over-credit depositors. Fault isolation applies only one level out, to the quantity-gate view `maxWithdraw` and to the deposit / withdraw routing, which do skip a faulting Source. The deposit-side equivalent lives on `HubLens` rather than the Hub — see [Sizing a deposit](#sizing-a-deposit). Recovery is the emergency path of `removeYieldGroup`, which permits removal precisely when the view reverts.
 * Hub idle is normally zero (deposits route out atomically, withdrawals pull exact amounts, reallocate is balanced). A direct token donation persists and is intentionally counted into NAV — it accrues to LPs and is consumed first on withdraw; the underlying cannot be swept.
 * View paths use the **stored** exchange rate (`exchangeRateStored`, stale up to one accrual cycle, no state mutation). Mutating paths trigger interest accrual on the resource during mint / redeem, so the rate is current by the time the operation completes.
 
@@ -93,6 +93,26 @@ effectiveCap = (percentageCapBps == 10_000)
 
 The optional **per-resource deposit cap** (Core & Flux) binds one level down, inside the YieldGroup — see [Yield Groups](yield-groups.md#resource-caps-core--flux-only).
 
+## Sizing a deposit
+
+`Hub.maxDeposit` and `Hub.maxMint` are **not** limits — they return `type(uint256).max` and reflect neither the caps nor the pause state. Sizing a deposit off either one gives no signal that the deposit will revert, exactly as with `previewDeposit`.
+
+The real ceiling lives on **`HubLens`**, a stateless, unowned, non-upgradeable periphery contract. It takes the Hub as a parameter, so a single deployment serves every Hub:
+
+```solidity
+import { IHubLens } from "@venusprotocol/liquidity-hub/contracts/interfaces/IHubLens.sol";
+
+uint256 room = IHubLens(lens).maxDeposit(hub);   // 0 while the Hub is paused
+```
+
+The figure is priced against the TVL the deposit itself produces, because the cascade prices the percentage caps there too. It is never overstated, so `hub.deposit(room, receiver)` fits.
+
+`depositCapacityBreakdown(hub)` returns that same total split by the Source that would receive it, in deposit-queue order, so the parts sum to `maxDeposit`. It answers "where would my deposit land", not "how much could this Source take on its own" — a Source late in the queue reads `0` whenever the ones ahead of it absorb everything.
+
+If a deposit is sent anyway and does not fit, it reverts `HubCapacityExceeded(assets, placed)`, whose second argument is how much **would** have fit.
+
+Nothing on chain points at `HubLens`: it is not registered in the `HubRegistry` and no Hub exposes its address. Take it from [Deployed contracts](../../deployed-contracts/liquidity-hub.md).
+
 ## Fees
 
 Three fee types. Management and performance fees are minted as **dilution shares** to a single `feeRecipient` (`address(0)` disables minting); the redeem fee is taken from the withdrawing lender. Accrual is idempotent within a block and runs before every deposit / withdraw / reallocate. The management and performance rates are capped at `MAX_FEE_BPS` (50%); the redeem fee is capped at `MAX_REDEEM_FEE_BPS` (5%).
@@ -110,8 +130,8 @@ Three independent scopes — a broader scope blocks everything beneath it; sibli
 
 <figure><img src="../../.gitbook/assets/liquidity-hub-multi-level-pause.svg" alt="Multi-level pause: a Hub pause blocks all user operations; a paused Source is skipped in routing while sibling Sources keep operating; a paused resource is skipped in its YieldGroup's inner queue"><figcaption></figcaption></figure>
 
-* **Hub paused** — all deposits / withdrawals / mints / redeems, `reallocate`, and fee accrual and the fee setters are blocked; `emergencyReallocate` and `sweep` stay callable; views stay readable, though all four `max*` views return `0`. Underlying products keep operating. Only the **time-based management fee** is excluded from the pause window — `unpauseHub` advances the accrual cursor by the pause duration, so LPs are not charged rent for frozen time. The performance fee is *not* excluded: the high-water mark is deliberately left unchanged, so per-share gains the underlying products earn during the freeze are charged on the first post-resume accrual.
-* **Source paused** — the Hub-level flag makes routing skip the Source **silently in both directions**: a user `deposit` / `mint` cascades to the next Source and a user `withdraw` / `redeem` pulls from elsewhere, with no `YieldGroupPaused` revert (only `HubCapacityExceeded` / `HubInsufficientLiquidity` fire if the rest of the queue cannot cover the amount). Its balance still counts in `totalAssets()` but is excluded from `maxDeposit()` / `maxWithdraw()`. Funds remain reachable via `reallocate` / `emergencyReallocate` — a **pull** leg from a paused Source is allowed, while a **push** leg into one reverts `YieldGroupPaused`.
+* **Hub paused** — all deposits / withdrawals / mints / redeems, `reallocate`, and fee accrual and the fee setters are blocked; `emergencyReallocate` and `sweep` stay callable; views stay readable, though `maxWithdraw` / `maxRedeem` return `0` and `HubLens.maxDeposit` reports `0` (`maxDeposit` / `maxMint` on the Hub are not overridden, so they keep returning `type(uint256).max` even while paused). Underlying products keep operating. Only the **time-based management fee** is excluded from the pause window — `unpauseHub` advances the accrual cursor by the pause duration, so LPs are not charged rent for frozen time. The performance fee is *not* excluded: the high-water mark is deliberately left unchanged, so per-share gains the underlying products earn during the freeze are charged on the first post-resume accrual.
+* **Source paused** — the Hub-level flag makes routing skip the Source **silently in both directions**: a user `deposit` / `mint` cascades to the next Source and a user `withdraw` / `redeem` pulls from elsewhere, with no `YieldGroupPaused` revert (only `HubCapacityExceeded` / `HubInsufficientLiquidity` fire if the rest of the queue cannot cover the amount). Its balance still counts in `totalAssets()` but is excluded from `maxWithdraw()` and from the `HubLens` deposit figure. Funds remain reachable via `reallocate` / `emergencyReallocate` — a **pull** leg from a paused Source is allowed, while a **push** leg into one reverts `YieldGroupPaused`.
 * **Resource paused** — set on the YieldGroup, not the Hub; see [Yield Groups](yield-groups.md#pause-asymmetric).
 
 ## Permissions
@@ -156,7 +176,7 @@ governance grants each role to — the asymmetry is a deployment decision, not a
 * **Atomic-or-revert.** Deposits, withdrawals, and reallocate fully complete or revert with a named error — no partial fills, no remainder returned.
 * **Net-zero reallocate.** `Σ withdraws == Σ deposits`; the Operator can only move funds among registered routes, never in or out.
 * **Reentrancy-guarded value paths.** Every entry point that moves assets is `nonReentrant` (`ReentrancyGuardUpgradeable`) — `deposit` / `mint` / `withdraw` / `redeem`, `reallocate`, `emergencyReallocate`, `accrueFees`, `sweep` on the Hub, and `deposit` / `withdraw` / `depositResource` / `withdrawResource` / `sweep` on each YieldGroup — since each makes external calls into Sources, delegatecalls into adapters, and reaches into the underlying Core / Flux / FRV protocols. The ACM-gated admin setters and the `onlyHub` `accrue()` poke are **not** individually guarded; they rely on ACM gating and `onlyHub` instead.
-* **Fault isolation on the quantity gates, fail-closed on price.** A Source with a reverting `totalAssets()` view contributes 0 to `maxDeposit()` / `maxWithdraw()` and is skipped by the deposit / withdraw routing — but `Hub.totalAssets()` itself is deliberately **fail-closed** and reverts with it, halting share pricing rather than understating NAV. Such a Source can still be removed as an emergency eviction: `removeYieldGroup` catches the reverting view and permits removal.
+* **Fault isolation on the quantity gates, fail-closed on price.** A Source with a reverting `totalAssets()` view contributes 0 to `maxWithdraw()` and is skipped by the deposit / withdraw routing — but `Hub.totalAssets()` itself is deliberately **fail-closed** and reverts with it, halting share pricing rather than understating NAV. Such a Source can still be removed as an emergency eviction: `removeYieldGroup` catches the reverting view and permits removal.
 * **Removal safety.** `removeYieldGroup` gates on the Source's balance so a funded Source can't be silently dropped; YieldGroups apply the same gate on a raw receipt-token balance.
 * **Inflation defense.** The ERC-4626 decimals offset is set per asset at `initialize` and enforced **on-chain in both directions**: `0` and anything above `MAX_DECIMALS_OFFSET` (12) revert `InvalidDecimalsOffset`, so a Hub can never be deployed with the offset disabled. A non-zero offset is required for every asset regardless of its decimals — offset 0 would let a donation attack zero a first depositor's shares.
 * **Standard ERC-20 only.** Fee-on-transfer, deflationary, and rebasing underlyings are unsupported (deposits fail closed if a token delivers less than requested).
@@ -244,7 +264,8 @@ Two consent-gated variants take an extra `bytes32 consentHash` and emit it in th
 Not all the standard ERC-4626 views behave identically to the OpenZeppelin base:
 
 * `convertToShares` / `convertToAssets` / `previewDeposit` / `previewMint` are **inherited unmodified**. They are pure share math and reflect *none* of the caps, liquidity, pause state or fees — sizing a deposit off `previewDeposit` gives no signal that the deposit will revert.
-* `maxDeposit` / `maxMint` / `maxWithdraw` / `maxRedeem` are **overridden** and do reflect live effective caps, aggregate liquidity, the per-transaction withdrawal cap and the redeem fee. All four return `0` while the Hub is paused.
+* `maxDeposit` / `maxMint` are **inherited unmodified** and return `type(uint256).max`, ERC-4626's "no limit" value. The Hub does not compute a deposit ceiling: OpenZeppelin's `deposit` / `mint` call these two views on every call, and solving every Source's dual cap against the TVL the deposit itself creates does not belong on that path. Caps are still enforced, by the routing cascade. Read the real figure from `HubLens` — see [Sizing a deposit](#sizing-a-deposit).
+* `maxWithdraw` / `maxRedeem` are **overridden** and do reflect aggregate liquidity, the per-transaction withdrawal cap and the redeem fee. Both return `0` while the Hub is paused.
 * `previewWithdraw` / `previewRedeem` are **overridden** to account for the redeem (exit) fee, so they diverge from `convertToAssets` / `convertToShares` whenever that fee is non-zero.
 
 ### Source registry (governance)
@@ -310,6 +331,8 @@ call everything else. Both sit with governance in v1.
 * **`redeemFeeBps()` → `uint16`** — current exit fee rate.
 * **`highWaterMarkPerShare()` → `uint256`** — performance HWM in share-price units.
 
+The Hub exposes no deposit-capacity view. That figure comes from `HubLens` — see [Sizing a deposit](#sizing-a-deposit).
+
 ## Events
 
 | Event                     | Parameters                                                  | Description                                       |
@@ -344,7 +367,7 @@ call everything else. Both sit with governance in v1.
 | Error                          | When                                                                       |
 | ------------------------------ | -------------------------------------------------------------------------- |
 | `Unauthorized`                 | Caller lacked the ACM role for the called function                        |
-| `HubCapacityExceeded`          | Deposit / mint exceeds aggregate spare cap across unpaused Sources, **or** a `reallocate` / `emergencyReallocate` push leg exceeds the destination Source's own effective cap |
+| `HubCapacityExceeded`          | Deposit / mint exceeds aggregate spare cap across unpaused Sources, **or** a `reallocate` / `emergencyReallocate` push leg exceeds the destination Source's own effective cap. Carries `(assets, placed)` — `placed` is how much of `assets` would have fit |
 | `HubInsufficientLiquidity`     | Withdraw / redeem exceeds liquid funds (withdraw queue + Hub idle)         |
 | `YieldGroupUnderfilled`            | A Source delivered an amount **not exactly equal** to the amount requested — under- *or* over-delivery, since the check is `!=` — on a user withdraw / redeem cascade step or on a `reallocate` leg. Not raised by the deposit cascade, which accepts partial fills |
 | `HubWithdrawCapExceeded`       | Withdraw / redeem exceeds `maxWithdrawalSize()`                            |

--- a/whats-new/liquidity-hub.md
+++ b/whats-new/liquidity-hub.md
@@ -43,7 +43,7 @@ Beyond user-driven flow, a privileged **Operator** can proactively rebalance cap
 
 ### Safety envelope
 
-* **Atomic-or-revert** — deposits, withdrawals, and rebalances either complete in full or revert. No partial fills, no stranded remainder.
+* **Atomic-or-revert** — deposits, withdrawals, and rebalances either complete in full or revert. No partial fills, no stranded remainder. A deposit larger than the remaining room reverts rather than filling part of it, and the revert itself reports how much would have fit.
 * **Dual caps per Source** — each Source carries both an absolute cap and a percentage-of-Hub cap; the stricter one binds. A large Source can never quietly exceed its share of the Hub.
 * **Per-transaction withdrawal cap** — bounds any single withdrawal so one transaction cannot drain a downstream product's liquidity.
 * **Multi-level pause** — the Hub, an individual Source, or a single product can each be paused independently. A broader pause blocks everything beneath it; unaffected siblings keep operating, and the underlying products themselves keep running normally even while the Hub is paused.


### PR DESCRIPTION
## What changes

- `technical-reference/reference-liquidity-hub/hub.md`
  - New `Sizing a deposit` section: `Hub.maxDeposit` / `maxMint` are no longer limits, read the real ceiling from `HubLens`, plus `depositCapacityBreakdown`.
  - The ERC-4626 view list split: `maxDeposit` / `maxMint` are now inherited unmodified and return `type(uint256).max`; only `maxWithdraw` / `maxRedeem` stay overridden.
  - Three fault-isolation sentences corrected, the deposit-side isolation now lives on `HubLens` rather than the Hub.
  - The Hub-paused bullet no longer claims all four `max*` views return 0.
  - `HubCapacityExceeded` documented as carrying `(assets, placed)`.
- `technical-reference/reference-liquidity-hub/README.md` — `HubLens` added to Contracts.
- `deployed-contracts/liquidity-hub.md` — `HubLens` rows on mainnet and testnet.
- `whats-new/liquidity-hub.md` — one clause on the atomic-or-revert bullet noting the revert reports how much would have fit.

Describes the post-upgrade state, so it stays draft until the checklist below clears.

## Open before merge

- [ ] venus-liquidity-hub#20 merged
- [ ] `HubLens` deployed on BNB Chain mainnet, address filled in (currently `TBD`)
- [ ] `HubLens` deployed on BSC testnet, address filled in (currently `TBD`)
- [ ] Hub beacon upgraded by VIP

Interfaces page deliberately untouched: it scopes itself to the boundary contracts (`IYieldGroupBase`, `IResourceAdapter`) and carries no periphery interfaces, not even `IMigrator`. `IHubLens` can go in later alongside it.